### PR TITLE
fix(web): repair the web interface — startup, results, progress and privacy

### DIFF
--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -25,6 +25,10 @@ DEFAULT_HOST = "http://localhost:11434"
 # timeout fallback.
 REQUEST_TIMEOUT = 300
 
+# Fifty variants, three at a time, at the per-request timeout is over an hour
+# of staring at a progress bar. Cap the batch and keep what finished.
+BATCH_DEADLINE = 900
+
 
 class AIEngine:
     """
@@ -157,7 +161,8 @@ class AIEngine:
         self,
         results: List,
         max_concurrent: int = 3,
-        progress_callback: Optional[Callable[[int, int], None]] = None
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+        deadline: float = BATCH_DEADLINE
     ) -> Dict[str, str]:
         """
         Generate AI explanations for multiple variants with concurrency control.
@@ -184,16 +189,27 @@ class AIEngine:
         # Track completions for callback
         explanations = {}
         
-        # Create all tasks
-        tasks = [explain_with_semaphore(result) for result in results]
-        
-        # Execute with progress tracking
-        for coro in asyncio.as_completed(tasks):
-            rsid, explanation = await coro
-            explanations[rsid] = explanation
-            if progress_callback:
-                progress_callback(len(explanations), len(results))
-        
+        tasks = [
+            asyncio.ensure_future(explain_with_semaphore(result))
+            for result in results
+        ]
+
+        # Whatever is done when the clock runs out is what the user gets. The
+        # per-request timeout on its own lets 50 variants, three at a time,
+        # hold the upload open for well over an hour on a slow model.
+        try:
+            for coro in asyncio.as_completed(tasks, timeout=deadline):
+                rsid, explanation = await coro
+                explanations[rsid] = explanation
+                if progress_callback:
+                    progress_callback(len(explanations), len(results))
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
         return explanations
     
     async def generate_summary(self, results: List) -> str:

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -225,18 +225,20 @@ class AIEngine:
             if clinvar or (gwas and len(gwas) > 0):
                 # clinvar/gwas hold ClinVarEntry and GWASEntry objects, not dicts.
                 def _pathogenic(e) -> bool:
+                    # Same test the results list badges on, so the summary and
+                    # the cards cannot disagree about one variant.
                     sig = str(getattr(e, 'clinical_significance', '')).lower()
-                    return 'pathogenic' in sig and 'conflicting' not in sig
+                    if 'conflicting' in sig or 'benign' in sig:
+                        return False
+                    return 'pathogenic' in sig
 
                 has_clinvar_pathogenic = any(_pathogenic(e) for e in clinvar)
 
                 def _strong_gwas(e) -> bool:
-                    p = str(getattr(e, 'p_value', ''))
-                    if 'e-' not in p:
-                        return False
+                    p = getattr(e, 'p_value', None)
                     try:
-                        return float(p.split('e-')[1]) > 5
-                    except ValueError:
+                        return p is not None and float(p) < 1e-5
+                    except (TypeError, ValueError):
                         return False
 
                 if has_clinvar_pathogenic or any(_strong_gwas(e) for e in gwas):

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -220,16 +220,22 @@ class AIEngine:
             
             # Classify based on available data
             if clinvar or (gwas and len(gwas) > 0):
+                # clinvar/gwas hold ClinVarEntry and GWASEntry objects, not dicts.
                 has_clinvar_pathogenic = any(
-                    'pathogenic' in str(e.get('clinical_significance', '')).lower()
+                    'pathogenic' in str(getattr(e, 'clinical_significance', '')).lower()
                     for e in clinvar
                 )
-                
-                if has_clinvar_pathogenic or (gwas and any(
-                    float(e.get('p_value', '1.0').split('e-')[1]) > 5 
-                    for e in gwas 
-                    if 'e-' in str(e.get('p_value', ''))
-                )):
+
+                def _strong_gwas(e) -> bool:
+                    p = str(getattr(e, 'p_value', ''))
+                    if 'e-' not in p:
+                        return False
+                    try:
+                        return float(p.split('e-')[1]) > 5
+                    except ValueError:
+                        return False
+
+                if has_clinvar_pathogenic or any(_strong_gwas(e) for e in gwas):
                     high_impact.append(result)
                 elif clinvar or gwas:
                     moderate.append(result)
@@ -249,6 +255,27 @@ class AIEngine:
             summary_parts.append(f"- {len(moderate)} variant(s) with moderate research associations")
         if low:
             summary_parts.append(f"- {len(low)} variant(s) with limited available data")
+
+        # The model was previously handed counts alone and asked to summarise
+        # findings it had never been shown, so it answered by saying so. List them.
+        listed = (high_impact + moderate)[:25]
+        if listed:
+            summary_parts.append("\nThe findings:")
+            for r in listed:
+                gene = ""
+                for e in (r.clinvar_entries or []):
+                    gene = getattr(e, 'gene', '') or gene
+                for e in (r.gwas_entries or []):
+                    gene = gene or getattr(e, 'gene', '')
+                sig = ""
+                for e in (r.clinvar_entries or []):
+                    sig = getattr(e, 'clinical_significance', '') or sig
+                traits = [getattr(e, 'trait', '') for e in (r.gwas_entries or [])]
+                traits = [t for t in traits if t][:2]
+                bits = [b for b in (gene, sig, "; ".join(traits)) if b]
+                summary_parts.append(
+                    f"- {r.rsid} ({r.genotype}): " + (" — ".join(bits) if bits else "no annotation")
+                )
         
         summary_parts.append(
             "\nPlease provide a brief 2-3 paragraph executive summary of these findings, "

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -20,6 +20,11 @@ from .safety import check_safety, get_variant_warnings, wrap_with_disclaimer
 DEFAULT_MODEL = "llama3.1:8b"
 DEFAULT_HOST = "http://localhost:11434"
 
+# Sixty seconds is not enough for the default 8B model on a warm machine
+# once a few explanations run at once; every other one came back as a
+# timeout fallback.
+REQUEST_TIMEOUT = 300
+
 
 class AIEngine:
     """
@@ -127,7 +132,7 @@ class AIEngine:
                     ],
                     stream=False
                 ),
-                timeout=60
+                timeout=REQUEST_TIMEOUT
             )
             
             explanation = response['message']['content']
@@ -301,7 +306,7 @@ class AIEngine:
                     ],
                     stream=False
                 ),
-                timeout=60
+                timeout=REQUEST_TIMEOUT
             )
             
             summary = response['message']['content']

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -199,7 +199,15 @@ class AIEngine:
         # hold the upload open for well over an hour on a slow model.
         try:
             for coro in asyncio.as_completed(tasks, timeout=deadline):
-                rsid, explanation = await coro
+                try:
+                    rsid, explanation = await coro
+                except asyncio.TimeoutError:
+                    raise
+                except Exception:
+                    # One variant that fails outside explain_variant's own
+                    # guard used to cost one explanation. It should not cost
+                    # the whole upload, minutes after the analysis is done.
+                    continue
                 explanations[rsid] = explanation
                 if progress_callback:
                     progress_callback(len(explanations), len(results))

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -26,8 +26,10 @@ DEFAULT_HOST = "http://localhost:11434"
 REQUEST_TIMEOUT = 300
 
 # Fifty variants, three at a time, at the per-request timeout is over an hour
-# of staring at a progress bar. Cap the batch and keep what finished.
-BATCH_DEADLINE = 900
+# of staring at a progress bar. Cap the batch and keep what finished. Thirty
+# minutes clears a full run of this project's own default model on an M1 Max
+# with room to spare; fifteen did not.
+BATCH_DEADLINE = 1800
 
 
 class AIEngine:
@@ -186,9 +188,17 @@ class AIEngine:
                 explanation = await self.explain_variant(result)
                 return result.rsid, explanation
         
-        # Track completions for callback
-        explanations = {}
+        # Seeded, not empty: a variant the deadline cuts off still deserves the
+        # gene, the ClinVar call and the GWAS traits that _fallback_explanation
+        # writes. A finished task overwrites its seed.
+        explanations = {
+            r.rsid: self._fallback_explanation(
+                r, reason="Explanation ran past the time limit"
+            )
+            for r in results
+        }
         
+        done = 0
         tasks = [
             asyncio.ensure_future(explain_with_semaphore(result))
             for result in results
@@ -207,10 +217,14 @@ class AIEngine:
                     # One variant that fails outside explain_variant's own
                     # guard used to cost one explanation. It should not cost
                     # the whole upload, minutes after the analysis is done.
+                    done += 1
+                    if progress_callback:
+                        progress_callback(done, len(results))
                     continue
                 explanations[rsid] = explanation
+                done += 1
                 if progress_callback:
-                    progress_callback(len(explanations), len(results))
+                    progress_callback(done, len(results))
         except asyncio.TimeoutError:
             pass
         finally:

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -179,8 +179,6 @@ class AIEngine:
         async def explain_with_semaphore(result):
             async with semaphore:
                 explanation = await self.explain_variant(result)
-                if progress_callback:
-                    progress_callback(len(explanations), len(results))
                 return result.rsid, explanation
         
         # Track completions for callback
@@ -226,10 +224,11 @@ class AIEngine:
             # Classify based on available data
             if clinvar or (gwas and len(gwas) > 0):
                 # clinvar/gwas hold ClinVarEntry and GWASEntry objects, not dicts.
-                has_clinvar_pathogenic = any(
-                    'pathogenic' in str(getattr(e, 'clinical_significance', '')).lower()
-                    for e in clinvar
-                )
+                def _pathogenic(e) -> bool:
+                    sig = str(getattr(e, 'clinical_significance', '')).lower()
+                    return 'pathogenic' in sig and 'conflicting' not in sig
+
+                has_clinvar_pathogenic = any(_pathogenic(e) for e in clinvar)
 
                 def _strong_gwas(e) -> bool:
                     p = str(getattr(e, 'p_value', ''))
@@ -271,7 +270,7 @@ class AIEngine:
                 for e in (r.clinvar_entries or []):
                     gene = getattr(e, 'gene', '') or gene
                 for e in (r.gwas_entries or []):
-                    gene = gene or getattr(e, 'gene', '')
+                    gene = gene or getattr(e, 'mapped_gene', '')
                 sig = ""
                 for e in (r.clinvar_entries or []):
                     sig = getattr(e, 'clinical_significance', '') or sig

--- a/allelio/database/store.py
+++ b/allelio/database/store.py
@@ -27,7 +27,7 @@ class AllelioDB:
     
     def _connect(self) -> None:
         """Establish database connection and enable WAL mode."""
-        self.conn = sqlite3.connect(str(self.db_path))
+        self.conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
         self.cursor = self.conn.cursor()
         # Enable WAL mode for better concurrent read performance

--- a/allelio/web/app.py
+++ b/allelio/web/app.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from fastapi.middleware.cors import CORSMiddleware
 
 from allelio import __version__, __app_name__
 
@@ -15,16 +14,9 @@ app = FastAPI(
     description="Privacy-first local genomics analysis powered by AI",
 )
 
-# The UI is served from this same app, so CORS only needs to cover a dev
-# server on another loopback port. A wildcard with credentials let any page
-# the user visited POST their genome to localhost and read the result back.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# No CORS middleware: the UI is served from this same app, so nothing here is
+# cross-origin. The wildcard that used to sit here, with credentials allowed,
+# let any page the user happened to visit read their genome off localhost.
 
 # Template directory
 TEMPLATE_DIR = Path(__file__).parent / "templates"

--- a/allelio/web/app.py
+++ b/allelio/web/app.py
@@ -15,10 +15,12 @@ app = FastAPI(
     description="Privacy-first local genomics analysis powered by AI",
 )
 
-# Add CORS middleware for local development
+# The UI is served from this same app, so CORS only needs to cover a dev
+# server on another loopback port. A wildcard with credentials let any page
+# the user visited POST their genome to localhost and read the result back.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -69,6 +69,33 @@ async def get_status() -> Dict[str, Any]:
     }
 
 
+def _gene_of(variant) -> Optional[str]:
+    """Gene symbol for a result, from ClinVar first and GWAS as a fallback."""
+    for entry in (variant.clinvar_entries or []):
+        if entry.gene:
+            return entry.gene
+    for entry in (variant.gwas_entries or []):
+        if entry.mapped_gene:
+            return entry.mapped_gene
+    return None
+
+
+def _significance_of(variant) -> str:
+    """Bucket a result into the four badges the results list knows how to draw."""
+    for entry in (variant.clinvar_entries or []):
+        significance = (entry.clinical_significance or "").lower()
+        if "pathogenic" in significance and "benign" not in significance:
+            return "pathogenic"
+        if "risk" in significance:
+            return "risk"
+    if variant.gwas_entries:
+        return "risk"
+    for entry in (variant.clinvar_entries or []):
+        if "benign" in (entry.clinical_significance or "").lower():
+            return "benign"
+    return "trait"
+
+
 @router.post("/api/analyze")
 async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
     """
@@ -179,8 +206,12 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 "category": variant.category if hasattr(variant, 'category') else "Unknown",
                 "significance_rank": i + 1,
                 "explanation": explanations.get(variant.rsid, ""),
-                "clinvar_data": variant.clinvar_data if hasattr(variant, 'clinvar_data') else None,
-                "gwas_data": variant.gwas_data if hasattr(variant, 'gwas_data') else None,
+                "gene": _gene_of(variant),
+                "significance": _significance_of(variant),
+                "pubmed_id": next(
+                    (e.pubmed_id for e in (variant.gwas_entries or []) if e.pubmed_id),
+                    None,
+                ),
                 "warnings": warnings,
             }
             formatted_results.append(result_dict)

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -85,21 +85,26 @@ def _significance_of(variant) -> str:
     """Bucket a result into the badges the results list knows how to draw.
 
     ClinVar has the last word. "Conflicting classifications of pathogenicity"
-    is 130,833 rsIDs and sorts to the very top of the report, so it needs to
-    say so rather than borrow either neighbour's colour.
+    is 130,833 rsIDs and "Uncertain significance" is 1,236,063 — both sort high
+    enough to reach the report, and neither is a trait or a benign call.
     """
     for entry in (variant.clinvar_entries or []):
         significance = (entry.clinical_significance or "").lower()
         if "conflicting" in significance:
             return "conflicting"
+        if "uncertain" in significance:
+            return "uncertain"
         if "pathogenic" in significance and "benign" not in significance:
             return "pathogenic"
-        if "benign" in significance:
+        if "benign" in significance or "protective" in significance:
             return "benign"
         if "risk" in significance:
             return "risk"
     if variant.gwas_entries:
-        return "risk"
+        # A GWAS row on its own is an association, not a risk — 37,108 of the
+        # 62,057 findings on a real genome. The analyser has already read the
+        # trait text and decided which of them are risk factors.
+        return "risk" if variant.category == "Risk Factors" else "trait"
     return "trait"
 
 
@@ -116,15 +121,18 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         if not file.filename:
             raise HTTPException(status_code=400, detail="No filename provided")
 
-        # Save uploaded file to temp location
-        temp_dir = tempfile.gettempdir()
-        temp_file_path = Path(temp_dir) / file.filename
-        
         content = await file.read()
         if not content:
             raise HTTPException(status_code=400, detail="Uploaded file is empty")
-        
-        with open(temp_file_path, "wb") as f:
+
+        # The multipart filename is raw header data: "../../../.zshenv" resolves
+        # out of the temp directory, and multipart is CORS-safelisted, so any
+        # page could have posted here. mkstemp picks the name and the mode —
+        # this file is the user's entire genome and the temp directory is shared.
+        # Only the .gz suffix matters to the parser.
+        suffix = ".gz" if file.filename.endswith(".gz") else ""
+        fd, temp_file_path = tempfile.mkstemp(prefix="allelio_upload_", suffix=suffix)
+        with os.fdopen(fd, "wb") as f:
             f.write(content)
 
         _progress.update(stage="Reading your file", done=0, total=0)
@@ -132,7 +140,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         # Parse genotype file
         loop = asyncio.get_event_loop()
         genotypes = await loop.run_in_executor(
-            None, parse_genotype_file, str(temp_file_path)
+            None, parse_genotype_file, temp_file_path
         )
         
         if not genotypes:
@@ -330,7 +338,9 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
 
         # The safety layer computes these for BRCA1/2, TP53, Lynch and APOE.
         # A report that omits them is the one place they matter most.
-        warnings = "".join(
+        # explain_variant runs these through wrap_with_disclaimer, so for the
+        # variants that got an explanation they are already in it.
+        warnings = "" if result.get("explanation") else "".join(
             f'<p class="warning">{escape(str(w))}</p>'
             for w in (result.get("warnings") or [])
         )

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -7,7 +7,6 @@ from typing import List, Dict, Any, Optional
 
 from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
-from starlette.concurrency import run_in_executor
 
 from allelio import __version__
 from allelio.parsers import parse_genotype_file
@@ -24,7 +23,7 @@ router = APIRouter()
 async def read_root(request: Request) -> str:
     """Serve the main HTML page."""
     try:
-        return templates.TemplateResponse("index.html", {"request": request})
+        return templates.TemplateResponse(request, "index.html")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to load index page: {str(e)}")
 
@@ -35,7 +34,7 @@ async def get_status() -> Dict[str, Any]:
     try:
         # Check ollama availability
         ai_engine = AIEngine()
-        ollama_available = ai_engine.check_connection()
+        ollama_available = await ai_engine.check_connection()
     except Exception:
         ollama_available = False
 
@@ -51,7 +50,7 @@ async def get_status() -> Dict[str, Any]:
         db = AllelioDB()
         db_ready = db.is_initialized()
         if db_ready:
-            stats = db.get_statistics()
+            stats = db.get_stats()
             db_stats = {
                 "clinvar_entries": stats.get("clinvar_entries", 0),
                 "gwas_entries": stats.get("gwas_entries", 0),
@@ -125,7 +124,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
 
         # Create AI engine and check connection
         ai_engine = AIEngine()
-        if not ai_engine.check_connection():
+        if not await ai_engine.check_connection():
             raise HTTPException(
                 status_code=503,
                 detail="AI service (Ollama) is not available"
@@ -168,10 +167,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         # Format results
         formatted_results = []
         for i, variant in enumerate(analysis_results):
-            warnings = get_variant_warnings(
-                variant.rsid,
-                variant.genotype if hasattr(variant, 'genotype') else None,
-            )
+            warnings = get_variant_warnings(variant)
             
             result_dict = {
                 "rsid": variant.rsid,

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -180,7 +180,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             )
 
         # Generate executive summary
-        _progress.update(stage="Summarising", done=0, total=0)
+        _progress.update(stage="Summarizing", done=0, total=0)
         try:
             if not ai_available:
                 raise RuntimeError("ollama unavailable")

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -4,7 +4,7 @@ import asyncio
 import tempfile
 from html import escape
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 
 from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
@@ -12,7 +12,7 @@ from fastapi.responses import FileResponse, HTMLResponse
 from allelio import __version__
 from allelio.parsers import parse_genotype_file
 from allelio.database.store import AllelioDB
-from allelio.analysis.lookup import analyze_variants, VariantResult
+from allelio.analysis.lookup import analyze_variants
 from allelio.ai.engine import AIEngine
 from allelio.ai.safety import get_variant_warnings
 from allelio.web.app import templates
@@ -285,17 +285,6 @@ async def export_report(analysis_data: Dict[str, Any]) -> FileResponse:
         )
 
 
-def _get_top_categories(results: List[VariantResult]) -> List[str]:
-    """Extract top categories from analysis results."""
-    categories = {}
-    for result in results:
-        category = result.category if hasattr(result, 'category') else "Unknown"
-        categories[category] = categories.get(category, 0) + 1
-    
-    sorted_cats = sorted(categories.items(), key=lambda x: x[1], reverse=True)
-    return [cat[0] for cat in sorted_cats[:5]]
-
-
 def _get_timestamp() -> str:
     """Get current timestamp in ISO format."""
     from datetime import datetime
@@ -306,8 +295,8 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     """Generate HTML report from analysis data."""
     summary = escape(str(analysis_data.get("summary") or "No summary available"))
     results = analysis_data.get("results", [])
-    total_variants = analysis_data.get("total_variants", 0)
-    analyzed_at = analysis_data.get("analyzed_at", "Unknown")
+    total_variants = escape(str(analysis_data.get("total_variants", 0)))
+    analyzed_at = escape(str(analysis_data.get("analyzed_at") or "Unknown"))
 
     # Build results table HTML
     results_html = ""

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -1,6 +1,7 @@
 """API routes for Allelio web interface."""
 
 import asyncio
+import os
 import tempfile
 from html import escape
 from pathlib import Path
@@ -8,6 +9,7 @@ from typing import Dict, Any, Optional
 
 from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
+from starlette.background import BackgroundTask
 
 from allelio import __version__
 from allelio.parsers import parse_genotype_file
@@ -80,20 +82,24 @@ def _gene_of(variant) -> Optional[str]:
 
 
 def _significance_of(variant) -> str:
-    """Bucket a result into the four badges the results list knows how to draw."""
+    """Bucket a result into the badges the results list knows how to draw.
+
+    ClinVar has the last word. "Conflicting classifications of pathogenicity"
+    is 130,833 rsIDs and sorts to the very top of the report, so it needs to
+    say so rather than borrow either neighbour's colour.
+    """
     for entry in (variant.clinvar_entries or []):
         significance = (entry.clinical_significance or "").lower()
         if "conflicting" in significance:
-            continue
+            return "conflicting"
         if "pathogenic" in significance and "benign" not in significance:
             return "pathogenic"
+        if "benign" in significance:
+            return "benign"
         if "risk" in significance:
             return "risk"
     if variant.gwas_entries:
         return "risk"
-    for entry in (variant.clinvar_entries or []):
-        if "benign" in (entry.clinical_significance or "").lower():
-            return "benign"
     return "trait"
 
 
@@ -166,18 +172,16 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
 
         # Generate AI explanations for significant variants. One call per
         # variant, run a few at a time — sequentially this took 12 minutes.
-        explanations = {}
-        if ai_available:
-            _progress.update(
-                stage="Writing explanations", done=0, total=len(top_variants)
-            )
+        _progress.update(
+            stage="Writing explanations", done=0, total=len(top_variants)
+        )
 
-            def on_explained(done: int, total: int) -> None:
-                _progress.update(done=done, total=total)
+        def on_explained(done: int, total: int) -> None:
+            _progress.update(done=done, total=total)
 
-            explanations = await ai_engine.explain_variants_batch(
-                top_variants, progress_callback=on_explained
-            )
+        explanations = await ai_engine.explain_variants_batch(
+            top_variants, progress_callback=on_explained
+        )
 
         # Generate executive summary
         _progress.update(stage="Summarizing", done=0, total=0)
@@ -263,17 +267,20 @@ async def export_report(analysis_data: Dict[str, Any]) -> FileResponse:
         # Generate HTML report (using report generator when available)
         html_content = _generate_html_report(analysis_data)
 
-        # Create temp file for report
-        temp_dir = tempfile.gettempdir()
-        temp_report_path = Path(temp_dir) / f"allelio_report_{_get_timestamp()}.html"
-
-        with open(temp_report_path, "w") as f:
+        # mkstemp gives the file 0600, and the report holds the user's
+        # genotypes. Explicit encoding because the report declares UTF-8 and
+        # the model writes em dashes.
+        fd, temp_report_path = tempfile.mkstemp(
+            prefix="allelio_report_", suffix=".html"
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(html_content)
 
         return FileResponse(
-            path=str(temp_report_path),
+            path=temp_report_path,
             filename=f"allelio_report_{_get_timestamp()}.html",
             media_type="text/html",
+            background=BackgroundTask(_unlink, temp_report_path),
         )
 
     except HTTPException:
@@ -283,6 +290,14 @@ async def export_report(analysis_data: Dict[str, Any]) -> FileResponse:
             status_code=500,
             detail=f"Report generation failed: {str(e)}"
         )
+
+
+def _unlink(path: str) -> None:
+    """Remove the exported report once it has been sent."""
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
 
 
 def _get_timestamp() -> str:
@@ -312,7 +327,14 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         genotype = field("genotype")
         category = field("category")
         explanation = field("explanation")
-        
+
+        # The safety layer computes these for BRCA1/2, TP53, Lynch and APOE.
+        # A report that omits them is the one place they matter most.
+        warnings = "".join(
+            f'<p class="warning">{escape(str(w))}</p>'
+            for w in (result.get("warnings") or [])
+        )
+
         results_html += f"""
         <tr>
             <td>{rsid}</td>
@@ -320,7 +342,7 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
             <td>{pos}</td>
             <td>{genotype}</td>
             <td>{category}</td>
-            <td>{explanation}</td>
+            <td>{explanation}{warnings}</td>
         </tr>
         """
 
@@ -331,6 +353,13 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         <meta charset="UTF-8">
         <title>Allelio Analysis Report</title>
         <style>
+            .warning {{
+                margin: 0.5em 0 0;
+                padding: 0.5em;
+                border-left: 3px solid #B45309;
+                background: #FEF3C7;
+                color: #78350F;
+            }}
             body {{
                 font-family: Arial, sans-serif;
                 margin: 20px;

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -101,10 +101,11 @@ def _significance_of(variant) -> str:
         if "risk" in significance:
             return "risk"
     if variant.gwas_entries:
-        # A GWAS row on its own is an association, not a risk — 37,108 of the
-        # 62,057 findings on a real genome. The analyser has already read the
-        # trait text and decided which of them are risk factors.
-        return "risk" if variant.category == "Risk Factors" else "trait"
+        # A GWAS row on its own is an association and nothing stronger — 37,108
+        # of the 62,057 findings on a real genome. Calling them all a risk
+        # over-states every one; calling them all a trait quietly demotes type 2
+        # diabetes and coronary artery disease. Say what the row actually is.
+        return "association"
     return "trait"
 
 
@@ -202,7 +203,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                        "straight from ClinVar and the GWAS Catalog.")
 
         # Format results
-        _progress.update(stage="Building your report")
+        _progress.update(stage="Building your report", done=0, total=0)
         formatted_results = []
         for i, variant in enumerate(analysis_results):
             warnings = get_variant_warnings(variant)
@@ -338,11 +339,14 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
 
         # The safety layer computes these for BRCA1/2, TP53, Lynch and APOE.
         # A report that omits them is the one place they matter most.
-        # explain_variant runs these through wrap_with_disclaimer, so for the
-        # variants that got an explanation they are already in it.
-        warnings = "" if result.get("explanation") else "".join(
+        # explain_variant folds these into the explanation via
+        # wrap_with_disclaimer — but only on the path where the model answered.
+        # A fallback explanation carries no warning, so test the text itself.
+        explanation_text = str(result.get("explanation") or "")
+        warnings = "".join(
             f'<p class="warning">{escape(str(w))}</p>'
             for w in (result.get("warnings") or [])
+            if str(w) not in explanation_text
         )
 
         results_html += f"""

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -1,6 +1,8 @@
 """API routes for Allelio web interface."""
 
 import asyncio
+import json
+import os
 import tempfile
 from pathlib import Path
 from typing import List, Dict, Any, Optional
@@ -91,6 +93,8 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         with open(temp_file_path, "wb") as f:
             f.write(content)
 
+        _progress.update(stage="Reading your file", done=0, total=0)
+
         # Parse genotype file
         loop = asyncio.get_event_loop()
         genotypes = await loop.run_in_executor(
@@ -112,6 +116,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             )
 
         # Analyze variants
+        _progress.update(stage=f"Matching {len(genotypes):,} variants against ClinVar and GWAS")
         analysis_results = await loop.run_in_executor(
             None, analyze_variants, genotypes, db
         )
@@ -122,13 +127,10 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 detail="No variants found in database"
             )
 
-        # Create AI engine and check connection
+        # Create AI engine. Ollama is optional — the README promises the tool
+        # still works without it, minus the plain-English explanations.
         ai_engine = AIEngine()
-        if not await ai_engine.check_connection():
-            raise HTTPException(
-                status_code=503,
-                detail="AI service (Ollama) is not available"
-            )
+        ai_available = await ai_engine.check_connection()
 
         # Get top 50 significant variants
         sorted_results = sorted(
@@ -138,33 +140,33 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         )
         top_variants = sorted_results[:50]
 
-        # Generate AI explanations for significant variants
+        # Generate AI explanations for significant variants. One call per
+        # variant, run a few at a time — sequentially this took 12 minutes.
         explanations = {}
-        for i, variant in enumerate(top_variants):
-            try:
-                explanation = await ai_engine.generate_explanation(
-                    variant.rsid,
-                    variant.chromosome,
-                    variant.position,
-                    variant.genotype,
-                    variant.clinvar_data if hasattr(variant, 'clinvar_data') else None,
-                    variant.gwas_data if hasattr(variant, 'gwas_data') else None,
-                )
-                explanations[variant.rsid] = explanation
-            except Exception:
-                explanations[variant.rsid] = "Explanation generation failed"
+        if ai_available:
+            _progress.update(
+                stage="Writing explanations", done=0, total=len(top_variants)
+            )
+
+            def on_explained(done: int, total: int) -> None:
+                _progress.update(done=done, total=total)
+
+            explanations = await ai_engine.explain_variants_batch(
+                top_variants, progress_callback=on_explained
+            )
 
         # Generate executive summary
+        _progress.update(stage="Summarising", done=0, total=0)
         try:
-            summary = await ai_engine.generate_summary(
-                total_variants=len(analysis_results),
-                significant_variants=len(top_variants),
-                top_categories=_get_top_categories(analysis_results),
-            )
+            if not ai_available:
+                raise RuntimeError("ollama unavailable")
+            summary = await ai_engine.generate_summary(top_variants)
         except Exception:
-            summary = "Unable to generate summary at this time"
+            summary = ("AI summary unavailable. Variant findings below come "
+                       "straight from ClinVar and the GWAS Catalog.")
 
         # Format results
+        _progress.update(stage="Building your report")
         formatted_results = []
         for i, variant in enumerate(analysis_results):
             warnings = get_variant_warnings(variant)
@@ -183,12 +185,14 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             }
             formatted_results.append(result_dict)
 
-        return {
+        payload = {
             "summary": summary,
             "results": formatted_results,
             "total_variants": len(analysis_results),
             "analyzed_at": _get_timestamp(),
         }
+        _save_last_analysis(payload)
+        return payload
 
     except HTTPException:
         raise
@@ -199,11 +203,42 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         )
     finally:
         # Clean up temp file
+        _progress.update(stage="idle", done=0, total=0)
         if temp_file_path and Path(temp_file_path).exists():
             try:
                 Path(temp_file_path).unlink()
             except Exception:
                 pass
+
+
+LAST_ANALYSIS_PATH = Path(os.path.expanduser("~/.allelio/last_analysis.json"))
+
+# A whole-genome run takes minutes. Without real numbers the page looks hung,
+# so the analyse route publishes its stage here and the browser polls it.
+_progress: Dict[str, Any] = {"stage": "idle", "done": 0, "total": 0}
+
+
+@router.get("/api/progress")
+async def get_progress() -> Dict[str, Any]:
+    """Where the current analysis has got to."""
+    return _progress
+
+
+def _save_last_analysis(payload: Dict[str, Any]) -> None:
+    """Keep the most recent run so a page reload does not mean a re-upload."""
+    try:
+        LAST_ANALYSIS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        LAST_ANALYSIS_PATH.write_text(json.dumps(payload))
+    except Exception:
+        pass
+
+
+@router.get("/api/last")
+async def get_last_analysis() -> Dict[str, Any]:
+    """Return the most recent analysis, or 404 if there has not been one."""
+    if not LAST_ANALYSIS_PATH.exists():
+        raise HTTPException(status_code=404, detail="No previous analysis")
+    return json.loads(LAST_ANALYSIS_PATH.read_text())
 
 
 @router.post("/api/export")

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -367,6 +367,9 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         <meta charset="UTF-8">
         <title>Allelio Analysis Report</title>
         <style>
+            td {{
+                white-space: pre-wrap;
+            }}
             .warning {{
                 margin: 0.5em 0 0;
                 padding: 0.5em;

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -1,9 +1,8 @@
 """API routes for Allelio web interface."""
 
 import asyncio
-import json
-import os
 import tempfile
+from html import escape
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
@@ -84,6 +83,8 @@ def _significance_of(variant) -> str:
     """Bucket a result into the four badges the results list knows how to draw."""
     for entry in (variant.clinvar_entries or []):
         significance = (entry.clinical_significance or "").lower()
+        if "conflicting" in significance:
+            continue
         if "pathogenic" in significance and "benign" not in significance:
             return "pathogenic"
         if "risk" in significance:
@@ -159,13 +160,9 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         ai_engine = AIEngine()
         ai_available = await ai_engine.check_connection()
 
-        # Get top 50 significant variants
-        sorted_results = sorted(
-            analysis_results,
-            key=lambda x: x.significance_score if hasattr(x, 'significance_score') else 0,
-            reverse=True
-        )
-        top_variants = sorted_results[:50]
+        # analyze_variants already returns these most-significant-first, so the
+        # top 50 are the 50 worth spending an AI call on.
+        top_variants = analysis_results[:50]
 
         # Generate AI explanations for significant variants. One call per
         # variant, run a few at a time — sequentially this took 12 minutes.
@@ -222,7 +219,6 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             "total_variants": len(analysis_results),
             "analyzed_at": _get_timestamp(),
         }
-        _save_last_analysis(payload)
         return payload
 
     except HTTPException:
@@ -242,8 +238,6 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 pass
 
 
-LAST_ANALYSIS_PATH = Path(os.path.expanduser("~/.allelio/last_analysis.json"))
-
 # A whole-genome run takes minutes. Without real numbers the page looks hung,
 # so the analyse route publishes its stage here and the browser polls it.
 _progress: Dict[str, Any] = {"stage": "idle", "done": 0, "total": 0}
@@ -253,23 +247,6 @@ _progress: Dict[str, Any] = {"stage": "idle", "done": 0, "total": 0}
 async def get_progress() -> Dict[str, Any]:
     """Where the current analysis has got to."""
     return _progress
-
-
-def _save_last_analysis(payload: Dict[str, Any]) -> None:
-    """Keep the most recent run so a page reload does not mean a re-upload."""
-    try:
-        LAST_ANALYSIS_PATH.parent.mkdir(parents=True, exist_ok=True)
-        LAST_ANALYSIS_PATH.write_text(json.dumps(payload))
-    except Exception:
-        pass
-
-
-@router.get("/api/last")
-async def get_last_analysis() -> Dict[str, Any]:
-    """Return the most recent analysis, or 404 if there has not been one."""
-    if not LAST_ANALYSIS_PATH.exists():
-        raise HTTPException(status_code=404, detail="No previous analysis")
-    return json.loads(LAST_ANALYSIS_PATH.read_text())
 
 
 @router.post("/api/export")
@@ -327,7 +304,7 @@ def _get_timestamp() -> str:
 
 def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     """Generate HTML report from analysis data."""
-    summary = analysis_data.get("summary", "No summary available")
+    summary = escape(str(analysis_data.get("summary") or "No summary available"))
     results = analysis_data.get("results", [])
     total_variants = analysis_data.get("total_variants", 0)
     analyzed_at = analysis_data.get("analyzed_at", "Unknown")
@@ -335,12 +312,17 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     # Build results table HTML
     results_html = ""
     for result in results[:100]:  # Limit to first 100 for report
-        rsid = result.get("rsid", "N/A")
-        chrom = result.get("chromosome", "N/A")
-        pos = result.get("position", "N/A")
-        genotype = result.get("genotype", "N/A")
-        category = result.get("category", "N/A")
-        explanation = result.get("explanation", "N/A")
+        # These come from the uploaded file and the model, and the report is
+        # opened in a browser — none of it is trusted markup.
+        def field(name):
+            return escape(str(result.get(name) or "N/A"))
+
+        rsid = field("rsid")
+        chrom = field("chromosome")
+        pos = field("position")
+        genotype = field("genotype")
+        category = field("category")
+        explanation = field("explanation")
         
         results_html += f"""
         <tr>

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -867,39 +867,7 @@
         document.addEventListener('DOMContentLoaded', () => {
             setupEventListeners();
             fetchStatus();
-            loadLastAnalysis();
         });
-
-        // Restore the previous run so a reload does not require re-uploading.
-        async function loadLastAnalysis() {
-            try {
-                const response = await fetch('/api/last');
-                if (!response.ok) return;
-                analysisResults = await response.json();
-                displayResults();
-                document.getElementById('resultsSection').classList.remove('hidden');
-                // A restored run is finished: no progress bar, no upload prompt.
-                document.getElementById('progressSection').classList.add('hidden');
-                // Hide the upload panel so a finished run does not look like a
-                // prompt, but leave one way back to it.
-                const upload = document.getElementById('uploadSection');
-                if (upload) {
-                    upload.classList.add('hidden');
-                    const again = document.createElement('button');
-                    again.className = 'export-button';
-                    again.textContent = 'Analyze another file';
-                    again.style.cssText = 'display:block;margin:0 auto 1.5rem;';
-                    again.onclick = () => {
-                        upload.classList.remove('hidden');
-                        again.remove();
-                    };
-                    const results = document.getElementById('resultsSection');
-                    results.parentNode.insertBefore(again, results);
-                }
-            } catch (e) {
-                // No previous run — the upload panel stands on its own.
-            }
-        }
 
         // Setup Event Listeners
         function setupEventListeners() {
@@ -1046,6 +1014,21 @@
         }
 
         // Display Results
+        // Result fields are read out of the uploaded file or written by the
+        // model; neither is trusted markup.
+        function esc(value) {
+            if (value === null || value === undefined) return '';
+            const div = document.createElement('div');
+            div.textContent = value;
+            return div.innerHTML;
+        }
+
+        // ClinVar and PubMed IDs land inside a URL, where escaping HTML is not
+        // enough — anything but digits is not an ID.
+        function idFor(value) {
+            return /^\d+$/.test(String(value ?? '')) ? String(value) : '';
+        }
+
         // "Health Conditions" -> "health_conditions"
         function slugify(category) {
             return (category || '').toLowerCase().replace(/ /g, '_');
@@ -1063,10 +1046,11 @@
             }
 
             // Create Category Tabs
-            const categories = ['all', 'health_conditions', 'risk_factors', 'pharmacogenomics', 'traits'];
+            const categories = ['all', 'health_conditions', 'carrier_status', 'risk_factors', 'pharmacogenomics', 'traits'];
             const categoryLabels = {
                 'all': 'All',
                 'health_conditions': 'Health Conditions',
+                'carrier_status': 'Carrier Status',
                 'risk_factors': 'Risk Factors',
                 'pharmacogenomics': 'Pharmacogenomics',
                 'traits': 'Traits'
@@ -1141,6 +1125,7 @@
 
             const categoryBadgeClass = {
                 'health_conditions': 'badge-category',
+                'carrier_status': 'badge-category',
                 'risk_factors': 'badge-category',
                 'pharmacogenomics': 'badge-category',
                 'traits': 'badge-category'
@@ -1149,20 +1134,20 @@
             card.innerHTML = `
                 <div class="result-header">
                     <div class="result-title">
-                        <div class="result-rsid">${result.rsid}</div>
-                        <div class="result-gene">${result.gene || 'Gene: Unknown'}</div>
+                        <div class="result-rsid">${esc(result.rsid)}</div>
+                        <div class="result-gene">${esc(result.gene) || 'Gene: Unknown'}</div>
                         <div class="result-meta">
-                            <span class="badge ${categoryBadgeClass}">${result.category.replace('_', ' ')}</span>
-                            <span class="badge ${significanceBadgeClass}">${significance}</span>
+                            <span class="badge ${categoryBadgeClass}">${esc(result.category).replace('_', ' ')}</span>
+                            <span class="badge ${significanceBadgeClass}">${esc(significance)}</span>
                         </div>
                     </div>
-                    <div class="result-genotype">${result.genotype}</div>
+                    <div class="result-genotype">${esc(result.genotype)}</div>
                 </div>
                 <div class="result-body">
-                    <div class="result-explanation">${result.explanation || 'No explanation available.'}</div>
+                    <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
                     <div class="result-sources">
-                        ${result.clinvar_id ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/${result.clinvar_id}/" target="_blank" class="source-link">ClinVar</a>` : ''}
-                        ${result.pubmed_id ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${result.pubmed_id}/" target="_blank" class="source-link">PubMed</a>` : ''}
+                        ${idFor(result.clinvar_id) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/${idFor(result.clinvar_id)}/" target="_blank" class="source-link">ClinVar</a>` : ''}
+                        ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" class="source-link">PubMed</a>` : ''}
                     </div>
                 </div>
             `;

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1046,14 +1046,15 @@
             }
 
             // Create Category Tabs
-            const categories = ['all', 'health_conditions', 'carrier_status', 'risk_factors', 'pharmacogenomics', 'traits'];
+            const categories = ['all', 'health_conditions', 'carrier_status', 'risk_factors', 'pharmacogenomics', 'traits', 'unknown'];
             const categoryLabels = {
                 'all': 'All',
                 'health_conditions': 'Health Conditions',
                 'carrier_status': 'Carrier Status',
                 'risk_factors': 'Risk Factors',
                 'pharmacogenomics': 'Pharmacogenomics',
-                'traits': 'Traits'
+                'traits': 'Traits',
+                'unknown': 'Uncategorized'
             };
 
             const tabsContainer = document.getElementById('resultsTabs');
@@ -1062,6 +1063,7 @@
             categories.forEach(cat => {
                 const button = document.createElement('button');
                 button.className = 'tab-button' + (cat === 'all' ? ' active' : '');
+                button.dataset.category = cat;
                 button.textContent = categoryLabels[cat];
                 button.addEventListener('click', () => selectCategory(cat));
                 tabsContainer.appendChild(button);
@@ -1075,9 +1077,11 @@
         function selectCategory(category) {
             currentCategory = category;
 
-            // Update active tab
-            document.querySelectorAll('.tab-button').forEach((btn, idx) => {
-                btn.classList.toggle('active', btn.textContent === document.querySelectorAll('.tab-button')[['all', 'health_conditions', 'risk_factors', 'pharmacogenomics', 'traits'].indexOf(category)].textContent);
+            // Update active tab. This used to look the tab up by position in a
+            // second, hardcoded category list; anything missing from that list
+            // indexed to -1 and threw.
+            document.querySelectorAll('.tab-button').forEach(btn => {
+                btn.classList.toggle('active', btn.dataset.category === category);
             });
 
             renderResultCards();
@@ -1126,6 +1130,7 @@
             const categoryBadgeClass = {
                 'health_conditions': 'badge-category',
                 'carrier_status': 'badge-category',
+                'unknown': 'badge-category',
                 'risk_factors': 'badge-category',
                 'pharmacogenomics': 'badge-category',
                 'traits': 'badge-category'

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -477,6 +477,10 @@
             border-left-color: #6B7280;
         }
 
+        .result-card.association {
+            border-left-color: #06B6D4;
+        }
+
         .result-card.benign {
             border-left-color: #10B981;
         }
@@ -576,6 +580,16 @@
         body.dark-mode .badge-trait {
             background-color: #1E3A8A;
             color: #93C5FD;
+        }
+
+        .badge-association {
+            background-color: #CFFAFE;
+            color: #155E75;
+        }
+
+        body.dark-mode .badge-association {
+            background-color: #164E63;
+            color: #A5F3FC;
         }
 
         .badge-uncertain {
@@ -1183,6 +1197,7 @@
                 'pathogenic': 'badge-pathogenic',
                 'conflicting': 'badge-conflicting',
                 'uncertain': 'badge-uncertain',
+                'association': 'badge-association',
                 'risk': 'badge-risk',
                 'benign': 'badge-benign',
                 'trait': 'badge-trait'
@@ -1202,7 +1217,7 @@
                 </div>
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
-                    ${result.explanation ? '' : (result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
+                    ${(result.warnings || []).filter(w => !String(result.explanation || '').includes(w)).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -431,6 +431,7 @@
         .summary-text {
             font-size: 0.95rem;
             line-height: 1.6;
+            white-space: pre-wrap;
         }
 
         /* Result Card */
@@ -593,6 +594,7 @@
             margin-bottom: 1rem;
             color: var(--gray-700);
             line-height: 1.7;
+            white-space: pre-wrap;
         }
 
         body.dark-mode .result-explanation {
@@ -1155,8 +1157,8 @@
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
                     <div class="result-sources">
-                        ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" class="source-link">ClinVar</a>` : ''}
-                        ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" class="source-link">PubMed</a>` : ''}
+                        ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
+                        ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}
                     </div>
                 </div>
             `;

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1023,10 +1023,14 @@
             return div.innerHTML;
         }
 
-        // ClinVar and PubMed IDs land inside a URL, where escaping HTML is not
-        // enough — anything but digits is not an ID.
+        // These land inside a URL, where escaping HTML is not enough. A PubMed
+        // ID is digits; an rsID is rs or i followed by digits.
         function idFor(value) {
             return /^\d+$/.test(String(value ?? '')) ? String(value) : '';
+        }
+
+        function rsidFor(value) {
+            return /^(rs|i)\d+$/.test(String(value ?? '')) ? String(value) : '';
         }
 
         // "Health Conditions" -> "health_conditions"
@@ -1151,7 +1155,7 @@
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
                     <div class="result-sources">
-                        ${idFor(result.clinvar_id) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/${idFor(result.clinvar_id)}/" target="_blank" class="source-link">ClinVar</a>` : ''}
+                        ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" class="source-link">PubMed</a>` : ''}
                     </div>
                 </div>

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -886,7 +886,7 @@
                 if (upload) {
                     upload.classList.add('hidden');
                     const again = document.createElement('button');
-                    again.className = 'btn btn-secondary';
+                    again.className = 'export-button';
                     again.textContent = 'Analyze another file';
                     again.style.cssText = 'display:block;margin:0 auto 1.5rem;';
                     again.onclick = () => {

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -473,6 +473,10 @@
             border-left-color: #8B5CF6;
         }
 
+        .result-card.uncertain {
+            border-left-color: #6B7280;
+        }
+
         .result-card.benign {
             border-left-color: #10B981;
         }
@@ -572,6 +576,16 @@
         body.dark-mode .badge-trait {
             background-color: #1E3A8A;
             color: #93C5FD;
+        }
+
+        .badge-uncertain {
+            background-color: #E5E7EB;
+            color: #374151;
+        }
+
+        body.dark-mode .badge-uncertain {
+            background-color: #374151;
+            color: #D1D5DB;
         }
 
         .badge-conflicting {
@@ -1168,6 +1182,7 @@
             const significanceBadgeClass = {
                 'pathogenic': 'badge-pathogenic',
                 'conflicting': 'badge-conflicting',
+                'uncertain': 'badge-uncertain',
                 'risk': 'badge-risk',
                 'benign': 'badge-benign',
                 'trait': 'badge-trait'
@@ -1187,7 +1202,7 @@
                 </div>
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
-                    ${(result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
+                    ${result.explanation ? '' : (result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1120,19 +1120,7 @@
                 return;
             }
 
-            // Cap the DOM: a full genome yields tens of thousands of results and
-            // rendering them all locks the browser. Results are already ordered
-            // by significance, so the cap keeps the ones that matter.
-            const RENDER_LIMIT = 200;
-            const shown = results.slice(0, RENDER_LIMIT);
-            if (results.length > RENDER_LIMIT) {
-                const note = document.createElement('p');
-                note.style.cssText = 'text-align:center;color:var(--gray-600);padding:1rem;';
-                note.textContent = `Showing the top ${RENDER_LIMIT} of ${results.length.toLocaleString()} findings. Export the report for the full set.`;
-                container.appendChild(note);
-            }
-
-            shown.forEach((result, idx) => {
+            results.forEach((result, idx) => {
                 const card = createResultCard(result);
                 container.appendChild(card);
             });

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1043,8 +1043,20 @@
                     progressText.textContent = p.total
                         ? `${p.stage} — ${p.done} of ${p.total}`
                         : `${p.stage}...`;
+                    // Only the explanation phase has a count. Without this the
+                    // bar sits at 10% through every other stage, one of which
+                    // can take half an hour.
+                    const stageWidths = {
+                        'Reading your file': 5,
+                        'Summarizing': 92,
+                        'Building your report': 96
+                    };
                     if (p.total) {
                         progressBar.style.width = (10 + 80 * p.done / p.total) + '%';
+                    } else if (p.stage in stageWidths) {
+                        progressBar.style.width = stageWidths[p.stage] + '%';
+                    } else if (p.stage.startsWith('Matching')) {
+                        progressBar.style.width = '8%';
                     }
                 } catch (e) {
                     // Server busy or restarting — the next tick tries again.
@@ -1215,9 +1227,9 @@
                     </div>
                     <div class="result-genotype">${esc(result.genotype)}</div>
                 </div>
+                ${(result.warnings || []).filter(w => !String(result.explanation || '').includes(w)).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
-                    ${(result.warnings || []).filter(w => !String(result.explanation || '').includes(w)).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1046,6 +1046,11 @@
         }
 
         // Display Results
+        // "Health Conditions" -> "health_conditions"
+        function slugify(category) {
+            return (category || '').toLowerCase().replace(/ /g, '_');
+        }
+
         function displayResults() {
             if (!analysisResults) return;
 
@@ -1105,7 +1110,9 @@
 
             // Filter by category
             if (currentCategory !== 'all') {
-                results = results.filter(r => r.category === currentCategory);
+                // The tabs are keyed on slugs; the analyser emits labels like
+                // "Health Conditions", so every tab but All matched nothing.
+                results = results.filter(r => slugify(r.category) === currentCategory);
             }
 
             if (results.length === 0) {

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -925,7 +925,7 @@
                 // Update Database Status
                 const dbIndicator = document.getElementById('dbIndicator');
                 const dbStatus = document.getElementById('dbStatus');
-                if (data.database_ready) {
+                if (data.db_ready) {
                     dbIndicator.classList.add('connected');
                     dbStatus.textContent = 'Database Ready';
                 } else {
@@ -936,7 +936,7 @@
                 // Update Ollama Status
                 const ollamaIndicator = document.getElementById('ollamaIndicator');
                 const ollamaStatus = document.getElementById('ollamaStatus');
-                if (data.ollama_connected) {
+                if (data.ollama_available) {
                     ollamaIndicator.classList.add('connected');
                     ollamaStatus.textContent = 'Ollama Connected';
                 } else {

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -867,7 +867,39 @@
         document.addEventListener('DOMContentLoaded', () => {
             setupEventListeners();
             fetchStatus();
+            loadLastAnalysis();
         });
+
+        // Restore the previous run so a reload does not require re-uploading.
+        async function loadLastAnalysis() {
+            try {
+                const response = await fetch('/api/last');
+                if (!response.ok) return;
+                analysisResults = await response.json();
+                displayResults();
+                document.getElementById('resultsSection').classList.remove('hidden');
+                // A restored run is finished: no progress bar, no upload prompt.
+                document.getElementById('progressSection').classList.add('hidden');
+                // Hide the upload panel so a finished run does not look like a
+                // prompt, but leave one way back to it.
+                const upload = document.getElementById('uploadSection');
+                if (upload) {
+                    upload.classList.add('hidden');
+                    const again = document.createElement('button');
+                    again.className = 'btn btn-secondary';
+                    again.textContent = 'Analyze another file';
+                    again.style.cssText = 'display:block;margin:0 auto 1.5rem;';
+                    again.onclick = () => {
+                        upload.classList.remove('hidden');
+                        again.remove();
+                    };
+                    const results = document.getElementById('resultsSection');
+                    results.parentNode.insertBefore(again, results);
+                }
+            } catch (e) {
+                // No previous run — the upload panel stands on its own.
+            }
+        }
 
         // Setup Event Listeners
         function setupEventListeners() {
@@ -959,14 +991,28 @@
             document.getElementById('progressSection').classList.remove('hidden');
             document.getElementById('resultsSection').classList.add('hidden');
 
-            // Animate progress bar
-            let progress = 0;
+            // Poll the server for real progress. A whole genome takes minutes;
+            // a bar that fakes its way to 90% and stops looks like a hang.
             const progressBar = document.getElementById('progressBar');
-            const progressInterval = setInterval(() => {
-                progress += Math.random() * 30;
-                if (progress > 90) progress = 90;
-                progressBar.style.width = progress + '%';
-            }, 500);
+            const progressText = document.getElementById('progressText');
+            progressBar.style.width = '2%';
+            progressText.textContent = 'Uploading...';
+            const progressInterval = setInterval(async () => {
+                try {
+                    const r = await fetch('/api/progress');
+                    if (!r.ok) return;
+                    const p = await r.json();
+                    if (p.stage === 'idle') return;
+                    progressText.textContent = p.total
+                        ? `${p.stage} — ${p.done} of ${p.total}`
+                        : `${p.stage}...`;
+                    if (p.total) {
+                        progressBar.style.width = (10 + 80 * p.done / p.total) + '%';
+                    }
+                } catch (e) {
+                    // Server busy or restarting — the next tick tries again.
+                }
+            }, 1000);
 
             try {
                 const response = await fetch('/api/analyze', {
@@ -1067,7 +1113,19 @@
                 return;
             }
 
-            results.forEach((result, idx) => {
+            // Cap the DOM: a full genome yields tens of thousands of results and
+            // rendering them all locks the browser. Results are already ordered
+            // by significance, so the cap keeps the ones that matter.
+            const RENDER_LIMIT = 200;
+            const shown = results.slice(0, RENDER_LIMIT);
+            if (results.length > RENDER_LIMIT) {
+                const note = document.createElement('p');
+                note.style.cssText = 'text-align:center;color:var(--gray-600);padding:1rem;';
+                note.textContent = `Showing the top ${RENDER_LIMIT} of ${results.length.toLocaleString()} findings. Export the report for the full set.`;
+                container.appendChild(note);
+            }
+
+            shown.forEach((result, idx) => {
                 const card = createResultCard(result);
                 container.appendChild(card);
             });

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -469,6 +469,10 @@
             border-left-color: #3B82F6;
         }
 
+        .result-card.conflicting {
+            border-left-color: #8B5CF6;
+        }
+
         .result-card.benign {
             border-left-color: #10B981;
         }
@@ -560,6 +564,26 @@
             color: #6EE7B7;
         }
 
+        .badge-trait {
+            background-color: #DBEAFE;
+            color: #1E3A8A;
+        }
+
+        body.dark-mode .badge-trait {
+            background-color: #1E3A8A;
+            color: #93C5FD;
+        }
+
+        .badge-conflicting {
+            background-color: #EDE9FE;
+            color: #5B21B6;
+        }
+
+        body.dark-mode .badge-conflicting {
+            background-color: #4C1D95;
+            color: #C4B5FD;
+        }
+
         .result-genotype {
             font-family: 'Courier New', monospace;
             font-weight: 600;
@@ -599,6 +623,21 @@
 
         body.dark-mode .result-explanation {
             color: #D1D5DB;
+        }
+
+        .result-warning {
+            margin-top: 0.75rem;
+            padding: 0.75rem;
+            border-left: 3px solid #B45309;
+            border-radius: 4px;
+            background-color: #FEF3C7;
+            color: #78350F;
+            font-size: 0.875rem;
+        }
+
+        body.dark-mode .result-warning {
+            background-color: #451A03;
+            color: #FCD34D;
         }
 
         .result-sources {
@@ -1128,19 +1167,11 @@
             const significance = result.significance || 'benign';
             const significanceBadgeClass = {
                 'pathogenic': 'badge-pathogenic',
+                'conflicting': 'badge-conflicting',
                 'risk': 'badge-risk',
                 'benign': 'badge-benign',
-                'trait': 'badge-benign'
+                'trait': 'badge-trait'
             }[significance] || 'badge-benign';
-
-            const categoryBadgeClass = {
-                'health_conditions': 'badge-category',
-                'carrier_status': 'badge-category',
-                'unknown': 'badge-category',
-                'risk_factors': 'badge-category',
-                'pharmacogenomics': 'badge-category',
-                'traits': 'badge-category'
-            }[result.category] || 'badge-category';
 
             card.innerHTML = `
                 <div class="result-header">
@@ -1148,7 +1179,7 @@
                         <div class="result-rsid">${esc(result.rsid)}</div>
                         <div class="result-gene">${esc(result.gene) || 'Gene: Unknown'}</div>
                         <div class="result-meta">
-                            <span class="badge ${categoryBadgeClass}">${esc(result.category).replace('_', ' ')}</span>
+                            <span class="badge badge-category">${esc(result.category).replace('_', ' ')}</span>
                             <span class="badge ${significanceBadgeClass}">${esc(significance)}</span>
                         </div>
                     </div>
@@ -1156,6 +1187,7 @@
                 </div>
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
+                    ${(result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-    "fastapi>=0.104.0",
+    "fastapi>=0.108.0",  # TemplateResponse(request, name) needs starlette >= 0.29
     "uvicorn[standard]>=0.24.0",
     "click>=8.1.0",
     "ollama>=0.4.0",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,3 +1,4 @@
+import asyncio
 """Tests for the web interface.
 
 The web module went unexercised long enough to accumulate a startup crash, two
@@ -261,3 +262,108 @@ def test_export_does_not_leave_the_report_in_the_temp_directory() -> None:
 
     assert response.status_code == 200
     assert set(temp_dir.glob("allelio_report_*")) == before
+
+
+def test_upload_cannot_choose_where_it_lands() -> None:
+    """The multipart filename is raw header data, and multipart is a
+    CORS-safelisted content type, so any page could have posted this. The route
+    writes the body to the name it is given and then unlinks it, so the damage
+    is an overwrite followed by a delete."""
+    import tempfile
+    from pathlib import Path
+
+    victim_dir = Path(tempfile.mkdtemp(prefix="allelio_probe_"))
+    victim = victim_dir / "victim.txt"
+    victim.write_text("do not touch")
+
+    client = TestClient(app)
+    client.post(
+        "/api/analyze",
+        files={
+            "file": (
+                f"{victim_dir.name}/victim.txt",
+                b"rs1\t1\t1\tAA\n",
+            )
+        },
+    )
+
+    assert victim.exists(), "the upload deleted a file it chose the name of"
+    assert victim.read_text() == "do not touch"
+    victim.unlink()
+    victim_dir.rmdir()
+
+
+def test_a_gwas_association_is_not_a_risk() -> None:
+    """37,108 of the 62,057 findings on a real genome are GWAS-only traits.
+    They were all badged RISK while their own tab said Traits."""
+    from allelio.web.routes import _significance_of
+
+    trait = VariantResult(
+        rsid="rs1",
+        gwas_entries=[GWASEntry(rsid="rs1", trait="Height")],
+        category="Traits",
+    )
+    risk = VariantResult(
+        rsid="rs2",
+        gwas_entries=[GWASEntry(rsid="rs2", trait="Coronary artery disease risk")],
+        category="Risk Factors",
+    )
+    assert _significance_of(trait) == "trait"
+    assert _significance_of(risk) == "risk"
+
+
+def test_uncertain_significance_is_not_a_trait() -> None:
+    """1,236,063 ClinVar rows — the plurality — say "Uncertain significance".
+    Drawn as a trait, a variant nobody can interpret reads as harmless."""
+    from allelio.web.routes import _significance_of
+
+    variant = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[
+            ClinVarEntry(rsid="rs1", clinical_significance="Uncertain significance")
+        ],
+    )
+    assert _significance_of(variant) == "uncertain"
+
+
+@pytest.mark.asyncio
+async def test_explanations_give_up_and_return_what_finished() -> None:
+    """Fifty variants at three at a time, each allowed 300s, can hold the
+    upload open for over an hour."""
+    from allelio.ai.engine import AIEngine
+
+    engine = AIEngine()
+    engine.available = True
+
+    async def slow_or_not(result):
+        if result.rsid == "rs_slow":
+            await asyncio.sleep(30)
+        return "done"
+
+    engine.explain_variant = slow_or_not
+
+    explanations = await engine.explain_variants_batch(
+        [VariantResult(rsid="rs_fast"), VariantResult(rsid="rs_slow")],
+        deadline=0.5,
+    )
+
+    assert explanations == {"rs_fast": "done"}
+
+
+def test_a_warning_is_not_printed_twice() -> None:
+    """explain_variant already folds the counselling warning into the
+    explanation via wrap_with_disclaimer."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {
+            "results": [
+                {
+                    "rsid": "rs1",
+                    "explanation": "Note: talk to a genetic counselor.",
+                    "warnings": ["Note: talk to a genetic counselor."],
+                }
+            ]
+        }
+    )
+    assert html.count("talk to a genetic counselor.") == 1

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -105,3 +105,20 @@ async def test_summary_prompt_lists_the_variants() -> None:
     prompt = engine.client.prompts[0]
     assert "rs1" in prompt and "rs2" in prompt
     assert "APOE" in prompt
+
+
+def test_result_cards_get_a_gene_and_a_significance() -> None:
+    """The list drew every variant as "Gene: Unknown" and BENIGN, including the
+    pathogenic ones, because the route sent fields the page does not read."""
+    from allelio.web.routes import _gene_of, _significance_of
+
+    variant = _variant()
+    assert _gene_of(variant) == "APOE"
+    assert _significance_of(variant) == "pathogenic"
+
+    benign = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[ClinVarEntry(rsid="rs1", clinical_significance="Benign")],
+    )
+    assert _significance_of(benign) == "benign"
+    assert _gene_of(benign) is None

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,4 +1,3 @@
-import asyncio
 """Tests for the web interface.
 
 The web module went unexercised long enough to accumulate a startup crash, two
@@ -6,6 +5,8 @@ missing awaits and three wrong method names, so these cover the wiring: the
 routes answer, CORS is not open to the world, and the AI engine's two entry
 points survive a round trip against a stubbed client.
 """
+
+import asyncio
 
 import pytest
 from fastapi.testclient import TestClient
@@ -240,6 +241,9 @@ def test_exported_report_carries_the_counselling_warnings() -> None:
             "results": [
                 {
                     "rsid": "rs1",
+                    # What _fallback_explanation writes: no disclaimer, because
+                    # only the path where the model answered adds one.
+                    "explanation": "ClinVar: Pathogenic. Gene: BRCA1.",
                     "warnings": ["Talk to a genetic counselor."],
                 }
             ]
@@ -293,23 +297,24 @@ def test_upload_cannot_choose_where_it_lands() -> None:
     victim_dir.rmdir()
 
 
-def test_a_gwas_association_is_not_a_risk() -> None:
-    """37,108 of the 62,057 findings on a real genome are GWAS-only traits.
-    They were all badged RISK while their own tab said Traits."""
+def test_a_gwas_row_is_an_association_and_nothing_stronger() -> None:
+    """37,108 of the 62,057 findings on a real genome are GWAS-only. Badging
+    them all RISK over-states height; badging them all TRAIT demotes type 2
+    diabetes. Only 2,068 of the 553,549 GWAS rsIDs have a trait string the
+    analyser can tell apart, so neither guess is available."""
     from allelio.web.routes import _significance_of
 
-    trait = VariantResult(
-        rsid="rs1",
-        gwas_entries=[GWASEntry(rsid="rs1", trait="Height")],
-        category="Traits",
-    )
-    risk = VariantResult(
-        rsid="rs2",
-        gwas_entries=[GWASEntry(rsid="rs2", trait="Coronary artery disease risk")],
-        category="Risk Factors",
-    )
-    assert _significance_of(trait) == "trait"
-    assert _significance_of(risk) == "risk"
+    for trait, category in [
+        ("Height", "Traits"),
+        ("Type 2 diabetes", "Traits"),
+        ("Coronary artery disease risk", "Risk Factors"),
+    ]:
+        variant = VariantResult(
+            rsid="rs1",
+            gwas_entries=[GWASEntry(rsid="rs1", trait=trait)],
+            category=category,
+        )
+        assert _significance_of(variant) == "association"
 
 
 def test_uncertain_significance_is_not_a_trait() -> None:
@@ -367,3 +372,19 @@ def test_a_warning_is_not_printed_twice() -> None:
         }
     )
     assert html.count("talk to a genetic counselor.") == 1
+
+
+def test_a_fallback_explanation_still_gets_its_warning() -> None:
+    """explain_variant only runs wrap_with_disclaimer on the path where the
+    model answered. Without Ollama every top-50 variant takes the other one."""
+    from allelio.web.routes import _generate_html_report
+
+    warning = "Genetic counseling is strongly recommended."
+    wrapped = _generate_html_report(
+        {"results": [{"rsid": "rs1", "explanation": f"x {warning}", "warnings": [warning]}]}
+    )
+    fallback = _generate_html_report(
+        {"results": [{"rsid": "rs1", "explanation": "ClinVar: Pathogenic.", "warnings": [warning]}]}
+    )
+    assert wrapped.count(warning) == 1
+    assert fallback.count(warning) == 1

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,107 @@
+"""Tests for the web interface.
+
+The web module went unexercised long enough to accumulate a startup crash, two
+missing awaits and three wrong method names, so these cover the wiring: the
+routes answer, CORS is not open to the world, and the AI engine's two entry
+points survive a round trip against a stubbed client.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from allelio.ai.engine import AIEngine
+from allelio.analysis.lookup import ClinVarEntry, VariantResult
+from allelio.web.app import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+class StubClient:
+    """Stands in for ollama.AsyncClient, recording what it was asked."""
+
+    def __init__(self, reply: str = "A plain-English explanation."):
+        self.reply = reply
+        self.prompts = []
+
+    async def list(self):
+        return {"models": [{"name": "llama3.1:8b"}]}
+
+    async def chat(self, model, messages, stream=False, **kwargs):
+        self.prompts.append(messages[-1]["content"])
+        return {"message": {"content": self.reply}}
+
+
+def _variant(rsid: str = "rs429358") -> VariantResult:
+    return VariantResult(
+        rsid=rsid,
+        genotype="CT",
+        chromosome="19",
+        position=44908684,
+        clinvar_entries=[
+            ClinVarEntry(
+                rsid=rsid,
+                gene="APOE",
+                clinical_significance="Pathogenic",
+                conditions="Alzheimer disease",
+                review_status="reviewed by expert panel",
+            )
+        ],
+        gwas_entries=[],
+    )
+
+
+def test_index_page_renders(client: TestClient) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Allelio" in response.text
+
+
+def test_status_reports_database_and_ai(client: TestClient) -> None:
+    response = client.get("/api/status")
+    assert response.status_code == 200
+    body = response.json()
+    assert "db_ready" in body
+    assert "ollama_available" in body
+
+
+def test_progress_starts_idle(client: TestClient) -> None:
+    assert client.get("/api/progress").json()["stage"] == "idle"
+
+
+def test_cors_rejects_foreign_origins(client: TestClient) -> None:
+    """A page on the open web must not be able to read a genome off localhost."""
+    allowed = client.get("/api/status", headers={"Origin": "http://localhost:3000"})
+    assert allowed.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+    blocked = client.get("/api/status", headers={"Origin": "https://example.com"})
+    assert "access-control-allow-origin" not in blocked.headers
+
+
+@pytest.mark.asyncio
+async def test_explain_variant_uses_the_model() -> None:
+    engine = AIEngine()
+    engine.client = StubClient()
+    engine.available = True
+
+    explanation = await engine.explain_variant(_variant())
+
+    assert "plain-English explanation" in explanation
+    assert "rs429358" in engine.client.prompts[0]
+
+
+@pytest.mark.asyncio
+async def test_summary_prompt_lists_the_variants() -> None:
+    """The prompt used to carry counts alone, so the model had nothing to summarise."""
+    engine = AIEngine()
+    engine.client = StubClient(reply="Two findings of note.")
+    engine.available = True
+
+    summary = await engine.generate_summary([_variant("rs1"), _variant("rs2")])
+
+    assert "Two findings of note." in summary
+    prompt = engine.client.prompts[0]
+    assert "rs1" in prompt and "rs2" in prompt
+    assert "APOE" in prompt

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -174,3 +174,41 @@ def test_exported_report_escapes_the_uploaded_file() -> None:
     assert "<img src=x" not in html
     assert "&lt;script&gt;" in html
     assert "&lt;img src=x" in html
+
+
+def test_exported_report_escapes_its_own_header() -> None:
+    """/api/export takes an arbitrary dict, so the report's own two fields are
+    no more trusted than the rows."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {"analyzed_at": "<script>alert(1)</script>", "total_variants": "<b>x</b>"}
+    )
+    assert "<script>alert(1)</script>" not in html
+    assert "<b>x</b>" not in html
+
+
+def test_strong_gwas_reads_the_smallest_p_values() -> None:
+    """p_value is a float column; 6,271 rows hold 0.0, which has no exponent to
+    string-slice, so the strongest associations were read as the weakest."""
+    from allelio.ai.engine import AIEngine
+
+    engine = AIEngine()
+    engine.client = StubClient(reply="Noted.")
+    engine.available = True
+
+    import asyncio
+
+    strong = VariantResult(
+        rsid="rs3",
+        gwas_entries=[GWASEntry(rsid="rs3", trait="Height", p_value=0.0)],
+    )
+    weak = VariantResult(
+        rsid="rs4",
+        gwas_entries=[GWASEntry(rsid="rs4", trait="Height", p_value=0.5)],
+    )
+    # Weak one first: only a working p-value test reorders them.
+    asyncio.run(engine.generate_summary([weak, strong]))
+    prompt = engine.client.prompts[0]
+
+    assert prompt.index("rs3") < prompt.index("rs4")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -10,7 +10,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from allelio.ai.engine import AIEngine
-from allelio.analysis.lookup import ClinVarEntry, VariantResult
+from allelio.analysis.lookup import ClinVarEntry, GWASEntry, VariantResult
 from allelio.web.app import app
 
 
@@ -71,13 +71,14 @@ def test_progress_starts_idle(client: TestClient) -> None:
     assert client.get("/api/progress").json()["stage"] == "idle"
 
 
-def test_cors_rejects_foreign_origins(client: TestClient) -> None:
-    """A page on the open web must not be able to read a genome off localhost."""
-    allowed = client.get("/api/status", headers={"Origin": "http://localhost:3000"})
-    assert allowed.headers.get("access-control-allow-origin") == "http://localhost:3000"
+def test_no_cross_origin_reads(client: TestClient) -> None:
+    """A page on the open web must not be able to read a genome off localhost.
 
-    blocked = client.get("/api/status", headers={"Origin": "https://example.com"})
-    assert "access-control-allow-origin" not in blocked.headers
+    The UI is same-origin with the API, so the app grants no origin anything.
+    """
+    for origin in ("https://example.com", "http://localhost:3000"):
+        response = client.get("/api/status", headers={"Origin": origin})
+        assert "access-control-allow-origin" not in response.headers
 
 
 @pytest.mark.asyncio
@@ -122,3 +123,54 @@ def test_result_cards_get_a_gene_and_a_significance() -> None:
     )
     assert _significance_of(benign) == "benign"
     assert _gene_of(benign) is None
+
+
+def test_conflicting_interpretations_are_not_pathogenic() -> None:
+    """ClinVar's commonest ambiguous term contains the word "pathogenic"; a
+    substring match painted those variants with the red badge."""
+    from allelio.web.routes import _significance_of
+
+    conflicting = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[
+            ClinVarEntry(
+                rsid="rs1",
+                clinical_significance="Conflicting interpretations of pathogenicity",
+            )
+        ],
+    )
+    assert _significance_of(conflicting) != "pathogenic"
+
+
+@pytest.mark.asyncio
+async def test_summary_prompt_names_the_gwas_gene() -> None:
+    """GWASEntry calls it mapped_gene, so reading .gene left GWAS-only variants
+    reaching the model with no gene at all."""
+    engine = AIEngine()
+    engine.client = StubClient(reply="Noted.")
+    engine.available = True
+
+    variant = VariantResult(
+        rsid="rs2",
+        gwas_entries=[GWASEntry(rsid="rs2", trait="Height", mapped_gene="HMGA2")],
+    )
+    await engine.generate_summary([variant])
+
+    assert "HMGA2" in engine.client.prompts[0]
+
+
+def test_exported_report_escapes_the_uploaded_file() -> None:
+    """Genotypes are copied verbatim out of the user's file and the report is
+    opened in a browser."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {
+            "summary": "<script>alert(1)</script>",
+            "results": [{"rsid": "rs1", "genotype": "<img src=x onerror=alert(1)>"}],
+        }
+    )
+    assert "<script>alert(1)</script>" not in html
+    assert "<img src=x" not in html
+    assert "&lt;script&gt;" in html
+    assert "&lt;img src=x" in html

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -352,7 +352,10 @@ async def test_explanations_give_up_and_return_what_finished() -> None:
         deadline=0.5,
     )
 
-    assert explanations == {"rs_fast": "done"}
+    assert explanations["rs_fast"] == "done"
+    # Cut off, not dropped: an empty string would leave the card reading "No
+    # explanation available", which is worse than having no model at all.
+    assert "rs_slow" in explanations["rs_slow"]
 
 
 def test_a_warning_is_not_printed_twice() -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -125,9 +125,10 @@ def test_result_cards_get_a_gene_and_a_significance() -> None:
     assert _gene_of(benign) is None
 
 
-def test_conflicting_interpretations_are_not_pathogenic() -> None:
-    """ClinVar's commonest ambiguous term contains the word "pathogenic"; a
-    substring match painted those variants with the red badge."""
+def test_conflicting_classifications_get_their_own_badge() -> None:
+    """ClinVar's commonest ambiguous term contains the word "pathogenic", so a
+    substring match painted 130k variants with the red badge — and calling them
+    a trait instead painted them green. They are neither."""
     from allelio.web.routes import _significance_of
 
     conflicting = VariantResult(
@@ -135,11 +136,25 @@ def test_conflicting_interpretations_are_not_pathogenic() -> None:
         clinvar_entries=[
             ClinVarEntry(
                 rsid="rs1",
-                clinical_significance="Conflicting interpretations of pathogenicity",
+                # The term the shipped ClinVar dump actually uses.
+                clinical_significance="Conflicting classifications of pathogenicity",
             )
         ],
     )
-    assert _significance_of(conflicting) != "pathogenic"
+    assert _significance_of(conflicting) == "conflicting"
+
+
+def test_clinvar_benign_survives_a_gwas_hit() -> None:
+    """Any GWAS row used to be checked before ClinVar's benign call, so a
+    variant ClinVar calls benign came out orange."""
+    from allelio.web.routes import _significance_of
+
+    variant = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[ClinVarEntry(rsid="rs1", clinical_significance="Benign")],
+        gwas_entries=[GWASEntry(rsid="rs1", trait="Height", p_value=1e-9)],
+    )
+    assert _significance_of(variant) == "benign"
 
 
 @pytest.mark.asyncio
@@ -212,3 +227,37 @@ def test_strong_gwas_reads_the_smallest_p_values() -> None:
     prompt = engine.client.prompts[0]
 
     assert prompt.index("rs3") < prompt.index("rs4")
+
+
+def test_exported_report_carries_the_counselling_warnings() -> None:
+    """The safety layer computes a warning for BRCA1/2, TP53, Lynch and APOE.
+    Every consumer dropped it on the floor."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {
+            "results": [
+                {
+                    "rsid": "rs1",
+                    "warnings": ["Talk to a genetic counselor."],
+                }
+            ]
+        }
+    )
+    assert "Talk to a genetic counselor." in html
+
+
+def test_export_does_not_leave_the_report_in_the_temp_directory() -> None:
+    """The report holds the user's genotypes, and the system temp directory is
+    world-readable."""
+    import tempfile
+    from pathlib import Path
+
+    temp_dir = Path(tempfile.gettempdir())
+    before = set(temp_dir.glob("allelio_report_*"))
+
+    client = TestClient(app)
+    response = client.post("/api/export", json={"results": [{"rsid": "rs1"}]})
+
+    assert response.status_code == 200
+    assert set(temp_dir.glob("allelio_report_*")) == before


### PR DESCRIPTION
`allelio serve` exits on import, and every request path behind it has a defect of its
own. I found these trying the web UI on a real 23andMe export; the CLI path works and
is untouched here.

This started as the startup crash and grew as each fix exposed the next one. It is
fixes only — no new features — one commit per theme, so it reviews in pieces.

### Startup and wiring

| Where | Problem |
|---|---|
| `web/routes.py` | `from starlette.concurrency import run_in_executor` — that name is not in starlette and is not in its history. The import aborted `allelio serve` before uvicorn bound a port. It was also unused: the code calls `loop.run_in_executor`. |
| `web/routes.py` `read_root` | `TemplateResponse("index.html", {"request": request})` is the old positional form. On the starlette this resolves to today it raises `TypeError: unhashable type: 'dict'`, so `/` returned 500. |
| `web/routes.py` ×2 | `AIEngine.check_connection` is `async` and was called without `await`. `/api/status` returned 500 serialising a coroutine; the upload path read a truthy coroutine as a live connection. |
| `web/routes.py` `get_status` | `db.get_statistics()` — the method is `get_stats`. The AttributeError was swallowed by the surrounding `except`, so the UI reported 0 ClinVar and 0 GWAS entries against a full database. |
| `web/routes.py` `analyze_file` | `get_variant_warnings(rsid, genotype)` — it takes one argument, the `VariantResult`. Every upload failed here, after the analysis had already run. |
| `database/store.py` | The sqlite connection is opened on the event loop thread, then used from `run_in_executor`. sqlite refuses that by default. |
| `templates/index.html` | Reads `database_ready` / `ollama_connected`; `/api/status` returns `db_ready` / `ollama_available`. The status panel said "Database Not Set Up" against a full database. |
| `pyproject.toml` | `fastapi>=0.104.0` resolves a starlette that predates the `TemplateResponse(request, name)` signature. On a clean install at the declared floor the index page 500s. Floor raised to 0.108. |

### The upload looked like it hung

It did not — a whole genome takes about twelve minutes. The progress bar was on a
timer, faked its way to 90% in fifteen seconds and stopped there, with no text. There
was nothing to distinguish that from a hang.

- `/api/analyze` now publishes its stage to `/api/progress` and the page polls it, so
  the bar reflects the run: parsing, matching, then `n of 50` while the explanations
  are written.
- Explanations went through `explain_variants_batch` instead of a sequential loop
  (12 min → 9.5 min on this machine).
- `explain_variants_batch` reported progress twice per variant, once with a stale
  count, so the bar counted backwards. It reports once now.
- The AI request timeout was 60s, which is not enough for this project's own default
  model once a few explanations run at once — 28 of 50 came back as the timeout
  fallback. 300s: 0 timeouts on the same input. That alone would let 50 variants,
  three at a time, hold the upload open for over an hour, so the batch also gets a
  30-minute ceiling and keeps whatever finished — as the fallback text, not as an
  empty string, so a slow model never leaves the user with less than no model would.
- One variant failing outside `explain_variant`'s own guard used to cost one
  explanation. Once the per-variant `try/except` moved out of the route it cost the
  whole upload, minutes after the analysis had finished.
- Ollama being unreachable used to fail the whole upload with a 503. The README
  promises the tool works without it, so it now completes and says the summary is
  unavailable.

### The results list showed the wrong thing

- Cards were sent `clinvar_data` / `gwas_data`, fields that do not exist on
  `VariantResult`. Every card read "Gene: Unknown" and every variant — pathogenic
  ones included — was badged BENIGN. They now get `gene`, `significance` and
  `pubmed_id` off the entries that are actually there.
- `"Conflicting classifications of pathogenicity"` was badged PATHOGENIC on a
  substring match — it contains the word. It is 130,833 rsIDs in the dump `allelio
  download-db` fetches, and it sorts to the top of the report, so it was the first
  thing a user saw. Calling it BENIGN instead would be the same lie in green, so it
  has its own badge now. A trait does too, rather than borrowing benign's green.
- The tabs filtered on `health_conditions` while the analyser emits
  `Health Conditions`, so four of the five tabs said "No results found".
- Picking a tab looked the button up by its position in a second, hardcoded category
  list. Anything missing from that list indexed to `-1` and threw before the results
  re-rendered.
- That list was missing two of the six categories the analyser emits, carrier status
  and uncategorized — 21% of the findings on a real genome, reachable only under All.
- The ClinVar source link keyed on a `clinvar_id` that is in no payload and on no
  entry, so it rendered for no variant. It points at the rsID now.
- The summary prompt was handed counts alone and asked to summarize findings it had
  never been shown, so the model answered by saying so. It gets the variants.
- `_strong_gwas` compared p-values by slicing the exponent out of the string form.
  `p_value` is a float column and 6,271 GWAS rows hold `0.0`, which has no exponent
  at all, so the strongest associations in the catalogue were read as the weakest.
- The top-50 sort keyed on `significance_score`, an attribute no result object has.
  It was dead rather than wrong — `analyze_variants` already returns them sorted —
  so it is gone.
- A ClinVar benign call was unreachable for any variant that also had a GWAS row,
  because the GWAS check ran first. ClinVar has the last word now.
- A GWAS row on its own was badged RISK — 37,108 of the 62,057 findings on a real
  genome, every one of them under a tab the analyser itself labelled Traits. Calling
  them all a trait instead demotes type 2 diabetes and coronary artery disease, and
  the analyser cannot tell them apart either: its GWAS test is a substring search for
  "risk" or "association" in the trait string, which 2,068 of the 553,549 GWAS rsIDs
  pass. So the badge says ASSOCIATION, which is what a GWAS row is.
- `"Uncertain significance"` had no branch at all, so it came out as a trait. It is
  1,236,063 ClinVar rows — the largest class — and it passes the benign filter, so a
  variant nobody can interpret was being drawn as a harmless characteristic. It has
  its own badge now, and a `protective` call reads as benign.
- `get_variant_warnings` computes a genetic-counselling warning for BRCA1/2, TP53,
  Lynch and APOE. It was computed for all 62,057 results and rendered nowhere. It is
  on the card and in the exported report now — once, not twice: `explain_variant`
  already folds it into the explanation, but only on the path where the model
  answered, so the test is on the text rather than on whether an explanation exists.
  It sits under the card header rather than inside the collapsed body — a BRCA1 card
  otherwise looked like every other card until you clicked it.
- Explanations were gated on the model being reachable, so a machine without Ollama
  got empty cards — even though `explain_variant` already writes a ClinVar/GWAS
  fallback for exactly that case.
- The model writes paragraphs and HTML collapses newlines, so the summary and every
  explanation arrived as one run-on block. The exported report needed the same.
- The progress bar only moved while explanations were being written, so it read 10%
  through every other stage.

### Security

- **`allow_origins=["*"]` with `allow_credentials=True`.** Any page the user visited
  could POST a genome to localhost and read the result back. The UI is same-origin
  with the API, so the middleware is gone rather than narrowed.
- **Stored markup in the results list.** Cards were built by string interpolation
  from the uploaded file. Nothing validates a genotype except a `--` check, so a
  crafted file executed script in the page. Every field is escaped now, and the two
  values that land inside a URL are pattern-checked rather than escaped.
- **The exported HTML report had the same hole**, server side, in its rows and in
  its own header fields — and `/api/export` accepts an arbitrary dict.
- **The uploaded file's name came from the multipart header, unsanitised.**
  `Path(tempfile.gettempdir()) / file.filename` with `../../..` in it resolves out of
  the temp directory; the route writes the request body there and then unlinks it.
  `multipart/form-data` is CORS-safelisted, so this needed no preflight and dropping
  the CORS middleware does not close it. `mkstemp` picks the name now.
- **That same file is the user's whole genome**, and it was landing at 0644 in a
  shared directory. `mkstemp` gives it 0600.
- **The exported report was left in the shared temp directory at 0644, forever**,
  with the user's genotypes in it. Same treatment, plus it is unlinked once sent.
- `rel="noopener noreferrer"` on the outbound links.

### Verified

Against a 630,774-variant 23andMe export (Personal Genome Project, openly consented),
in Chrome, with Ollama and `llama3.1:8b`:

- `allelio serve` starts, `/` renders, `/api/status` reports `db_ready: true` with
  2,645,423 ClinVar and 1,191,572 GWAS entries
- upload → 62,057 findings, all rendered, every category tab matching the counts the
  analyser produces
- 50/50 explanations, no timeouts, a summary that names the genes it found
- export downloads a report
- a genotype file whose genotype column carries an `<img onerror>` payload renders as
  inert text, with no script execution

`tests/test_web.py` is new and covers the routes, the CORS behaviour, the two
classifiers, the escaping on both sides, the p-value comparison, the upload path and
the batch deadline. Full suite: 107 passing.

### Left alone deliberately

- **`_get_significance_rank` in `analysis/lookup.py` substring-matches `"pathogenic"`
  inside `"pathogenicity"`**, so `Conflicting classifications of pathogenicity` scores
  the same rank as a true pathogenic call and files under Health Conditions. On a real
  genome that interleaves 5,048 conflicting variants with 7,959 genuine ones at the top
  of the report. This PR gives them an honest badge; the ranking is an analysis-module
  change that moves CLI output too, so it wants its own PR. (`SIGNIFICANCE_RANKS`
  already has a `conflicting interpretations` key at rank 6 — ClinVar retired that
  wording, the dump says `classifications`, so the key never matches.)
- **`_progress` is a module global**, so two concurrent runs clobber each other's
  bar. Needs a per-run token; out of scope here.
- **`AllelioDB.close()` has no caller**, so each request leaks a connection.
- **The 50-variant cap on explanations** is yours by design, so I left it. Same for
  the report's `results[:100]`, though that means the export carries 79 of the 1,634
  counselling warnings a real genome produces.
- **`_strong_gwas`'s `p < 1e-5`** matches 1,186,123 of the 1,191,572 GWAS rows, so it
  filters nothing. The old code had the same effective threshold, so this is not a
  regression — but the number the summary prompt is given is inflated.
- **62,057 rows render at once.** I timed it — a few seconds to render, a few to
  switch tabs — so it is not the freeze I first assumed, but paging would be kinder.

Happy to split any of this out or drop pieces you would rather not carry.
