### PR TITLE
feat(web): let the user keep an analysis instead of re-running it

### DIFF
--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -25,6 +25,10 @@ DEFAULT_HOST = "http://localhost:11434"
 # timeout fallback.
 REQUEST_TIMEOUT = 300
 
+# Fifty variants, three at a time, at the per-request timeout is over an hour
+# of staring at a progress bar. Cap the batch and keep what finished.
+BATCH_DEADLINE = 900
+
 
 class AIEngine:
     """
@@ -157,7 +161,8 @@ class AIEngine:
         self,
         results: List,
         max_concurrent: int = 3,
-        progress_callback: Optional[Callable[[int, int], None]] = None
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+        deadline: float = BATCH_DEADLINE
     ) -> Dict[str, str]:
         """
         Generate AI explanations for multiple variants with concurrency control.
@@ -184,16 +189,27 @@ class AIEngine:
         # Track completions for callback
         explanations = {}
         
-        # Create all tasks
-        tasks = [explain_with_semaphore(result) for result in results]
-        
-        # Execute with progress tracking
-        for coro in asyncio.as_completed(tasks):
-            rsid, explanation = await coro
-            explanations[rsid] = explanation
-            if progress_callback:
-                progress_callback(len(explanations), len(results))
-        
+        tasks = [
+            asyncio.ensure_future(explain_with_semaphore(result))
+            for result in results
+        ]
+
+        # Whatever is done when the clock runs out is what the user gets. The
+        # per-request timeout on its own lets 50 variants, three at a time,
+        # hold the upload open for well over an hour on a slow model.
+        try:
+            for coro in asyncio.as_completed(tasks, timeout=deadline):
+                rsid, explanation = await coro
+                explanations[rsid] = explanation
+                if progress_callback:
+                    progress_callback(len(explanations), len(results))
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
         return explanations
     
     async def generate_summary(self, results: List) -> str:

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -225,18 +225,20 @@ class AIEngine:
             if clinvar or (gwas and len(gwas) > 0):
                 # clinvar/gwas hold ClinVarEntry and GWASEntry objects, not dicts.
                 def _pathogenic(e) -> bool:
+                    # Same test the results list badges on, so the summary and
+                    # the cards cannot disagree about one variant.
                     sig = str(getattr(e, 'clinical_significance', '')).lower()
-                    return 'pathogenic' in sig and 'conflicting' not in sig
+                    if 'conflicting' in sig or 'benign' in sig:
+                        return False
+                    return 'pathogenic' in sig
 
                 has_clinvar_pathogenic = any(_pathogenic(e) for e in clinvar)
 
                 def _strong_gwas(e) -> bool:
-                    p = str(getattr(e, 'p_value', ''))
-                    if 'e-' not in p:
-                        return False
+                    p = getattr(e, 'p_value', None)
                     try:
-                        return float(p.split('e-')[1]) > 5
-                    except ValueError:
+                        return p is not None and float(p) < 1e-5
+                    except (TypeError, ValueError):
                         return False
 
                 if has_clinvar_pathogenic or any(_strong_gwas(e) for e in gwas):

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -220,16 +220,22 @@ class AIEngine:
             
             # Classify based on available data
             if clinvar or (gwas and len(gwas) > 0):
+                # clinvar/gwas hold ClinVarEntry and GWASEntry objects, not dicts.
                 has_clinvar_pathogenic = any(
-                    'pathogenic' in str(e.get('clinical_significance', '')).lower()
+                    'pathogenic' in str(getattr(e, 'clinical_significance', '')).lower()
                     for e in clinvar
                 )
-                
-                if has_clinvar_pathogenic or (gwas and any(
-                    float(e.get('p_value', '1.0').split('e-')[1]) > 5 
-                    for e in gwas 
-                    if 'e-' in str(e.get('p_value', ''))
-                )):
+
+                def _strong_gwas(e) -> bool:
+                    p = str(getattr(e, 'p_value', ''))
+                    if 'e-' not in p:
+                        return False
+                    try:
+                        return float(p.split('e-')[1]) > 5
+                    except ValueError:
+                        return False
+
+                if has_clinvar_pathogenic or any(_strong_gwas(e) for e in gwas):
                     high_impact.append(result)
                 elif clinvar or gwas:
                     moderate.append(result)
@@ -249,6 +255,27 @@ class AIEngine:
             summary_parts.append(f"- {len(moderate)} variant(s) with moderate research associations")
         if low:
             summary_parts.append(f"- {len(low)} variant(s) with limited available data")
+
+        # The model was previously handed counts alone and asked to summarise
+        # findings it had never been shown, so it answered by saying so. List them.
+        listed = (high_impact + moderate)[:25]
+        if listed:
+            summary_parts.append("\nThe findings:")
+            for r in listed:
+                gene = ""
+                for e in (r.clinvar_entries or []):
+                    gene = getattr(e, 'gene', '') or gene
+                for e in (r.gwas_entries or []):
+                    gene = gene or getattr(e, 'gene', '')
+                sig = ""
+                for e in (r.clinvar_entries or []):
+                    sig = getattr(e, 'clinical_significance', '') or sig
+                traits = [getattr(e, 'trait', '') for e in (r.gwas_entries or [])]
+                traits = [t for t in traits if t][:2]
+                bits = [b for b in (gene, sig, "; ".join(traits)) if b]
+                summary_parts.append(
+                    f"- {r.rsid} ({r.genotype}): " + (" — ".join(bits) if bits else "no annotation")
+                )
         
         summary_parts.append(
             "\nPlease provide a brief 2-3 paragraph executive summary of these findings, "

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -20,6 +20,11 @@ from .safety import check_safety, get_variant_warnings, wrap_with_disclaimer
 DEFAULT_MODEL = "llama3.1:8b"
 DEFAULT_HOST = "http://localhost:11434"
 
+# Sixty seconds is not enough for the default 8B model on a warm machine
+# once a few explanations run at once; every other one came back as a
+# timeout fallback.
+REQUEST_TIMEOUT = 300
+
 
 class AIEngine:
     """
@@ -127,7 +132,7 @@ class AIEngine:
                     ],
                     stream=False
                 ),
-                timeout=60
+                timeout=REQUEST_TIMEOUT
             )
             
             explanation = response['message']['content']
@@ -301,7 +306,7 @@ class AIEngine:
                     ],
                     stream=False
                 ),
-                timeout=60
+                timeout=REQUEST_TIMEOUT
             )
             
             summary = response['message']['content']

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -199,7 +199,15 @@ class AIEngine:
         # hold the upload open for well over an hour on a slow model.
         try:
             for coro in asyncio.as_completed(tasks, timeout=deadline):
-                rsid, explanation = await coro
+                try:
+                    rsid, explanation = await coro
+                except asyncio.TimeoutError:
+                    raise
+                except Exception:
+                    # One variant that fails outside explain_variant's own
+                    # guard used to cost one explanation. It should not cost
+                    # the whole upload, minutes after the analysis is done.
+                    continue
                 explanations[rsid] = explanation
                 if progress_callback:
                     progress_callback(len(explanations), len(results))

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -26,8 +26,10 @@ DEFAULT_HOST = "http://localhost:11434"
 REQUEST_TIMEOUT = 300
 
 # Fifty variants, three at a time, at the per-request timeout is over an hour
-# of staring at a progress bar. Cap the batch and keep what finished.
-BATCH_DEADLINE = 900
+# of staring at a progress bar. Cap the batch and keep what finished. Thirty
+# minutes clears a full run of this project's own default model on an M1 Max
+# with room to spare; fifteen did not.
+BATCH_DEADLINE = 1800
 
 
 class AIEngine:
@@ -186,9 +188,17 @@ class AIEngine:
                 explanation = await self.explain_variant(result)
                 return result.rsid, explanation
         
-        # Track completions for callback
-        explanations = {}
+        # Seeded, not empty: a variant the deadline cuts off still deserves the
+        # gene, the ClinVar call and the GWAS traits that _fallback_explanation
+        # writes. A finished task overwrites its seed.
+        explanations = {
+            r.rsid: self._fallback_explanation(
+                r, reason="Explanation ran past the time limit"
+            )
+            for r in results
+        }
         
+        done = 0
         tasks = [
             asyncio.ensure_future(explain_with_semaphore(result))
             for result in results
@@ -207,10 +217,14 @@ class AIEngine:
                     # One variant that fails outside explain_variant's own
                     # guard used to cost one explanation. It should not cost
                     # the whole upload, minutes after the analysis is done.
+                    done += 1
+                    if progress_callback:
+                        progress_callback(done, len(results))
                     continue
                 explanations[rsid] = explanation
+                done += 1
                 if progress_callback:
-                    progress_callback(len(explanations), len(results))
+                    progress_callback(done, len(results))
         except asyncio.TimeoutError:
             pass
         finally:

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -179,8 +179,6 @@ class AIEngine:
         async def explain_with_semaphore(result):
             async with semaphore:
                 explanation = await self.explain_variant(result)
-                if progress_callback:
-                    progress_callback(len(explanations), len(results))
                 return result.rsid, explanation
         
         # Track completions for callback
@@ -226,10 +224,11 @@ class AIEngine:
             # Classify based on available data
             if clinvar or (gwas and len(gwas) > 0):
                 # clinvar/gwas hold ClinVarEntry and GWASEntry objects, not dicts.
-                has_clinvar_pathogenic = any(
-                    'pathogenic' in str(getattr(e, 'clinical_significance', '')).lower()
-                    for e in clinvar
-                )
+                def _pathogenic(e) -> bool:
+                    sig = str(getattr(e, 'clinical_significance', '')).lower()
+                    return 'pathogenic' in sig and 'conflicting' not in sig
+
+                has_clinvar_pathogenic = any(_pathogenic(e) for e in clinvar)
 
                 def _strong_gwas(e) -> bool:
                     p = str(getattr(e, 'p_value', ''))
@@ -271,7 +270,7 @@ class AIEngine:
                 for e in (r.clinvar_entries or []):
                     gene = getattr(e, 'gene', '') or gene
                 for e in (r.gwas_entries or []):
-                    gene = gene or getattr(e, 'gene', '')
+                    gene = gene or getattr(e, 'mapped_gene', '')
                 sig = ""
                 for e in (r.clinvar_entries or []):
                     sig = getattr(e, 'clinical_significance', '') or sig

--- a/allelio/cli.py
+++ b/allelio/cli.py
@@ -2,11 +2,13 @@
 
 import asyncio
 import os
+import socket
 from pathlib import Path
 from typing import Optional
 
 import click
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
@@ -278,13 +280,61 @@ def serve(port: int, host: str):
     Start an interactive web server for variant analysis and exploration.
     """
     console.print("\n[bold cyan]Allelio Web Interface[/bold cyan]\n")
-    console.print(f"Starting Allelio web interface on {host}:{port}...\n")
-    console.print(f"Open [bold cyan]http://{host}:{port}[/bold cyan] in your browser\n")
-    
+    # escape: rich reads "[" as the start of a style tag, and --host takes
+    # whatever the shell hands it.
+    console.print(f"Starting Allelio web interface on {escape(host)}:{port}...\n")
+
+    # The app rejects Host headers it does not recognise, which is what stops a
+    # remote page from reaching this server by pointing its own domain at
+    # 127.0.0.1. Whatever the operator chose to bind belongs on the list; it has
+    # to be set before the app module is imported.
+    # An empty --host binds everywhere; there is no URL in it to print.
+    browse_to = host or "localhost"
+    if not os.environ.get("ALLELIO_ALLOWED_HOSTS"):
+        try:
+            # inet_aton takes every legacy spelling of "all interfaces" — 0,
+            # 0.0, 0x0 — that comparing against "0.0.0.0" would miss, and it
+            # does no lookups, so a hostname simply raises.
+            binds_everywhere = socket.inet_aton(host) == b"\x00\x00\x00\x00"
+        except OSError:
+            binds_everywhere = False
+
+        # Starlette strips the port by splitting the Host header on ":", so no
+        # IPv6 literal on the list could ever match; neither could a bind
+        # address nobody types into a browser. Lowercased because that is how
+        # browsers send it and starlette compares exactly.
+        # An empty --host binds everywhere too: asyncio special-cases it into a
+        # getaddrinfo with AI_PASSIVE, which answers 0.0.0.0 and ::.
+        extra = [] if binds_everywhere or not host or ":" in host else [host.lower()]
+        os.environ["ALLELIO_ALLOWED_HOSTS"] = ",".join(
+            dict.fromkeys(["localhost", "127.0.0.1"] + extra)
+        )
+        if not extra:
+            # Printing the bound address here would send them to a URL that
+            # answers 400.
+            browse_to = "localhost"
+            console.print(
+                f"[bold yellow]⚠[/bold yellow] Bound to {escape(host) or 'every interface'}, but "
+                "browse to "
+                "localhost — "
+                "the host check has no way to match that address.\n"
+                "  That check is what stops a web page you visit from reading your genome "
+                "off this server, which has no password on it.\n"
+                "  To let another machine reach it, name that machine: "
+                "ALLELIO_ALLOWED_HOSTS=192.168.1.50 allelio serve --host 0.0.0.0\n",
+                style="yellow",
+            )
+
+    # A bare IPv6 literal needs brackets or the browser reads the last colon as
+    # the port separator, and rich reads "[::1]" as a style tag.
+    url = f"http://[{browse_to}]:{port}" if ":" in browse_to else f"http://{browse_to}:{port}"
+    console.print(f"Open [bold cyan]{escape(url)}[/bold cyan] in your browser\n")
+
     try:
         import uvicorn
+
         from allelio.web.app import app
-        
+
         uvicorn.run(app, host=host, port=port, log_level="info")
     except ImportError:
         console.print("[bold red]✗[/bold red] Web server dependencies not installed\n", style="red")

--- a/allelio/database/store.py
+++ b/allelio/database/store.py
@@ -27,7 +27,7 @@ class AllelioDB:
     
     def _connect(self) -> None:
         """Establish database connection and enable WAL mode."""
-        self.conn = sqlite3.connect(str(self.db_path))
+        self.conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
         self.cursor = self.conn.cursor()
         # Enable WAL mode for better concurrent read performance

--- a/allelio/web/app.py
+++ b/allelio/web/app.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from fastapi.middleware.cors import CORSMiddleware
 
 from allelio import __version__, __app_name__
 
@@ -15,16 +14,9 @@ app = FastAPI(
     description="Privacy-first local genomics analysis powered by AI",
 )
 
-# The UI is served from this same app, so CORS only needs to cover a dev
-# server on another loopback port. A wildcard with credentials let any page
-# the user visited POST their genome to localhost and read the result back.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# No CORS middleware: the UI is served from this same app, so nothing here is
+# cross-origin. The wildcard that used to sit here, with credentials allowed,
+# let any page the user happened to visit read their genome off localhost.
 
 # Template directory
 TEMPLATE_DIR = Path(__file__).parent / "templates"

--- a/allelio/web/app.py
+++ b/allelio/web/app.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from allelio import __version__, __app_name__
 
@@ -17,6 +18,54 @@ app = FastAPI(
 # No CORS middleware: the UI is served from this same app, so nothing here is
 # cross-origin. The wildcard that used to sit here, with credentials allowed,
 # let any page the user happened to visit read their genome off localhost.
+
+# Binding to 127.0.0.1 is not on its own a boundary: a page on a domain whose
+# DNS re-resolves to 127.0.0.1 is same-origin by the browser's reckoning, and
+# CORS never enters into it. Checking the Host header is what closes that, and
+# it costs nothing when the host is what we bound to. `serve` widens this to
+# whatever --host it was given.
+#
+# Starlette compares against the Host header with the port already stripped, so
+# entries carry no port. It splits on ":" to do it, which leaves no spelling of
+# a bracketed IPv6 literal that can ever match — "localhost" is how you reach
+# this over IPv6.
+# Loopback always stays on the list. It is the address the person running this
+# actually types, and naming a LAN address should not lock them out of their own
+# machine. It costs nothing: a rebound domain arrives in the Host header as its
+# own name, never as "localhost", so this is not a way in.
+#
+# Lowercased because browsers send the host lowercased and starlette compares it
+# exactly — an entry with a capital in it could never match.
+ALLOWED_HOSTS = list(
+    dict.fromkeys(
+        ["localhost", "127.0.0.1"]
+        + [
+            h.strip().lower()
+            for h in os.environ.get("ALLELIO_ALLOWED_HOSTS", "").split(",")
+            if h.strip()
+        ]
+    )
+)
+
+# TrustedHostMiddleware only checks its patterns when the stack is first built,
+# which is on the first request — a typo in the environment would otherwise take
+# down a run that had already printed its URL. It checks with an assert, so it
+# would also stop checking under -O. Both halves of starlette's rule, restated
+# here and raising for real: no "*" past the first character, and a leading one
+# has to be the "*." of a subdomain wildcard. "*example.com" fails both its
+# check and this one — it is a forgotten dot, not a pattern.
+_bad = [
+    h
+    for h in ALLOWED_HOSTS
+    if "*" in h[1:] or (h.startswith("*") and h != "*" and not h.startswith("*."))
+]
+if _bad:
+    raise ValueError(
+        f"ALLELIO_ALLOWED_HOSTS: {', '.join(_bad)} — a wildcard host has to look "
+        "like '*.example.com', or be '*' on its own."
+    )
+
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=ALLOWED_HOSTS)
 
 # Template directory
 TEMPLATE_DIR = Path(__file__).parent / "templates"

--- a/allelio/web/app.py
+++ b/allelio/web/app.py
@@ -15,10 +15,12 @@ app = FastAPI(
     description="Privacy-first local genomics analysis powered by AI",
 )
 
-# Add CORS middleware for local development
+# The UI is served from this same app, so CORS only needs to cover a dev
+# server on another loopback port. A wildcard with credentials let any page
+# the user visited POST their genome to localhost and read the result back.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -69,6 +69,33 @@ async def get_status() -> Dict[str, Any]:
     }
 
 
+def _gene_of(variant) -> Optional[str]:
+    """Gene symbol for a result, from ClinVar first and GWAS as a fallback."""
+    for entry in (variant.clinvar_entries or []):
+        if entry.gene:
+            return entry.gene
+    for entry in (variant.gwas_entries or []):
+        if entry.mapped_gene:
+            return entry.mapped_gene
+    return None
+
+
+def _significance_of(variant) -> str:
+    """Bucket a result into the four badges the results list knows how to draw."""
+    for entry in (variant.clinvar_entries or []):
+        significance = (entry.clinical_significance or "").lower()
+        if "pathogenic" in significance and "benign" not in significance:
+            return "pathogenic"
+        if "risk" in significance:
+            return "risk"
+    if variant.gwas_entries:
+        return "risk"
+    for entry in (variant.clinvar_entries or []):
+        if "benign" in (entry.clinical_significance or "").lower():
+            return "benign"
+    return "trait"
+
+
 @router.post("/api/analyze")
 async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
     """
@@ -179,8 +206,12 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 "category": variant.category if hasattr(variant, 'category') else "Unknown",
                 "significance_rank": i + 1,
                 "explanation": explanations.get(variant.rsid, ""),
-                "clinvar_data": variant.clinvar_data if hasattr(variant, 'clinvar_data') else None,
-                "gwas_data": variant.gwas_data if hasattr(variant, 'gwas_data') else None,
+                "gene": _gene_of(variant),
+                "significance": _significance_of(variant),
+                "pubmed_id": next(
+                    (e.pubmed_id for e in (variant.gwas_entries or []) if e.pubmed_id),
+                    None,
+                ),
                 "warnings": warnings,
             }
             formatted_results.append(result_dict)

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -85,21 +85,26 @@ def _significance_of(variant) -> str:
     """Bucket a result into the badges the results list knows how to draw.
 
     ClinVar has the last word. "Conflicting classifications of pathogenicity"
-    is 130,833 rsIDs and sorts to the very top of the report, so it needs to
-    say so rather than borrow either neighbour's colour.
+    is 130,833 rsIDs and "Uncertain significance" is 1,236,063 — both sort high
+    enough to reach the report, and neither is a trait or a benign call.
     """
     for entry in (variant.clinvar_entries or []):
         significance = (entry.clinical_significance or "").lower()
         if "conflicting" in significance:
             return "conflicting"
+        if "uncertain" in significance:
+            return "uncertain"
         if "pathogenic" in significance and "benign" not in significance:
             return "pathogenic"
-        if "benign" in significance:
+        if "benign" in significance or "protective" in significance:
             return "benign"
         if "risk" in significance:
             return "risk"
     if variant.gwas_entries:
-        return "risk"
+        # A GWAS row on its own is an association, not a risk — 37,108 of the
+        # 62,057 findings on a real genome. The analyser has already read the
+        # trait text and decided which of them are risk factors.
+        return "risk" if variant.category == "Risk Factors" else "trait"
     return "trait"
 
 
@@ -116,15 +121,18 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         if not file.filename:
             raise HTTPException(status_code=400, detail="No filename provided")
 
-        # Save uploaded file to temp location
-        temp_dir = tempfile.gettempdir()
-        temp_file_path = Path(temp_dir) / file.filename
-        
         content = await file.read()
         if not content:
             raise HTTPException(status_code=400, detail="Uploaded file is empty")
-        
-        with open(temp_file_path, "wb") as f:
+
+        # The multipart filename is raw header data: "../../../.zshenv" resolves
+        # out of the temp directory, and multipart is CORS-safelisted, so any
+        # page could have posted here. mkstemp picks the name and the mode —
+        # this file is the user's entire genome and the temp directory is shared.
+        # Only the .gz suffix matters to the parser.
+        suffix = ".gz" if file.filename.endswith(".gz") else ""
+        fd, temp_file_path = tempfile.mkstemp(prefix="allelio_upload_", suffix=suffix)
+        with os.fdopen(fd, "wb") as f:
             f.write(content)
 
         _progress.update(stage="Reading your file", done=0, total=0)
@@ -132,7 +140,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         # Parse genotype file
         loop = asyncio.get_event_loop()
         genotypes = await loop.run_in_executor(
-            None, parse_genotype_file, str(temp_file_path)
+            None, parse_genotype_file, temp_file_path
         )
         
         if not genotypes:
@@ -330,7 +338,9 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
 
         # The safety layer computes these for BRCA1/2, TP53, Lynch and APOE.
         # A report that omits them is the one place they matter most.
-        warnings = "".join(
+        # explain_variant runs these through wrap_with_disclaimer, so for the
+        # variants that got an explanation they are already in it.
+        warnings = "" if result.get("explanation") else "".join(
             f'<p class="warning">{escape(str(w))}</p>'
             for w in (result.get("warnings") or [])
         )

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -7,7 +7,6 @@ from typing import List, Dict, Any, Optional
 
 from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
-from starlette.concurrency import run_in_executor
 
 from allelio import __version__
 from allelio.parsers import parse_genotype_file
@@ -24,7 +23,7 @@ router = APIRouter()
 async def read_root(request: Request) -> str:
     """Serve the main HTML page."""
     try:
-        return templates.TemplateResponse("index.html", {"request": request})
+        return templates.TemplateResponse(request, "index.html")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to load index page: {str(e)}")
 
@@ -35,7 +34,7 @@ async def get_status() -> Dict[str, Any]:
     try:
         # Check ollama availability
         ai_engine = AIEngine()
-        ollama_available = ai_engine.check_connection()
+        ollama_available = await ai_engine.check_connection()
     except Exception:
         ollama_available = False
 
@@ -51,7 +50,7 @@ async def get_status() -> Dict[str, Any]:
         db = AllelioDB()
         db_ready = db.is_initialized()
         if db_ready:
-            stats = db.get_statistics()
+            stats = db.get_stats()
             db_stats = {
                 "clinvar_entries": stats.get("clinvar_entries", 0),
                 "gwas_entries": stats.get("gwas_entries", 0),
@@ -125,7 +124,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
 
         # Create AI engine and check connection
         ai_engine = AIEngine()
-        if not ai_engine.check_connection():
+        if not await ai_engine.check_connection():
             raise HTTPException(
                 status_code=503,
                 detail="AI service (Ollama) is not available"
@@ -168,10 +167,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         # Format results
         formatted_results = []
         for i, variant in enumerate(analysis_results):
-            warnings = get_variant_warnings(
-                variant.rsid,
-                variant.genotype if hasattr(variant, 'genotype') else None,
-            )
+            warnings = get_variant_warnings(variant)
             
             result_dict = {
                 "rsid": variant.rsid,

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -180,7 +180,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             )
 
         # Generate executive summary
-        _progress.update(stage="Summarising", done=0, total=0)
+        _progress.update(stage="Summarizing", done=0, total=0)
         try:
             if not ai_available:
                 raise RuntimeError("ollama unavailable")

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -4,7 +4,7 @@ import asyncio
 import tempfile
 from html import escape
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 
 from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
@@ -12,7 +12,7 @@ from fastapi.responses import FileResponse, HTMLResponse
 from allelio import __version__
 from allelio.parsers import parse_genotype_file
 from allelio.database.store import AllelioDB
-from allelio.analysis.lookup import analyze_variants, VariantResult
+from allelio.analysis.lookup import analyze_variants
 from allelio.ai.engine import AIEngine
 from allelio.ai.safety import get_variant_warnings
 from allelio.web.app import templates
@@ -285,17 +285,6 @@ async def export_report(analysis_data: Dict[str, Any]) -> FileResponse:
         )
 
 
-def _get_top_categories(results: List[VariantResult]) -> List[str]:
-    """Extract top categories from analysis results."""
-    categories = {}
-    for result in results:
-        category = result.category if hasattr(result, 'category') else "Unknown"
-        categories[category] = categories.get(category, 0) + 1
-    
-    sorted_cats = sorted(categories.items(), key=lambda x: x[1], reverse=True)
-    return [cat[0] for cat in sorted_cats[:5]]
-
-
 def _get_timestamp() -> str:
     """Get current timestamp in ISO format."""
     from datetime import datetime
@@ -306,8 +295,8 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     """Generate HTML report from analysis data."""
     summary = escape(str(analysis_data.get("summary") or "No summary available"))
     results = analysis_data.get("results", [])
-    total_variants = analysis_data.get("total_variants", 0)
-    analyzed_at = analysis_data.get("analyzed_at", "Unknown")
+    total_variants = escape(str(analysis_data.get("total_variants", 0)))
+    analyzed_at = escape(str(analysis_data.get("analyzed_at") or "Unknown"))
 
     # Build results table HTML
     results_html = ""

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -1,6 +1,7 @@
 """API routes for Allelio web interface."""
 
 import asyncio
+import os
 import tempfile
 from html import escape
 from pathlib import Path
@@ -8,6 +9,7 @@ from typing import Dict, Any, Optional
 
 from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
+from starlette.background import BackgroundTask
 
 from allelio import __version__
 from allelio.parsers import parse_genotype_file
@@ -80,20 +82,24 @@ def _gene_of(variant) -> Optional[str]:
 
 
 def _significance_of(variant) -> str:
-    """Bucket a result into the four badges the results list knows how to draw."""
+    """Bucket a result into the badges the results list knows how to draw.
+
+    ClinVar has the last word. "Conflicting classifications of pathogenicity"
+    is 130,833 rsIDs and sorts to the very top of the report, so it needs to
+    say so rather than borrow either neighbour's colour.
+    """
     for entry in (variant.clinvar_entries or []):
         significance = (entry.clinical_significance or "").lower()
         if "conflicting" in significance:
-            continue
+            return "conflicting"
         if "pathogenic" in significance and "benign" not in significance:
             return "pathogenic"
+        if "benign" in significance:
+            return "benign"
         if "risk" in significance:
             return "risk"
     if variant.gwas_entries:
         return "risk"
-    for entry in (variant.clinvar_entries or []):
-        if "benign" in (entry.clinical_significance or "").lower():
-            return "benign"
     return "trait"
 
 
@@ -166,18 +172,16 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
 
         # Generate AI explanations for significant variants. One call per
         # variant, run a few at a time — sequentially this took 12 minutes.
-        explanations = {}
-        if ai_available:
-            _progress.update(
-                stage="Writing explanations", done=0, total=len(top_variants)
-            )
+        _progress.update(
+            stage="Writing explanations", done=0, total=len(top_variants)
+        )
 
-            def on_explained(done: int, total: int) -> None:
-                _progress.update(done=done, total=total)
+        def on_explained(done: int, total: int) -> None:
+            _progress.update(done=done, total=total)
 
-            explanations = await ai_engine.explain_variants_batch(
-                top_variants, progress_callback=on_explained
-            )
+        explanations = await ai_engine.explain_variants_batch(
+            top_variants, progress_callback=on_explained
+        )
 
         # Generate executive summary
         _progress.update(stage="Summarizing", done=0, total=0)
@@ -263,17 +267,20 @@ async def export_report(analysis_data: Dict[str, Any]) -> FileResponse:
         # Generate HTML report (using report generator when available)
         html_content = _generate_html_report(analysis_data)
 
-        # Create temp file for report
-        temp_dir = tempfile.gettempdir()
-        temp_report_path = Path(temp_dir) / f"allelio_report_{_get_timestamp()}.html"
-
-        with open(temp_report_path, "w") as f:
+        # mkstemp gives the file 0600, and the report holds the user's
+        # genotypes. Explicit encoding because the report declares UTF-8 and
+        # the model writes em dashes.
+        fd, temp_report_path = tempfile.mkstemp(
+            prefix="allelio_report_", suffix=".html"
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(html_content)
 
         return FileResponse(
-            path=str(temp_report_path),
+            path=temp_report_path,
             filename=f"allelio_report_{_get_timestamp()}.html",
             media_type="text/html",
+            background=BackgroundTask(_unlink, temp_report_path),
         )
 
     except HTTPException:
@@ -283,6 +290,14 @@ async def export_report(analysis_data: Dict[str, Any]) -> FileResponse:
             status_code=500,
             detail=f"Report generation failed: {str(e)}"
         )
+
+
+def _unlink(path: str) -> None:
+    """Remove the exported report once it has been sent."""
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
 
 
 def _get_timestamp() -> str:
@@ -312,7 +327,14 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         genotype = field("genotype")
         category = field("category")
         explanation = field("explanation")
-        
+
+        # The safety layer computes these for BRCA1/2, TP53, Lynch and APOE.
+        # A report that omits them is the one place they matter most.
+        warnings = "".join(
+            f'<p class="warning">{escape(str(w))}</p>'
+            for w in (result.get("warnings") or [])
+        )
+
         results_html += f"""
         <tr>
             <td>{rsid}</td>
@@ -320,7 +342,7 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
             <td>{pos}</td>
             <td>{genotype}</td>
             <td>{category}</td>
-            <td>{explanation}</td>
+            <td>{explanation}{warnings}</td>
         </tr>
         """
 
@@ -331,6 +353,13 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         <meta charset="UTF-8">
         <title>Allelio Analysis Report</title>
         <style>
+            .warning {{
+                margin: 0.5em 0 0;
+                padding: 0.5em;
+                border-left: 3px solid #B45309;
+                background: #FEF3C7;
+                color: #78350F;
+            }}
             body {{
                 font-family: Arial, sans-serif;
                 margin: 20px;

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -101,10 +101,11 @@ def _significance_of(variant) -> str:
         if "risk" in significance:
             return "risk"
     if variant.gwas_entries:
-        # A GWAS row on its own is an association, not a risk — 37,108 of the
-        # 62,057 findings on a real genome. The analyser has already read the
-        # trait text and decided which of them are risk factors.
-        return "risk" if variant.category == "Risk Factors" else "trait"
+        # A GWAS row on its own is an association and nothing stronger — 37,108
+        # of the 62,057 findings on a real genome. Calling them all a risk
+        # over-states every one; calling them all a trait quietly demotes type 2
+        # diabetes and coronary artery disease. Say what the row actually is.
+        return "association"
     return "trait"
 
 
@@ -202,7 +203,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                        "straight from ClinVar and the GWAS Catalog.")
 
         # Format results
-        _progress.update(stage="Building your report")
+        _progress.update(stage="Building your report", done=0, total=0)
         formatted_results = []
         for i, variant in enumerate(analysis_results):
             warnings = get_variant_warnings(variant)
@@ -338,11 +339,14 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
 
         # The safety layer computes these for BRCA1/2, TP53, Lynch and APOE.
         # A report that omits them is the one place they matter most.
-        # explain_variant runs these through wrap_with_disclaimer, so for the
-        # variants that got an explanation they are already in it.
-        warnings = "" if result.get("explanation") else "".join(
+        # explain_variant folds these into the explanation via
+        # wrap_with_disclaimer — but only on the path where the model answered.
+        # A fallback explanation carries no warning, so test the text itself.
+        explanation_text = str(result.get("explanation") or "")
+        warnings = "".join(
             f'<p class="warning">{escape(str(w))}</p>'
             for w in (result.get("warnings") or [])
+            if str(w) not in explanation_text
         )
 
         results_html += f"""

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -1,6 +1,8 @@
 """API routes for Allelio web interface."""
 
 import asyncio
+import json
+import os
 import tempfile
 from pathlib import Path
 from typing import List, Dict, Any, Optional
@@ -91,6 +93,8 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         with open(temp_file_path, "wb") as f:
             f.write(content)
 
+        _progress.update(stage="Reading your file", done=0, total=0)
+
         # Parse genotype file
         loop = asyncio.get_event_loop()
         genotypes = await loop.run_in_executor(
@@ -112,6 +116,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             )
 
         # Analyze variants
+        _progress.update(stage=f"Matching {len(genotypes):,} variants against ClinVar and GWAS")
         analysis_results = await loop.run_in_executor(
             None, analyze_variants, genotypes, db
         )
@@ -122,13 +127,10 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 detail="No variants found in database"
             )
 
-        # Create AI engine and check connection
+        # Create AI engine. Ollama is optional — the README promises the tool
+        # still works without it, minus the plain-English explanations.
         ai_engine = AIEngine()
-        if not await ai_engine.check_connection():
-            raise HTTPException(
-                status_code=503,
-                detail="AI service (Ollama) is not available"
-            )
+        ai_available = await ai_engine.check_connection()
 
         # Get top 50 significant variants
         sorted_results = sorted(
@@ -138,33 +140,33 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         )
         top_variants = sorted_results[:50]
 
-        # Generate AI explanations for significant variants
+        # Generate AI explanations for significant variants. One call per
+        # variant, run a few at a time — sequentially this took 12 minutes.
         explanations = {}
-        for i, variant in enumerate(top_variants):
-            try:
-                explanation = await ai_engine.generate_explanation(
-                    variant.rsid,
-                    variant.chromosome,
-                    variant.position,
-                    variant.genotype,
-                    variant.clinvar_data if hasattr(variant, 'clinvar_data') else None,
-                    variant.gwas_data if hasattr(variant, 'gwas_data') else None,
-                )
-                explanations[variant.rsid] = explanation
-            except Exception:
-                explanations[variant.rsid] = "Explanation generation failed"
+        if ai_available:
+            _progress.update(
+                stage="Writing explanations", done=0, total=len(top_variants)
+            )
+
+            def on_explained(done: int, total: int) -> None:
+                _progress.update(done=done, total=total)
+
+            explanations = await ai_engine.explain_variants_batch(
+                top_variants, progress_callback=on_explained
+            )
 
         # Generate executive summary
+        _progress.update(stage="Summarising", done=0, total=0)
         try:
-            summary = await ai_engine.generate_summary(
-                total_variants=len(analysis_results),
-                significant_variants=len(top_variants),
-                top_categories=_get_top_categories(analysis_results),
-            )
+            if not ai_available:
+                raise RuntimeError("ollama unavailable")
+            summary = await ai_engine.generate_summary(top_variants)
         except Exception:
-            summary = "Unable to generate summary at this time"
+            summary = ("AI summary unavailable. Variant findings below come "
+                       "straight from ClinVar and the GWAS Catalog.")
 
         # Format results
+        _progress.update(stage="Building your report")
         formatted_results = []
         for i, variant in enumerate(analysis_results):
             warnings = get_variant_warnings(variant)
@@ -183,12 +185,14 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             }
             formatted_results.append(result_dict)
 
-        return {
+        payload = {
             "summary": summary,
             "results": formatted_results,
             "total_variants": len(analysis_results),
             "analyzed_at": _get_timestamp(),
         }
+        _save_last_analysis(payload)
+        return payload
 
     except HTTPException:
         raise
@@ -199,11 +203,42 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         )
     finally:
         # Clean up temp file
+        _progress.update(stage="idle", done=0, total=0)
         if temp_file_path and Path(temp_file_path).exists():
             try:
                 Path(temp_file_path).unlink()
             except Exception:
                 pass
+
+
+LAST_ANALYSIS_PATH = Path(os.path.expanduser("~/.allelio/last_analysis.json"))
+
+# A whole-genome run takes minutes. Without real numbers the page looks hung,
+# so the analyse route publishes its stage here and the browser polls it.
+_progress: Dict[str, Any] = {"stage": "idle", "done": 0, "total": 0}
+
+
+@router.get("/api/progress")
+async def get_progress() -> Dict[str, Any]:
+    """Where the current analysis has got to."""
+    return _progress
+
+
+def _save_last_analysis(payload: Dict[str, Any]) -> None:
+    """Keep the most recent run so a page reload does not mean a re-upload."""
+    try:
+        LAST_ANALYSIS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        LAST_ANALYSIS_PATH.write_text(json.dumps(payload))
+    except Exception:
+        pass
+
+
+@router.get("/api/last")
+async def get_last_analysis() -> Dict[str, Any]:
+    """Return the most recent analysis, or 404 if there has not been one."""
+    if not LAST_ANALYSIS_PATH.exists():
+        raise HTTPException(status_code=404, detail="No previous analysis")
+    return json.loads(LAST_ANALYSIS_PATH.read_text())
 
 
 @router.post("/api/export")

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -1,8 +1,10 @@
 """API routes for Allelio web interface."""
 
 import asyncio
+import json
 import os
 import tempfile
+from datetime import datetime
 from html import escape
 from pathlib import Path
 from typing import Dict, Any, Optional
@@ -302,16 +304,141 @@ async def export_report(analysis_data: Dict[str, Any]) -> FileResponse:
 
 
 def _unlink(path: str) -> None:
-    """Remove the exported report once it has been sent."""
+    """Delete a file we are done with, where failing to is not worth reporting."""
     try:
         os.unlink(path)
     except OSError:
         pass
 
 
+# A whole-genome run is half an hour, and the results only live in the tab that
+# ran it — a reload throws them away. Saving is opt-in and stays on this
+# machine: the file is the user's genome and never leaves it.
+SAVED_ANALYSIS_PATH = os.path.expanduser("~/.allelio/last_analysis.json")
+
+
+# No lock around any of this, and none needed: every writer gets its own mkstemp
+# temp file, os.replace is atomic, and the delete treats "already gone" as
+# success. Concurrent saves and deletes can only order differently, never tear.
+def _write_saved_analysis(analysis_data: Dict[str, Any]) -> None:
+    """Write the saved analysis atomically, readable only by its owner."""
+    directory = os.path.dirname(SAVED_ANALYSIS_PATH)
+    # 0700 only bites when this creates the directory; ~/.allelio usually
+    # already exists for the database, and silently tightening a directory
+    # this module does not own is not this feature's call to make.
+    os.makedirs(directory, mode=0o700, exist_ok=True)
+
+    # Same directory so os.replace stays on one filesystem, and mkstemp so a
+    # crash mid-write leaves the previous save intact rather than a half file.
+    fd, temp_path = tempfile.mkstemp(prefix=".last_analysis_", dir=directory)
+    try:
+        # os.fdopen owns the descriptor once it succeeds; if it raises, nothing
+        # else is going to close it.
+        try:
+            handle = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with handle as f:
+            json.dump(analysis_data, f)
+            # os.replace orders this rename against other renames, not against
+            # the data blocks. Without the fsync a power cut can land the
+            # rename and lose the contents — the truncated file this whole
+            # dance exists to prevent.
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temp_path, SAVED_ANALYSIS_PATH)
+    except BaseException:
+        # BaseException on purpose: a KeyboardInterrupt here would otherwise
+        # strand 15 MB of genotypes under a dotfile name nothing cleans up.
+        _unlink(temp_path)
+        raise
+
+
+def _read_saved_analysis() -> Optional[Dict[str, Any]]:
+    """Return the saved analysis, or None if there isn't a usable one."""
+    try:
+        with open(SAVED_ANALYSIS_PATH, encoding="utf-8") as f:
+            analysis_data = json.load(f)
+    except (OSError, ValueError):
+        # Missing, unreadable, or truncated by a crash mid-write. Any of those
+        # means "nothing to restore" — none of them should wedge the page.
+        return None
+    # A file holding a valid JSON list, string or number parses fine and then
+    # fails serialisation on the way out as a 500. It is not a saved analysis.
+    return analysis_data if isinstance(analysis_data, dict) else None
+
+
+@router.get("/api/saved")
+async def get_saved_analysis_info() -> Dict[str, Any]:
+    """Whether there is a saved analysis worth offering to restore."""
+    try:
+        saved_at = os.path.getmtime(SAVED_ANALYSIS_PATH)
+    except OSError:
+        return {"saved": False, "saved_at": None}
+    # Reading it to answer costs a parse of 15 MB on every page load, so the
+    # banner is offered on the strength of the file existing. /api/saved/data
+    # is the one that can still say no; the page handles that.
+    return {
+        "saved": True,
+        "saved_at": datetime.fromtimestamp(saved_at).isoformat(timespec="seconds"),
+    }
+
+
+@router.get("/api/saved/data")
+async def get_saved_analysis() -> Dict[str, Any]:
+    """The saved analysis itself, for restoring the results view."""
+    analysis_data = await asyncio.to_thread(_read_saved_analysis)
+    if analysis_data is None:
+        raise HTTPException(status_code=404, detail="No saved analysis")
+    return analysis_data
+
+
+@router.post("/api/saved")
+async def save_analysis(analysis_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Save the current analysis to this machine, at the user's request."""
+    if not analysis_data:
+        raise HTTPException(status_code=400, detail="No analysis data provided")
+
+    try:
+        # A whole genome is 15 MB of JSON and encoding it takes a quarter of a
+        # second, which on the event loop is a quarter of a second nothing else
+        # is served. FastAPI has already spent its own on decoding the body;
+        # this is the half we get to move off.
+        await asyncio.to_thread(_write_saved_analysis, analysis_data)
+    except (OSError, TypeError, ValueError):
+        # The path is under the user's home directory — saying which home is
+        # not the browser's business.
+        raise HTTPException(status_code=500, detail="Could not save the analysis")
+
+    return {"saved": True}
+
+
+def _delete_saved_analysis() -> None:
+    """Remove the saved analysis. Absent already is success, not an error."""
+    try:
+        os.unlink(SAVED_ANALYSIS_PATH)
+    except FileNotFoundError:
+        pass
+
+
+@router.delete("/api/saved")
+async def delete_saved_analysis() -> Dict[str, Any]:
+    """Forget the saved analysis, and only say so if it is really gone."""
+    try:
+        await asyncio.to_thread(_delete_saved_analysis)
+    except OSError:
+        # The page says "deleted" on any 200. Reporting success over a genome
+        # file still sitting on the disk is the one lie this feature cannot
+        # afford.
+        raise HTTPException(
+            status_code=500, detail="Could not delete the saved analysis"
+        )
+    return {"saved": False}
+
+
 def _get_timestamp() -> str:
     """Get current timestamp in ISO format."""
-    from datetime import datetime
     return datetime.now().isoformat().replace(":", "-").split(".")[0]
 
 

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -367,6 +367,9 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         <meta charset="UTF-8">
         <title>Allelio Analysis Report</title>
         <style>
+            td {{
+                white-space: pre-wrap;
+            }}
             .warning {{
                 margin: 0.5em 0 0;
                 padding: 0.5em;

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -1,9 +1,8 @@
 """API routes for Allelio web interface."""
 
 import asyncio
-import json
-import os
 import tempfile
+from html import escape
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
@@ -84,6 +83,8 @@ def _significance_of(variant) -> str:
     """Bucket a result into the four badges the results list knows how to draw."""
     for entry in (variant.clinvar_entries or []):
         significance = (entry.clinical_significance or "").lower()
+        if "conflicting" in significance:
+            continue
         if "pathogenic" in significance and "benign" not in significance:
             return "pathogenic"
         if "risk" in significance:
@@ -159,13 +160,9 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         ai_engine = AIEngine()
         ai_available = await ai_engine.check_connection()
 
-        # Get top 50 significant variants
-        sorted_results = sorted(
-            analysis_results,
-            key=lambda x: x.significance_score if hasattr(x, 'significance_score') else 0,
-            reverse=True
-        )
-        top_variants = sorted_results[:50]
+        # analyze_variants already returns these most-significant-first, so the
+        # top 50 are the 50 worth spending an AI call on.
+        top_variants = analysis_results[:50]
 
         # Generate AI explanations for significant variants. One call per
         # variant, run a few at a time — sequentially this took 12 minutes.
@@ -222,7 +219,6 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             "total_variants": len(analysis_results),
             "analyzed_at": _get_timestamp(),
         }
-        _save_last_analysis(payload)
         return payload
 
     except HTTPException:
@@ -242,8 +238,6 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 pass
 
 
-LAST_ANALYSIS_PATH = Path(os.path.expanduser("~/.allelio/last_analysis.json"))
-
 # A whole-genome run takes minutes. Without real numbers the page looks hung,
 # so the analyse route publishes its stage here and the browser polls it.
 _progress: Dict[str, Any] = {"stage": "idle", "done": 0, "total": 0}
@@ -253,23 +247,6 @@ _progress: Dict[str, Any] = {"stage": "idle", "done": 0, "total": 0}
 async def get_progress() -> Dict[str, Any]:
     """Where the current analysis has got to."""
     return _progress
-
-
-def _save_last_analysis(payload: Dict[str, Any]) -> None:
-    """Keep the most recent run so a page reload does not mean a re-upload."""
-    try:
-        LAST_ANALYSIS_PATH.parent.mkdir(parents=True, exist_ok=True)
-        LAST_ANALYSIS_PATH.write_text(json.dumps(payload))
-    except Exception:
-        pass
-
-
-@router.get("/api/last")
-async def get_last_analysis() -> Dict[str, Any]:
-    """Return the most recent analysis, or 404 if there has not been one."""
-    if not LAST_ANALYSIS_PATH.exists():
-        raise HTTPException(status_code=404, detail="No previous analysis")
-    return json.loads(LAST_ANALYSIS_PATH.read_text())
 
 
 @router.post("/api/export")
@@ -327,7 +304,7 @@ def _get_timestamp() -> str:
 
 def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     """Generate HTML report from analysis data."""
-    summary = analysis_data.get("summary", "No summary available")
+    summary = escape(str(analysis_data.get("summary") or "No summary available"))
     results = analysis_data.get("results", [])
     total_variants = analysis_data.get("total_variants", 0)
     analyzed_at = analysis_data.get("analyzed_at", "Unknown")
@@ -335,12 +312,17 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     # Build results table HTML
     results_html = ""
     for result in results[:100]:  # Limit to first 100 for report
-        rsid = result.get("rsid", "N/A")
-        chrom = result.get("chromosome", "N/A")
-        pos = result.get("position", "N/A")
-        genotype = result.get("genotype", "N/A")
-        category = result.get("category", "N/A")
-        explanation = result.get("explanation", "N/A")
+        # These come from the uploaded file and the model, and the report is
+        # opened in a browser — none of it is trusted markup.
+        def field(name):
+            return escape(str(result.get(name) or "N/A"))
+
+        rsid = field("rsid")
+        chrom = field("chromosome")
+        pos = field("position")
+        genotype = field("genotype")
+        category = field("category")
+        explanation = field("explanation")
         
         results_html += f"""
         <tr>

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -867,39 +867,7 @@
         document.addEventListener('DOMContentLoaded', () => {
             setupEventListeners();
             fetchStatus();
-            loadLastAnalysis();
         });
-
-        // Restore the previous run so a reload does not require re-uploading.
-        async function loadLastAnalysis() {
-            try {
-                const response = await fetch('/api/last');
-                if (!response.ok) return;
-                analysisResults = await response.json();
-                displayResults();
-                document.getElementById('resultsSection').classList.remove('hidden');
-                // A restored run is finished: no progress bar, no upload prompt.
-                document.getElementById('progressSection').classList.add('hidden');
-                // Hide the upload panel so a finished run does not look like a
-                // prompt, but leave one way back to it.
-                const upload = document.getElementById('uploadSection');
-                if (upload) {
-                    upload.classList.add('hidden');
-                    const again = document.createElement('button');
-                    again.className = 'export-button';
-                    again.textContent = 'Analyze another file';
-                    again.style.cssText = 'display:block;margin:0 auto 1.5rem;';
-                    again.onclick = () => {
-                        upload.classList.remove('hidden');
-                        again.remove();
-                    };
-                    const results = document.getElementById('resultsSection');
-                    results.parentNode.insertBefore(again, results);
-                }
-            } catch (e) {
-                // No previous run — the upload panel stands on its own.
-            }
-        }
 
         // Setup Event Listeners
         function setupEventListeners() {
@@ -1046,6 +1014,21 @@
         }
 
         // Display Results
+        // Result fields are read out of the uploaded file or written by the
+        // model; neither is trusted markup.
+        function esc(value) {
+            if (value === null || value === undefined) return '';
+            const div = document.createElement('div');
+            div.textContent = value;
+            return div.innerHTML;
+        }
+
+        // ClinVar and PubMed IDs land inside a URL, where escaping HTML is not
+        // enough — anything but digits is not an ID.
+        function idFor(value) {
+            return /^\d+$/.test(String(value ?? '')) ? String(value) : '';
+        }
+
         // "Health Conditions" -> "health_conditions"
         function slugify(category) {
             return (category || '').toLowerCase().replace(/ /g, '_');
@@ -1063,10 +1046,11 @@
             }
 
             // Create Category Tabs
-            const categories = ['all', 'health_conditions', 'risk_factors', 'pharmacogenomics', 'traits'];
+            const categories = ['all', 'health_conditions', 'carrier_status', 'risk_factors', 'pharmacogenomics', 'traits'];
             const categoryLabels = {
                 'all': 'All',
                 'health_conditions': 'Health Conditions',
+                'carrier_status': 'Carrier Status',
                 'risk_factors': 'Risk Factors',
                 'pharmacogenomics': 'Pharmacogenomics',
                 'traits': 'Traits'
@@ -1141,6 +1125,7 @@
 
             const categoryBadgeClass = {
                 'health_conditions': 'badge-category',
+                'carrier_status': 'badge-category',
                 'risk_factors': 'badge-category',
                 'pharmacogenomics': 'badge-category',
                 'traits': 'badge-category'
@@ -1149,20 +1134,20 @@
             card.innerHTML = `
                 <div class="result-header">
                     <div class="result-title">
-                        <div class="result-rsid">${result.rsid}</div>
-                        <div class="result-gene">${result.gene || 'Gene: Unknown'}</div>
+                        <div class="result-rsid">${esc(result.rsid)}</div>
+                        <div class="result-gene">${esc(result.gene) || 'Gene: Unknown'}</div>
                         <div class="result-meta">
-                            <span class="badge ${categoryBadgeClass}">${result.category.replace('_', ' ')}</span>
-                            <span class="badge ${significanceBadgeClass}">${significance}</span>
+                            <span class="badge ${categoryBadgeClass}">${esc(result.category).replace('_', ' ')}</span>
+                            <span class="badge ${significanceBadgeClass}">${esc(significance)}</span>
                         </div>
                     </div>
-                    <div class="result-genotype">${result.genotype}</div>
+                    <div class="result-genotype">${esc(result.genotype)}</div>
                 </div>
                 <div class="result-body">
-                    <div class="result-explanation">${result.explanation || 'No explanation available.'}</div>
+                    <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
                     <div class="result-sources">
-                        ${result.clinvar_id ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/${result.clinvar_id}/" target="_blank" class="source-link">ClinVar</a>` : ''}
-                        ${result.pubmed_id ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${result.pubmed_id}/" target="_blank" class="source-link">PubMed</a>` : ''}
+                        ${idFor(result.clinvar_id) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/${idFor(result.clinvar_id)}/" target="_blank" class="source-link">ClinVar</a>` : ''}
+                        ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" class="source-link">PubMed</a>` : ''}
                     </div>
                 </div>
             `;

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1046,14 +1046,15 @@
             }
 
             // Create Category Tabs
-            const categories = ['all', 'health_conditions', 'carrier_status', 'risk_factors', 'pharmacogenomics', 'traits'];
+            const categories = ['all', 'health_conditions', 'carrier_status', 'risk_factors', 'pharmacogenomics', 'traits', 'unknown'];
             const categoryLabels = {
                 'all': 'All',
                 'health_conditions': 'Health Conditions',
                 'carrier_status': 'Carrier Status',
                 'risk_factors': 'Risk Factors',
                 'pharmacogenomics': 'Pharmacogenomics',
-                'traits': 'Traits'
+                'traits': 'Traits',
+                'unknown': 'Uncategorized'
             };
 
             const tabsContainer = document.getElementById('resultsTabs');
@@ -1062,6 +1063,7 @@
             categories.forEach(cat => {
                 const button = document.createElement('button');
                 button.className = 'tab-button' + (cat === 'all' ? ' active' : '');
+                button.dataset.category = cat;
                 button.textContent = categoryLabels[cat];
                 button.addEventListener('click', () => selectCategory(cat));
                 tabsContainer.appendChild(button);
@@ -1075,9 +1077,11 @@
         function selectCategory(category) {
             currentCategory = category;
 
-            // Update active tab
-            document.querySelectorAll('.tab-button').forEach((btn, idx) => {
-                btn.classList.toggle('active', btn.textContent === document.querySelectorAll('.tab-button')[['all', 'health_conditions', 'risk_factors', 'pharmacogenomics', 'traits'].indexOf(category)].textContent);
+            // Update active tab. This used to look the tab up by position in a
+            // second, hardcoded category list; anything missing from that list
+            // indexed to -1 and threw.
+            document.querySelectorAll('.tab-button').forEach(btn => {
+                btn.classList.toggle('active', btn.dataset.category === category);
             });
 
             renderResultCards();
@@ -1126,6 +1130,7 @@
             const categoryBadgeClass = {
                 'health_conditions': 'badge-category',
                 'carrier_status': 'badge-category',
+                'unknown': 'badge-category',
                 'risk_factors': 'badge-category',
                 'pharmacogenomics': 'badge-category',
                 'traits': 'badge-category'

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -477,6 +477,10 @@
             border-left-color: #6B7280;
         }
 
+        .result-card.association {
+            border-left-color: #06B6D4;
+        }
+
         .result-card.benign {
             border-left-color: #10B981;
         }
@@ -576,6 +580,16 @@
         body.dark-mode .badge-trait {
             background-color: #1E3A8A;
             color: #93C5FD;
+        }
+
+        .badge-association {
+            background-color: #CFFAFE;
+            color: #155E75;
+        }
+
+        body.dark-mode .badge-association {
+            background-color: #164E63;
+            color: #A5F3FC;
         }
 
         .badge-uncertain {
@@ -1183,6 +1197,7 @@
                 'pathogenic': 'badge-pathogenic',
                 'conflicting': 'badge-conflicting',
                 'uncertain': 'badge-uncertain',
+                'association': 'badge-association',
                 'risk': 'badge-risk',
                 'benign': 'badge-benign',
                 'trait': 'badge-trait'
@@ -1202,7 +1217,7 @@
                 </div>
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
-                    ${result.explanation ? '' : (result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
+                    ${(result.warnings || []).filter(w => !String(result.explanation || '').includes(w)).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -431,6 +431,7 @@
         .summary-text {
             font-size: 0.95rem;
             line-height: 1.6;
+            white-space: pre-wrap;
         }
 
         /* Result Card */
@@ -593,6 +594,7 @@
             margin-bottom: 1rem;
             color: var(--gray-700);
             line-height: 1.7;
+            white-space: pre-wrap;
         }
 
         body.dark-mode .result-explanation {
@@ -1155,8 +1157,8 @@
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
                     <div class="result-sources">
-                        ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" class="source-link">ClinVar</a>` : ''}
-                        ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" class="source-link">PubMed</a>` : ''}
+                        ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
+                        ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}
                     </div>
                 </div>
             `;

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1023,10 +1023,14 @@
             return div.innerHTML;
         }
 
-        // ClinVar and PubMed IDs land inside a URL, where escaping HTML is not
-        // enough — anything but digits is not an ID.
+        // These land inside a URL, where escaping HTML is not enough. A PubMed
+        // ID is digits; an rsID is rs or i followed by digits.
         function idFor(value) {
             return /^\d+$/.test(String(value ?? '')) ? String(value) : '';
+        }
+
+        function rsidFor(value) {
+            return /^(rs|i)\d+$/.test(String(value ?? '')) ? String(value) : '';
         }
 
         // "Health Conditions" -> "health_conditions"
@@ -1151,7 +1155,7 @@
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
                     <div class="result-sources">
-                        ${idFor(result.clinvar_id) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/${idFor(result.clinvar_id)}/" target="_blank" class="source-link">ClinVar</a>` : ''}
+                        ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" class="source-link">PubMed</a>` : ''}
                     </div>
                 </div>

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -886,7 +886,7 @@
                 if (upload) {
                     upload.classList.add('hidden');
                     const again = document.createElement('button');
-                    again.className = 'btn btn-secondary';
+                    again.className = 'export-button';
                     again.textContent = 'Analyze another file';
                     again.style.cssText = 'display:block;margin:0 auto 1.5rem;';
                     again.onclick = () => {

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -473,6 +473,10 @@
             border-left-color: #8B5CF6;
         }
 
+        .result-card.uncertain {
+            border-left-color: #6B7280;
+        }
+
         .result-card.benign {
             border-left-color: #10B981;
         }
@@ -572,6 +576,16 @@
         body.dark-mode .badge-trait {
             background-color: #1E3A8A;
             color: #93C5FD;
+        }
+
+        .badge-uncertain {
+            background-color: #E5E7EB;
+            color: #374151;
+        }
+
+        body.dark-mode .badge-uncertain {
+            background-color: #374151;
+            color: #D1D5DB;
         }
 
         .badge-conflicting {
@@ -1168,6 +1182,7 @@
             const significanceBadgeClass = {
                 'pathogenic': 'badge-pathogenic',
                 'conflicting': 'badge-conflicting',
+                'uncertain': 'badge-uncertain',
                 'risk': 'badge-risk',
                 'benign': 'badge-benign',
                 'trait': 'badge-trait'
@@ -1187,7 +1202,7 @@
                 </div>
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
-                    ${(result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
+                    ${result.explanation ? '' : (result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1120,19 +1120,7 @@
                 return;
             }
 
-            // Cap the DOM: a full genome yields tens of thousands of results and
-            // rendering them all locks the browser. Results are already ordered
-            // by significance, so the cap keeps the ones that matter.
-            const RENDER_LIMIT = 200;
-            const shown = results.slice(0, RENDER_LIMIT);
-            if (results.length > RENDER_LIMIT) {
-                const note = document.createElement('p');
-                note.style.cssText = 'text-align:center;color:var(--gray-600);padding:1rem;';
-                note.textContent = `Showing the top ${RENDER_LIMIT} of ${results.length.toLocaleString()} findings. Export the report for the full set.`;
-                container.appendChild(note);
-            }
-
-            shown.forEach((result, idx) => {
+            results.forEach((result, idx) => {
                 const card = createResultCard(result);
                 container.appendChild(card);
             });

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -738,6 +738,59 @@
             transform: none;
         }
 
+        .export-button.secondary {
+            background-color: transparent;
+            color: var(--primary);
+            border: 1px solid var(--primary);
+            margin-left: 0.75rem;
+        }
+
+        .export-button.secondary:hover {
+            background-color: var(--primary);
+            color: white;
+        }
+
+        /* Saved analysis banner */
+        .saved-banner {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+            padding: 1rem 1.25rem;
+            border-radius: var(--border-radius);
+            border-left: 3px solid var(--primary);
+            background-color: #CCFBF1;
+            color: #134E4A;
+        }
+
+        body.dark-mode .saved-banner {
+            background-color: #134E4A;
+            color: #CCFBF1;
+        }
+
+        .saved-banner-text {
+            flex: 1;
+            min-width: 12rem;
+        }
+
+        .saved-banner button {
+            border: none;
+            padding: 0.5rem 1rem;
+            border-radius: var(--border-radius);
+            cursor: pointer;
+            font-weight: 600;
+            transition: var(--transition);
+            background-color: var(--primary);
+            color: white;
+        }
+
+        .saved-banner button.ghost {
+            background-color: transparent;
+            color: inherit;
+            border: 1px solid currentColor;
+        }
+
         /* Alert/Toast */
         .alert {
             padding: 1rem 1.5rem;
@@ -878,6 +931,11 @@
 
         <!-- Upload Section -->
         <div id="uploadSection" class="section">
+            <div class="saved-banner hidden" id="savedBanner">
+                <div class="saved-banner-text" id="savedBannerText"></div>
+                <button id="restoreSavedButton">Open it</button>
+                <button class="ghost" id="deleteSavedButton">Delete</button>
+            </div>
             <div class="card">
                 <div class="upload-zone" id="uploadZone">
                     <div class="upload-icon">📤</div>
@@ -922,6 +980,7 @@
             <!-- Export -->
             <div class="export-container">
                 <button class="export-button" id="exportButton">📥 Export Report</button>
+                <button class="export-button secondary" id="saveButton">💾 Save results on this computer</button>
             </div>
         </div>
     </div>
@@ -936,6 +995,7 @@
         document.addEventListener('DOMContentLoaded', () => {
             setupEventListeners();
             fetchStatus();
+            fetchSavedInfo();
         });
 
         // Setup Event Listeners
@@ -976,6 +1036,11 @@
 
             // Export Button
             document.getElementById('exportButton').addEventListener('click', exportReport);
+
+            // Saving results on this machine — opt-in, and reversible
+            document.getElementById('saveButton').addEventListener('click', saveResults);
+            document.getElementById('restoreSavedButton').addEventListener('click', restoreSaved);
+            document.getElementById('deleteSavedButton').addEventListener('click', deleteSaved);
         }
 
         // Dark Mode Toggle
@@ -1121,6 +1186,12 @@
 
         function displayResults() {
             if (!analysisResults) return;
+
+            // The tab bar below is rebuilt with All marked active, but the
+            // filter renderResultCards applies is this module-level variable.
+            // Leave it on the last tab clicked and a fresh set of results comes
+            // up reading "All" while showing only pharmacogenomics.
+            currentCategory = 'all';
 
             // Executive Summary
             const executiveSummary = document.getElementById('executiveSummary');
@@ -1281,6 +1352,96 @@
                 showAlert('Error exporting report: ' + error.message, 'error');
                 document.getElementById('exportButton').disabled = false;
             }
+        }
+
+        // Saved analysis
+        // A run is half an hour and the results only live in this tab. Saving
+        // writes them to a file on this computer, and only when asked.
+        async function fetchSavedInfo() {
+            const banner = document.getElementById('savedBanner');
+            try {
+                const response = await fetch('/api/saved');
+                if (!response.ok) return;
+                const info = await response.json();
+                if (!info.saved) {
+                    banner.classList.add('hidden');
+                    return;
+                }
+                document.getElementById('savedBannerText').textContent =
+                    `You saved an analysis on this computer (${info.saved_at.replace('T', ' ')}).`;
+                banner.classList.remove('hidden');
+            } catch (error) {
+                // No banner is the right failure here — the upload path works
+                // without it.
+            }
+        }
+
+        async function saveResults() {
+            if (!analysisResults) return;
+
+            const button = document.getElementById('saveButton');
+            button.disabled = true;
+            try {
+                const response = await fetch('/api/saved', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(analysisResults)
+                });
+                if (!response.ok) throw new Error('Save failed');
+                showAlert('Saved on this computer. It will be offered next time you open Allelio.', 'success');
+                fetchSavedInfo();
+            } catch (error) {
+                console.error('Error saving results:', error);
+                showAlert('Error saving results: ' + error.message, 'error');
+            }
+            button.disabled = false;
+        }
+
+        async function restoreSaved() {
+            const button = document.getElementById('restoreSavedButton');
+            button.disabled = true;
+            try {
+                const response = await fetch('/api/saved/data');
+                // The banner is offered on the file existing, not on it
+                // parsing — reading 15 MB to draw a banner is not worth it. A
+                // save cut short by a crash lands here. Say so and leave Delete
+                // reachable; the file really is still there, so hiding the
+                // banner would only mean claiming otherwise.
+                if (response.status === 404) {
+                    document.getElementById('savedBannerText').textContent =
+                        'The saved analysis cannot be opened — it was removed, or cut short by a crash. Delete it and run your file again.';
+                    button.disabled = true;
+                    return;
+                }
+                if (!response.ok) throw new Error('Could not open the saved analysis');
+                analysisResults = await response.json();
+                displayResults();
+                document.getElementById('uploadSection').classList.add('hidden');
+                document.getElementById('resultsSection').classList.remove('hidden');
+            } catch (error) {
+                console.error('Error opening saved analysis:', error);
+                showAlert('Error opening saved analysis: ' + error.message, 'error');
+            }
+            button.disabled = false;
+        }
+
+        async function deleteSaved() {
+            // Irreversible, sits next to "Open it", and re-earning it costs
+            // half an hour.
+            if (!confirm('Delete the saved analysis? Running the file again takes about half an hour.')) return;
+
+            const button = document.getElementById('deleteSavedButton');
+            button.disabled = true;
+            try {
+                const response = await fetch('/api/saved', { method: 'DELETE' });
+                if (!response.ok) throw new Error('the file is still on the disk');
+                document.getElementById('savedBanner').classList.add('hidden');
+                showAlert('Saved analysis deleted.', 'success');
+            } catch (error) {
+                console.error('Error deleting saved analysis:', error);
+                showAlert('Could not delete the saved analysis — ' + error.message, 'error');
+            }
+            button.disabled = false;
         }
 
         // Show Alert

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1043,8 +1043,20 @@
                     progressText.textContent = p.total
                         ? `${p.stage} — ${p.done} of ${p.total}`
                         : `${p.stage}...`;
+                    // Only the explanation phase has a count. Without this the
+                    // bar sits at 10% through every other stage, one of which
+                    // can take half an hour.
+                    const stageWidths = {
+                        'Reading your file': 5,
+                        'Summarizing': 92,
+                        'Building your report': 96
+                    };
                     if (p.total) {
                         progressBar.style.width = (10 + 80 * p.done / p.total) + '%';
+                    } else if (p.stage in stageWidths) {
+                        progressBar.style.width = stageWidths[p.stage] + '%';
+                    } else if (p.stage.startsWith('Matching')) {
+                        progressBar.style.width = '8%';
                     }
                 } catch (e) {
                     // Server busy or restarting — the next tick tries again.
@@ -1215,9 +1227,9 @@
                     </div>
                     <div class="result-genotype">${esc(result.genotype)}</div>
                 </div>
+                ${(result.warnings || []).filter(w => !String(result.explanation || '').includes(w)).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
-                    ${(result.warnings || []).filter(w => !String(result.explanation || '').includes(w)).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1046,6 +1046,11 @@
         }
 
         // Display Results
+        // "Health Conditions" -> "health_conditions"
+        function slugify(category) {
+            return (category || '').toLowerCase().replace(/ /g, '_');
+        }
+
         function displayResults() {
             if (!analysisResults) return;
 
@@ -1105,7 +1110,9 @@
 
             // Filter by category
             if (currentCategory !== 'all') {
-                results = results.filter(r => r.category === currentCategory);
+                // The tabs are keyed on slugs; the analyser emits labels like
+                // "Health Conditions", so every tab but All matched nothing.
+                results = results.filter(r => slugify(r.category) === currentCategory);
             }
 
             if (results.length === 0) {

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -925,7 +925,7 @@
                 // Update Database Status
                 const dbIndicator = document.getElementById('dbIndicator');
                 const dbStatus = document.getElementById('dbStatus');
-                if (data.database_ready) {
+                if (data.db_ready) {
                     dbIndicator.classList.add('connected');
                     dbStatus.textContent = 'Database Ready';
                 } else {
@@ -936,7 +936,7 @@
                 // Update Ollama Status
                 const ollamaIndicator = document.getElementById('ollamaIndicator');
                 const ollamaStatus = document.getElementById('ollamaStatus');
-                if (data.ollama_connected) {
+                if (data.ollama_available) {
                     ollamaIndicator.classList.add('connected');
                     ollamaStatus.textContent = 'Ollama Connected';
                 } else {

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -867,7 +867,39 @@
         document.addEventListener('DOMContentLoaded', () => {
             setupEventListeners();
             fetchStatus();
+            loadLastAnalysis();
         });
+
+        // Restore the previous run so a reload does not require re-uploading.
+        async function loadLastAnalysis() {
+            try {
+                const response = await fetch('/api/last');
+                if (!response.ok) return;
+                analysisResults = await response.json();
+                displayResults();
+                document.getElementById('resultsSection').classList.remove('hidden');
+                // A restored run is finished: no progress bar, no upload prompt.
+                document.getElementById('progressSection').classList.add('hidden');
+                // Hide the upload panel so a finished run does not look like a
+                // prompt, but leave one way back to it.
+                const upload = document.getElementById('uploadSection');
+                if (upload) {
+                    upload.classList.add('hidden');
+                    const again = document.createElement('button');
+                    again.className = 'btn btn-secondary';
+                    again.textContent = 'Analyze another file';
+                    again.style.cssText = 'display:block;margin:0 auto 1.5rem;';
+                    again.onclick = () => {
+                        upload.classList.remove('hidden');
+                        again.remove();
+                    };
+                    const results = document.getElementById('resultsSection');
+                    results.parentNode.insertBefore(again, results);
+                }
+            } catch (e) {
+                // No previous run — the upload panel stands on its own.
+            }
+        }
 
         // Setup Event Listeners
         function setupEventListeners() {
@@ -959,14 +991,28 @@
             document.getElementById('progressSection').classList.remove('hidden');
             document.getElementById('resultsSection').classList.add('hidden');
 
-            // Animate progress bar
-            let progress = 0;
+            // Poll the server for real progress. A whole genome takes minutes;
+            // a bar that fakes its way to 90% and stops looks like a hang.
             const progressBar = document.getElementById('progressBar');
-            const progressInterval = setInterval(() => {
-                progress += Math.random() * 30;
-                if (progress > 90) progress = 90;
-                progressBar.style.width = progress + '%';
-            }, 500);
+            const progressText = document.getElementById('progressText');
+            progressBar.style.width = '2%';
+            progressText.textContent = 'Uploading...';
+            const progressInterval = setInterval(async () => {
+                try {
+                    const r = await fetch('/api/progress');
+                    if (!r.ok) return;
+                    const p = await r.json();
+                    if (p.stage === 'idle') return;
+                    progressText.textContent = p.total
+                        ? `${p.stage} — ${p.done} of ${p.total}`
+                        : `${p.stage}...`;
+                    if (p.total) {
+                        progressBar.style.width = (10 + 80 * p.done / p.total) + '%';
+                    }
+                } catch (e) {
+                    // Server busy or restarting — the next tick tries again.
+                }
+            }, 1000);
 
             try {
                 const response = await fetch('/api/analyze', {
@@ -1067,7 +1113,19 @@
                 return;
             }
 
-            results.forEach((result, idx) => {
+            // Cap the DOM: a full genome yields tens of thousands of results and
+            // rendering them all locks the browser. Results are already ordered
+            // by significance, so the cap keeps the ones that matter.
+            const RENDER_LIMIT = 200;
+            const shown = results.slice(0, RENDER_LIMIT);
+            if (results.length > RENDER_LIMIT) {
+                const note = document.createElement('p');
+                note.style.cssText = 'text-align:center;color:var(--gray-600);padding:1rem;';
+                note.textContent = `Showing the top ${RENDER_LIMIT} of ${results.length.toLocaleString()} findings. Export the report for the full set.`;
+                container.appendChild(note);
+            }
+
+            shown.forEach((result, idx) => {
                 const card = createResultCard(result);
                 container.appendChild(card);
             });

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -469,6 +469,10 @@
             border-left-color: #3B82F6;
         }
 
+        .result-card.conflicting {
+            border-left-color: #8B5CF6;
+        }
+
         .result-card.benign {
             border-left-color: #10B981;
         }
@@ -560,6 +564,26 @@
             color: #6EE7B7;
         }
 
+        .badge-trait {
+            background-color: #DBEAFE;
+            color: #1E3A8A;
+        }
+
+        body.dark-mode .badge-trait {
+            background-color: #1E3A8A;
+            color: #93C5FD;
+        }
+
+        .badge-conflicting {
+            background-color: #EDE9FE;
+            color: #5B21B6;
+        }
+
+        body.dark-mode .badge-conflicting {
+            background-color: #4C1D95;
+            color: #C4B5FD;
+        }
+
         .result-genotype {
             font-family: 'Courier New', monospace;
             font-weight: 600;
@@ -599,6 +623,21 @@
 
         body.dark-mode .result-explanation {
             color: #D1D5DB;
+        }
+
+        .result-warning {
+            margin-top: 0.75rem;
+            padding: 0.75rem;
+            border-left: 3px solid #B45309;
+            border-radius: 4px;
+            background-color: #FEF3C7;
+            color: #78350F;
+            font-size: 0.875rem;
+        }
+
+        body.dark-mode .result-warning {
+            background-color: #451A03;
+            color: #FCD34D;
         }
 
         .result-sources {
@@ -1128,19 +1167,11 @@
             const significance = result.significance || 'benign';
             const significanceBadgeClass = {
                 'pathogenic': 'badge-pathogenic',
+                'conflicting': 'badge-conflicting',
                 'risk': 'badge-risk',
                 'benign': 'badge-benign',
-                'trait': 'badge-benign'
+                'trait': 'badge-trait'
             }[significance] || 'badge-benign';
-
-            const categoryBadgeClass = {
-                'health_conditions': 'badge-category',
-                'carrier_status': 'badge-category',
-                'unknown': 'badge-category',
-                'risk_factors': 'badge-category',
-                'pharmacogenomics': 'badge-category',
-                'traits': 'badge-category'
-            }[result.category] || 'badge-category';
 
             card.innerHTML = `
                 <div class="result-header">
@@ -1148,7 +1179,7 @@
                         <div class="result-rsid">${esc(result.rsid)}</div>
                         <div class="result-gene">${esc(result.gene) || 'Gene: Unknown'}</div>
                         <div class="result-meta">
-                            <span class="badge ${categoryBadgeClass}">${esc(result.category).replace('_', ' ')}</span>
+                            <span class="badge badge-category">${esc(result.category).replace('_', ' ')}</span>
                             <span class="badge ${significanceBadgeClass}">${esc(significance)}</span>
                         </div>
                     </div>
@@ -1156,6 +1187,7 @@
                 </div>
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
+                    ${(result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-    "fastapi>=0.104.0",
+    "fastapi>=0.108.0",  # TemplateResponse(request, name) needs starlette >= 0.29
     "uvicorn[standard]>=0.24.0",
     "click>=8.1.0",
     "ollama>=0.4.0",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,3 +1,4 @@
+import asyncio
 """Tests for the web interface.
 
 The web module went unexercised long enough to accumulate a startup crash, two
@@ -261,3 +262,108 @@ def test_export_does_not_leave_the_report_in_the_temp_directory() -> None:
 
     assert response.status_code == 200
     assert set(temp_dir.glob("allelio_report_*")) == before
+
+
+def test_upload_cannot_choose_where_it_lands() -> None:
+    """The multipart filename is raw header data, and multipart is a
+    CORS-safelisted content type, so any page could have posted this. The route
+    writes the body to the name it is given and then unlinks it, so the damage
+    is an overwrite followed by a delete."""
+    import tempfile
+    from pathlib import Path
+
+    victim_dir = Path(tempfile.mkdtemp(prefix="allelio_probe_"))
+    victim = victim_dir / "victim.txt"
+    victim.write_text("do not touch")
+
+    client = TestClient(app)
+    client.post(
+        "/api/analyze",
+        files={
+            "file": (
+                f"{victim_dir.name}/victim.txt",
+                b"rs1\t1\t1\tAA\n",
+            )
+        },
+    )
+
+    assert victim.exists(), "the upload deleted a file it chose the name of"
+    assert victim.read_text() == "do not touch"
+    victim.unlink()
+    victim_dir.rmdir()
+
+
+def test_a_gwas_association_is_not_a_risk() -> None:
+    """37,108 of the 62,057 findings on a real genome are GWAS-only traits.
+    They were all badged RISK while their own tab said Traits."""
+    from allelio.web.routes import _significance_of
+
+    trait = VariantResult(
+        rsid="rs1",
+        gwas_entries=[GWASEntry(rsid="rs1", trait="Height")],
+        category="Traits",
+    )
+    risk = VariantResult(
+        rsid="rs2",
+        gwas_entries=[GWASEntry(rsid="rs2", trait="Coronary artery disease risk")],
+        category="Risk Factors",
+    )
+    assert _significance_of(trait) == "trait"
+    assert _significance_of(risk) == "risk"
+
+
+def test_uncertain_significance_is_not_a_trait() -> None:
+    """1,236,063 ClinVar rows — the plurality — say "Uncertain significance".
+    Drawn as a trait, a variant nobody can interpret reads as harmless."""
+    from allelio.web.routes import _significance_of
+
+    variant = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[
+            ClinVarEntry(rsid="rs1", clinical_significance="Uncertain significance")
+        ],
+    )
+    assert _significance_of(variant) == "uncertain"
+
+
+@pytest.mark.asyncio
+async def test_explanations_give_up_and_return_what_finished() -> None:
+    """Fifty variants at three at a time, each allowed 300s, can hold the
+    upload open for over an hour."""
+    from allelio.ai.engine import AIEngine
+
+    engine = AIEngine()
+    engine.available = True
+
+    async def slow_or_not(result):
+        if result.rsid == "rs_slow":
+            await asyncio.sleep(30)
+        return "done"
+
+    engine.explain_variant = slow_or_not
+
+    explanations = await engine.explain_variants_batch(
+        [VariantResult(rsid="rs_fast"), VariantResult(rsid="rs_slow")],
+        deadline=0.5,
+    )
+
+    assert explanations == {"rs_fast": "done"}
+
+
+def test_a_warning_is_not_printed_twice() -> None:
+    """explain_variant already folds the counselling warning into the
+    explanation via wrap_with_disclaimer."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {
+            "results": [
+                {
+                    "rsid": "rs1",
+                    "explanation": "Note: talk to a genetic counselor.",
+                    "warnings": ["Note: talk to a genetic counselor."],
+                }
+            ]
+        }
+    )
+    assert html.count("talk to a genetic counselor.") == 1

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -105,3 +105,20 @@ async def test_summary_prompt_lists_the_variants() -> None:
     prompt = engine.client.prompts[0]
     assert "rs1" in prompt and "rs2" in prompt
     assert "APOE" in prompt
+
+
+def test_result_cards_get_a_gene_and_a_significance() -> None:
+    """The list drew every variant as "Gene: Unknown" and BENIGN, including the
+    pathogenic ones, because the route sent fields the page does not read."""
+    from allelio.web.routes import _gene_of, _significance_of
+
+    variant = _variant()
+    assert _gene_of(variant) == "APOE"
+    assert _significance_of(variant) == "pathogenic"
+
+    benign = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[ClinVarEntry(rsid="rs1", clinical_significance="Benign")],
+    )
+    assert _significance_of(benign) == "benign"
+    assert _gene_of(benign) is None

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,4 +1,3 @@
-import asyncio
 """Tests for the web interface.
 
 The web module went unexercised long enough to accumulate a startup crash, two
@@ -6,6 +5,8 @@ missing awaits and three wrong method names, so these cover the wiring: the
 routes answer, CORS is not open to the world, and the AI engine's two entry
 points survive a round trip against a stubbed client.
 """
+
+import asyncio
 
 import pytest
 from fastapi.testclient import TestClient
@@ -240,6 +241,9 @@ def test_exported_report_carries_the_counselling_warnings() -> None:
             "results": [
                 {
                     "rsid": "rs1",
+                    # What _fallback_explanation writes: no disclaimer, because
+                    # only the path where the model answered adds one.
+                    "explanation": "ClinVar: Pathogenic. Gene: BRCA1.",
                     "warnings": ["Talk to a genetic counselor."],
                 }
             ]
@@ -293,23 +297,24 @@ def test_upload_cannot_choose_where_it_lands() -> None:
     victim_dir.rmdir()
 
 
-def test_a_gwas_association_is_not_a_risk() -> None:
-    """37,108 of the 62,057 findings on a real genome are GWAS-only traits.
-    They were all badged RISK while their own tab said Traits."""
+def test_a_gwas_row_is_an_association_and_nothing_stronger() -> None:
+    """37,108 of the 62,057 findings on a real genome are GWAS-only. Badging
+    them all RISK over-states height; badging them all TRAIT demotes type 2
+    diabetes. Only 2,068 of the 553,549 GWAS rsIDs have a trait string the
+    analyser can tell apart, so neither guess is available."""
     from allelio.web.routes import _significance_of
 
-    trait = VariantResult(
-        rsid="rs1",
-        gwas_entries=[GWASEntry(rsid="rs1", trait="Height")],
-        category="Traits",
-    )
-    risk = VariantResult(
-        rsid="rs2",
-        gwas_entries=[GWASEntry(rsid="rs2", trait="Coronary artery disease risk")],
-        category="Risk Factors",
-    )
-    assert _significance_of(trait) == "trait"
-    assert _significance_of(risk) == "risk"
+    for trait, category in [
+        ("Height", "Traits"),
+        ("Type 2 diabetes", "Traits"),
+        ("Coronary artery disease risk", "Risk Factors"),
+    ]:
+        variant = VariantResult(
+            rsid="rs1",
+            gwas_entries=[GWASEntry(rsid="rs1", trait=trait)],
+            category=category,
+        )
+        assert _significance_of(variant) == "association"
 
 
 def test_uncertain_significance_is_not_a_trait() -> None:
@@ -367,3 +372,19 @@ def test_a_warning_is_not_printed_twice() -> None:
         }
     )
     assert html.count("talk to a genetic counselor.") == 1
+
+
+def test_a_fallback_explanation_still_gets_its_warning() -> None:
+    """explain_variant only runs wrap_with_disclaimer on the path where the
+    model answered. Without Ollama every top-50 variant takes the other one."""
+    from allelio.web.routes import _generate_html_report
+
+    warning = "Genetic counseling is strongly recommended."
+    wrapped = _generate_html_report(
+        {"results": [{"rsid": "rs1", "explanation": f"x {warning}", "warnings": [warning]}]}
+    )
+    fallback = _generate_html_report(
+        {"results": [{"rsid": "rs1", "explanation": "ClinVar: Pathogenic.", "warnings": [warning]}]}
+    )
+    assert wrapped.count(warning) == 1
+    assert fallback.count(warning) == 1

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,107 @@
+"""Tests for the web interface.
+
+The web module went unexercised long enough to accumulate a startup crash, two
+missing awaits and three wrong method names, so these cover the wiring: the
+routes answer, CORS is not open to the world, and the AI engine's two entry
+points survive a round trip against a stubbed client.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from allelio.ai.engine import AIEngine
+from allelio.analysis.lookup import ClinVarEntry, VariantResult
+from allelio.web.app import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+class StubClient:
+    """Stands in for ollama.AsyncClient, recording what it was asked."""
+
+    def __init__(self, reply: str = "A plain-English explanation."):
+        self.reply = reply
+        self.prompts = []
+
+    async def list(self):
+        return {"models": [{"name": "llama3.1:8b"}]}
+
+    async def chat(self, model, messages, stream=False, **kwargs):
+        self.prompts.append(messages[-1]["content"])
+        return {"message": {"content": self.reply}}
+
+
+def _variant(rsid: str = "rs429358") -> VariantResult:
+    return VariantResult(
+        rsid=rsid,
+        genotype="CT",
+        chromosome="19",
+        position=44908684,
+        clinvar_entries=[
+            ClinVarEntry(
+                rsid=rsid,
+                gene="APOE",
+                clinical_significance="Pathogenic",
+                conditions="Alzheimer disease",
+                review_status="reviewed by expert panel",
+            )
+        ],
+        gwas_entries=[],
+    )
+
+
+def test_index_page_renders(client: TestClient) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Allelio" in response.text
+
+
+def test_status_reports_database_and_ai(client: TestClient) -> None:
+    response = client.get("/api/status")
+    assert response.status_code == 200
+    body = response.json()
+    assert "db_ready" in body
+    assert "ollama_available" in body
+
+
+def test_progress_starts_idle(client: TestClient) -> None:
+    assert client.get("/api/progress").json()["stage"] == "idle"
+
+
+def test_cors_rejects_foreign_origins(client: TestClient) -> None:
+    """A page on the open web must not be able to read a genome off localhost."""
+    allowed = client.get("/api/status", headers={"Origin": "http://localhost:3000"})
+    assert allowed.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+    blocked = client.get("/api/status", headers={"Origin": "https://example.com"})
+    assert "access-control-allow-origin" not in blocked.headers
+
+
+@pytest.mark.asyncio
+async def test_explain_variant_uses_the_model() -> None:
+    engine = AIEngine()
+    engine.client = StubClient()
+    engine.available = True
+
+    explanation = await engine.explain_variant(_variant())
+
+    assert "plain-English explanation" in explanation
+    assert "rs429358" in engine.client.prompts[0]
+
+
+@pytest.mark.asyncio
+async def test_summary_prompt_lists_the_variants() -> None:
+    """The prompt used to carry counts alone, so the model had nothing to summarise."""
+    engine = AIEngine()
+    engine.client = StubClient(reply="Two findings of note.")
+    engine.available = True
+
+    summary = await engine.generate_summary([_variant("rs1"), _variant("rs2")])
+
+    assert "Two findings of note." in summary
+    prompt = engine.client.prompts[0]
+    assert "rs1" in prompt and "rs2" in prompt
+    assert "APOE" in prompt

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -174,3 +174,41 @@ def test_exported_report_escapes_the_uploaded_file() -> None:
     assert "<img src=x" not in html
     assert "&lt;script&gt;" in html
     assert "&lt;img src=x" in html
+
+
+def test_exported_report_escapes_its_own_header() -> None:
+    """/api/export takes an arbitrary dict, so the report's own two fields are
+    no more trusted than the rows."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {"analyzed_at": "<script>alert(1)</script>", "total_variants": "<b>x</b>"}
+    )
+    assert "<script>alert(1)</script>" not in html
+    assert "<b>x</b>" not in html
+
+
+def test_strong_gwas_reads_the_smallest_p_values() -> None:
+    """p_value is a float column; 6,271 rows hold 0.0, which has no exponent to
+    string-slice, so the strongest associations were read as the weakest."""
+    from allelio.ai.engine import AIEngine
+
+    engine = AIEngine()
+    engine.client = StubClient(reply="Noted.")
+    engine.available = True
+
+    import asyncio
+
+    strong = VariantResult(
+        rsid="rs3",
+        gwas_entries=[GWASEntry(rsid="rs3", trait="Height", p_value=0.0)],
+    )
+    weak = VariantResult(
+        rsid="rs4",
+        gwas_entries=[GWASEntry(rsid="rs4", trait="Height", p_value=0.5)],
+    )
+    # Weak one first: only a working p-value test reorders them.
+    asyncio.run(engine.generate_summary([weak, strong]))
+    prompt = engine.client.prompts[0]
+
+    assert prompt.index("rs3") < prompt.index("rs4")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -10,7 +10,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from allelio.ai.engine import AIEngine
-from allelio.analysis.lookup import ClinVarEntry, VariantResult
+from allelio.analysis.lookup import ClinVarEntry, GWASEntry, VariantResult
 from allelio.web.app import app
 
 
@@ -71,13 +71,14 @@ def test_progress_starts_idle(client: TestClient) -> None:
     assert client.get("/api/progress").json()["stage"] == "idle"
 
 
-def test_cors_rejects_foreign_origins(client: TestClient) -> None:
-    """A page on the open web must not be able to read a genome off localhost."""
-    allowed = client.get("/api/status", headers={"Origin": "http://localhost:3000"})
-    assert allowed.headers.get("access-control-allow-origin") == "http://localhost:3000"
+def test_no_cross_origin_reads(client: TestClient) -> None:
+    """A page on the open web must not be able to read a genome off localhost.
 
-    blocked = client.get("/api/status", headers={"Origin": "https://example.com"})
-    assert "access-control-allow-origin" not in blocked.headers
+    The UI is same-origin with the API, so the app grants no origin anything.
+    """
+    for origin in ("https://example.com", "http://localhost:3000"):
+        response = client.get("/api/status", headers={"Origin": origin})
+        assert "access-control-allow-origin" not in response.headers
 
 
 @pytest.mark.asyncio
@@ -122,3 +123,54 @@ def test_result_cards_get_a_gene_and_a_significance() -> None:
     )
     assert _significance_of(benign) == "benign"
     assert _gene_of(benign) is None
+
+
+def test_conflicting_interpretations_are_not_pathogenic() -> None:
+    """ClinVar's commonest ambiguous term contains the word "pathogenic"; a
+    substring match painted those variants with the red badge."""
+    from allelio.web.routes import _significance_of
+
+    conflicting = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[
+            ClinVarEntry(
+                rsid="rs1",
+                clinical_significance="Conflicting interpretations of pathogenicity",
+            )
+        ],
+    )
+    assert _significance_of(conflicting) != "pathogenic"
+
+
+@pytest.mark.asyncio
+async def test_summary_prompt_names_the_gwas_gene() -> None:
+    """GWASEntry calls it mapped_gene, so reading .gene left GWAS-only variants
+    reaching the model with no gene at all."""
+    engine = AIEngine()
+    engine.client = StubClient(reply="Noted.")
+    engine.available = True
+
+    variant = VariantResult(
+        rsid="rs2",
+        gwas_entries=[GWASEntry(rsid="rs2", trait="Height", mapped_gene="HMGA2")],
+    )
+    await engine.generate_summary([variant])
+
+    assert "HMGA2" in engine.client.prompts[0]
+
+
+def test_exported_report_escapes_the_uploaded_file() -> None:
+    """Genotypes are copied verbatim out of the user's file and the report is
+    opened in a browser."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {
+            "summary": "<script>alert(1)</script>",
+            "results": [{"rsid": "rs1", "genotype": "<img src=x onerror=alert(1)>"}],
+        }
+    )
+    assert "<script>alert(1)</script>" not in html
+    assert "<img src=x" not in html
+    assert "&lt;script&gt;" in html
+    assert "&lt;img src=x" in html

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -352,7 +352,10 @@ async def test_explanations_give_up_and_return_what_finished() -> None:
         deadline=0.5,
     )
 
-    assert explanations == {"rs_fast": "done"}
+    assert explanations["rs_fast"] == "done"
+    # Cut off, not dropped: an empty string would leave the card reading "No
+    # explanation available", which is worse than having no model at all.
+    assert "rs_slow" in explanations["rs_slow"]
 
 
 def test_a_warning_is_not_printed_twice() -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -7,6 +7,8 @@ points survive a round trip against a stubbed client.
 """
 
 import asyncio
+import os
+from unittest import mock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -18,7 +20,7 @@ from allelio.web.app import app
 
 @pytest.fixture
 def client() -> TestClient:
-    return TestClient(app)
+    return TestClient(app, base_url="http://127.0.0.1")
 
 
 class StubClient:
@@ -261,7 +263,7 @@ def test_export_does_not_leave_the_report_in_the_temp_directory() -> None:
     temp_dir = Path(tempfile.gettempdir())
     before = set(temp_dir.glob("allelio_report_*"))
 
-    client = TestClient(app)
+    client = TestClient(app, base_url="http://127.0.0.1")
     response = client.post("/api/export", json={"results": [{"rsid": "rs1"}]})
 
     assert response.status_code == 200
@@ -280,7 +282,7 @@ def test_upload_cannot_choose_where_it_lands() -> None:
     victim = victim_dir / "victim.txt"
     victim.write_text("do not touch")
 
-    client = TestClient(app)
+    client = TestClient(app, base_url="http://127.0.0.1")
     client.post(
         "/api/analyze",
         files={
@@ -391,3 +393,272 @@ def test_a_fallback_explanation_still_gets_its_warning() -> None:
     )
     assert wrapped.count(warning) == 1
     assert fallback.count(warning) == 1
+
+
+@pytest.fixture
+def saved_path(tmp_path, monkeypatch):
+    """Point the saved-analysis file at a temp directory, not the real one."""
+    path = tmp_path / "allelio" / "last_analysis.json"
+    monkeypatch.setattr("allelio.web.routes.SAVED_ANALYSIS_PATH", str(path))
+    return path
+
+
+def test_saving_is_opt_in(client: TestClient, saved_path) -> None:
+    """Nothing reaches the disk until the user asks for it. An analysis is the
+    user's genome, and a run that writes it by default is a decision made for
+    them."""
+    assert client.get("/api/saved").json() == {"saved": False, "saved_at": None}
+    assert client.get("/api/saved/data").status_code == 404
+
+    # The route that produces an analysis is not the route that saves one. Its
+    # own outcome does not matter here; that it wrote nothing does.
+    client.post("/api/analyze", files={"file": ("g.txt", b"rs1\t1\t1\tAA\n")})
+
+    assert not saved_path.exists()
+    assert client.get("/api/saved").json()["saved"] is False
+
+
+def test_a_saved_analysis_comes_back_and_can_be_forgotten(
+    client: TestClient, saved_path
+) -> None:
+    analysis = {"summary": "s", "results": [{"rsid": "rs429358"}], "total_variants": 1}
+
+    assert client.post("/api/saved", json=analysis).status_code == 200
+    assert client.get("/api/saved").json()["saved"] is True
+    assert client.get("/api/saved/data").json() == analysis
+
+    assert client.delete("/api/saved").status_code == 200
+    assert not saved_path.exists()
+    assert client.get("/api/saved").json()["saved"] is False
+    assert client.get("/api/saved/data").status_code == 404
+
+    # Deleting what is already gone is what the user asked for, not an error.
+    assert client.delete("/api/saved").status_code == 200
+
+
+def test_an_empty_body_is_not_a_saved_analysis(client: TestClient, saved_path) -> None:
+    assert client.post("/api/saved", json={}).status_code == 400
+    assert not saved_path.exists()
+
+
+def test_an_existing_data_directory_is_left_as_it_was(
+    client: TestClient, saved_path
+) -> None:
+    """~/.allelio normally exists already, holding the database. Silently
+    re-permissioning a directory this feature does not own is not its call —
+    but the file it writes there is private either way."""
+    import stat
+
+    saved_path.parent.mkdir(parents=True)
+    os.chmod(saved_path.parent, 0o755)
+
+    client.post("/api/saved", json={"results": [{"rsid": "rs1"}]})
+
+    assert stat.S_IMODE(saved_path.parent.stat().st_mode) == 0o755
+    assert stat.S_IMODE(saved_path.stat().st_mode) == 0o600
+
+
+def test_the_saved_analysis_is_readable_only_by_its_owner(
+    client: TestClient, saved_path
+) -> None:
+    """It holds the user's genotypes. The home directory is not private on a
+    shared machine; the file has to be."""
+    import stat
+
+    client.post("/api/saved", json={"results": [{"rsid": "rs1", "genotype": "AA"}]})
+
+    assert stat.S_IMODE(saved_path.stat().st_mode) == 0o600
+    # Nothing existed under tmp_path, so this save is what created the directory
+    # and the 0700 applies. On a real install `setup` gets there first and
+    # leaves it 0755 — the test above is the one that covers that.
+    assert stat.S_IMODE(saved_path.parent.stat().st_mode) == 0o700
+
+
+def test_a_truncated_save_does_not_wedge_the_page(
+    client: TestClient, saved_path
+) -> None:
+    """A crash mid-write leaves half a file. Restoring should offer nothing,
+    not answer 500 forever."""
+    saved_path.parent.mkdir(parents=True, exist_ok=True)
+    saved_path.write_text('{"results": [{"rsid":')
+
+    assert client.get("/api/saved/data").status_code == 404
+
+
+@pytest.mark.parametrize("contents", ["[1, 2, 3]", '"hello"', "123", "null"])
+def test_json_that_is_not_an_analysis_is_a_404_not_a_500(
+    saved_path, contents: str
+) -> None:
+    """These parse, so the guarded read waves them through and they die in
+    response serialisation instead — a 500 the page has no answer for."""
+    saved_path.parent.mkdir(parents=True, exist_ok=True)
+    saved_path.write_text(contents)
+
+    client = TestClient(app, base_url="http://127.0.0.1", raise_server_exceptions=False)
+    assert client.get("/api/saved/data").status_code == 404
+
+
+def test_delete_does_not_claim_a_file_it_could_not_remove(
+    saved_path, monkeypatch
+) -> None:
+    """The page says "deleted" on any 200. Over a file holding the user's
+    genotypes, that is the one lie this feature cannot afford."""
+    client = TestClient(app, base_url="http://127.0.0.1", raise_server_exceptions=False)
+    client.post("/api/saved", json={"results": [{"rsid": "rs1"}]})
+
+    def denied(path):
+        raise PermissionError(13, "Permission denied", path)
+
+    monkeypatch.setattr("allelio.web.routes.os.unlink", denied)
+
+    assert client.delete("/api/saved").status_code == 500
+    assert saved_path.exists(), "the test itself failed to keep the file"
+
+
+def test_a_failed_save_keeps_the_previous_one(saved_path, monkeypatch) -> None:
+    """The write is a temp file plus a rename for this reason: the user pays
+    half an hour for each analysis, so a bad save must not eat the good one."""
+    client = TestClient(app, base_url="http://127.0.0.1", raise_server_exceptions=False)
+    good = {"summary": "the one that finished", "results": []}
+    assert client.post("/api/saved", json=good).status_code == 200
+
+    # Out of disk part-way through the dump — the case the rename exists for,
+    # and the one where the temp file already has bytes in it.
+    import json as json_module
+
+    real_dump = json_module.dump
+
+    def full_disk(obj, fp):
+        fp.write("{" * 100)
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr("allelio.web.routes.json.dump", full_disk)
+
+    assert client.post("/api/saved", json={"summary": "the one that ran out"}).status_code == 500
+
+    # Put json.dump back and nothing else: monkeypatch.undo() would also drop
+    # the saved_path fixture's patch and send the read at the real home
+    # directory.
+    monkeypatch.setattr("allelio.web.routes.json.dump", real_dump)
+    assert client.get("/api/saved/data").json() == good
+    assert list(saved_path.parent.glob(".last_analysis_*")) == []
+
+
+def test_a_rebound_domain_cannot_read_the_saved_genome(saved_path) -> None:
+    """Binding to 127.0.0.1 is not a boundary. A page on a domain whose DNS
+    re-resolves to 127.0.0.1 is same-origin to the browser, so CORS never
+    applies; the Host header is the only thing that tells the two apart."""
+    client = TestClient(app, base_url="http://attacker.example")
+
+    assert client.get("/api/saved").status_code == 400
+    assert client.get("/api/saved/data").status_code == 400
+    assert client.post("/api/saved", json={"results": []}).status_code == 400
+    assert client.delete("/api/saved").status_code == 400
+
+    # Starlette strips the port before matching, so a port on the URL changes
+    # nothing — which is exactly why no allow-list entry carries one.
+    assert TestClient(app, base_url="http://127.0.0.1:8080").get("/api/saved").status_code == 200
+    assert TestClient(app, base_url="http://localhost").get("/api/saved").status_code == 200
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        # A bind address is never a Host header anyone types, and starlette
+        # strips the port by splitting on ":", so no IPv6 literal can match.
+        # None of these belong on the list; localhost is how you reach them.
+        ("0.0.0.0", ["localhost", "127.0.0.1"]),
+        ("::", ["localhost", "127.0.0.1"]),
+        ("::1", ["localhost", "127.0.0.1"]),
+        # inet_aton takes all of these as "every interface", and so does the
+        # bind — comparing against the dotted quad alone would let them past.
+        ("0", ["localhost", "127.0.0.1"]),
+        ("0.0", ["localhost", "127.0.0.1"]),
+        ("0x0", ["localhost", "127.0.0.1"]),
+        # asyncio turns an empty host into a passive getaddrinfo, which binds
+        # every interface as surely as 0.0.0.0 does.
+        ("", ["localhost", "127.0.0.1"]),
+        ("127.0.0.1", ["localhost", "127.0.0.1"]),
+        # A real name the operator can browse to does belong on it — lowercased,
+        # because that is how the browser will send it.
+        ("192.168.1.50", ["localhost", "127.0.0.1", "192.168.1.50"]),
+        ("MyBox.local", ["localhost", "127.0.0.1", "mybox.local"]),
+    ],
+)
+def test_only_hosts_a_browser_can_actually_send_go_on_the_allow_list(host, expected) -> None:
+    from click.testing import CliRunner
+
+    from allelio.cli import allelio
+
+    with mock.patch.dict(os.environ, {}, clear=False):
+        # An empty value has to count as unset: app.py drops empties and falls
+        # back, so leaving it would 400 every request with no warning printed.
+        os.environ["ALLELIO_ALLOWED_HOSTS"] = ""
+        with mock.patch("uvicorn.run") as run:
+            result = CliRunner().invoke(allelio, ["serve", "--host", host, "--port", "9999"])
+        assert run.called
+        assert os.environ["ALLELIO_ALLOWED_HOSTS"].split(",") == expected
+        # Rich wraps to the terminal width, so match on collapsed whitespace.
+        # A host that could not go on the list gets told where to browse
+        # instead; one that did needs no warning it would learn to ignore.
+        printed = " ".join(result.output.split())
+        browsable = host in ("127.0.0.1", "192.168.1.50", "MyBox.local")
+        assert ("browse to localhost" in printed) != browsable
+        # And the URL it tells them to open is one that will actually answer.
+        assert (f"http://{host}:9999" in printed) == browsable
+
+
+def test_a_users_own_host_list_is_left_alone() -> None:
+    from click.testing import CliRunner
+
+    from allelio.cli import allelio
+
+    with mock.patch.dict(os.environ, {"ALLELIO_ALLOWED_HOSTS": "Allelio.Local"}, clear=False):
+        with mock.patch("uvicorn.run"):
+            CliRunner().invoke(allelio, ["serve", "--host", "0.0.0.0", "--port", "9999"])
+        assert os.environ["ALLELIO_ALLOWED_HOSTS"] == "Allelio.Local"
+
+    import importlib
+
+    import allelio.web.app as app_module
+
+    with mock.patch.dict(os.environ, {"ALLELIO_ALLOWED_HOSTS": "Allelio.Local"}, clear=False):
+        try:
+            hosts = importlib.reload(app_module).ALLOWED_HOSTS
+        finally:
+            os.environ.pop("ALLELIO_ALLOWED_HOSTS", None)
+            importlib.reload(app_module)
+
+    # Lowercased, because a browser sends the host lowercased and starlette
+    # compares it exactly. Loopback stays on: naming a LAN address should not
+    # lock the operator out of the machine the server is running on.
+    assert hosts == ["localhost", "127.0.0.1", "allelio.local"]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        # A "*" anywhere past the first character.
+        "192.168.*.5",
+        # And a leading one that is not the "*." of a subdomain wildcard: a
+        # forgotten dot, which starlette rejects on its own second assert.
+        "*example.com",
+    ],
+)
+def test_a_typo_in_the_host_list_fails_at_startup_not_mid_run(monkeypatch, bad) -> None:
+    """Starlette only checks its patterns when the stack is first built, which is
+    on the first request — long after the URL has been printed and opened — and
+    it checks with an assert, which -O removes. Hence our own check at import."""
+    import importlib
+
+    import allelio.web.app as app_module
+
+    monkeypatch.setenv("ALLELIO_ALLOWED_HOSTS", bad)
+    try:
+        with pytest.raises(ValueError, match="wildcard host"):
+            importlib.reload(app_module)
+    finally:
+        # Put the module back whether or not the check fired: a failure here
+        # would otherwise hand every later test an app built from the bad list.
+        monkeypatch.delenv("ALLELIO_ALLOWED_HOSTS")
+        importlib.reload(app_module)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -125,9 +125,10 @@ def test_result_cards_get_a_gene_and_a_significance() -> None:
     assert _gene_of(benign) is None
 
 
-def test_conflicting_interpretations_are_not_pathogenic() -> None:
-    """ClinVar's commonest ambiguous term contains the word "pathogenic"; a
-    substring match painted those variants with the red badge."""
+def test_conflicting_classifications_get_their_own_badge() -> None:
+    """ClinVar's commonest ambiguous term contains the word "pathogenic", so a
+    substring match painted 130k variants with the red badge — and calling them
+    a trait instead painted them green. They are neither."""
     from allelio.web.routes import _significance_of
 
     conflicting = VariantResult(
@@ -135,11 +136,25 @@ def test_conflicting_interpretations_are_not_pathogenic() -> None:
         clinvar_entries=[
             ClinVarEntry(
                 rsid="rs1",
-                clinical_significance="Conflicting interpretations of pathogenicity",
+                # The term the shipped ClinVar dump actually uses.
+                clinical_significance="Conflicting classifications of pathogenicity",
             )
         ],
     )
-    assert _significance_of(conflicting) != "pathogenic"
+    assert _significance_of(conflicting) == "conflicting"
+
+
+def test_clinvar_benign_survives_a_gwas_hit() -> None:
+    """Any GWAS row used to be checked before ClinVar's benign call, so a
+    variant ClinVar calls benign came out orange."""
+    from allelio.web.routes import _significance_of
+
+    variant = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[ClinVarEntry(rsid="rs1", clinical_significance="Benign")],
+        gwas_entries=[GWASEntry(rsid="rs1", trait="Height", p_value=1e-9)],
+    )
+    assert _significance_of(variant) == "benign"
 
 
 @pytest.mark.asyncio
@@ -212,3 +227,37 @@ def test_strong_gwas_reads_the_smallest_p_values() -> None:
     prompt = engine.client.prompts[0]
 
     assert prompt.index("rs3") < prompt.index("rs4")
+
+
+def test_exported_report_carries_the_counselling_warnings() -> None:
+    """The safety layer computes a warning for BRCA1/2, TP53, Lynch and APOE.
+    Every consumer dropped it on the floor."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {
+            "results": [
+                {
+                    "rsid": "rs1",
+                    "warnings": ["Talk to a genetic counselor."],
+                }
+            ]
+        }
+    )
+    assert "Talk to a genetic counselor." in html
+
+
+def test_export_does_not_leave_the_report_in_the_temp_directory() -> None:
+    """The report holds the user's genotypes, and the system temp directory is
+    world-readable."""
+    import tempfile
+    from pathlib import Path
+
+    temp_dir = Path(tempfile.gettempdir())
+    before = set(temp_dir.glob("allelio_report_*"))
+
+    client = TestClient(app)
+    response = client.post("/api/export", json={"results": [{"rsid": "rs1"}]})
+
+    assert response.status_code == 200
+    assert set(temp_dir.glob("allelio_report_*")) == before


### PR DESCRIPTION
> **Read #1 first — the diff below includes it.**
>
> This branch is built on top of #1, and the save UI hooks straight into the
> `displayResults()` and category-tab code that #1 rewrites. Both touch `routes.py`,
> `index.html`, `app.py` and `tests/test_web.py`, so it cannot be rebased onto `main`
> as it stands.
>
> GitHub will not let me base a PR on #1, because a base has to be a branch in this
> repo and #1's branch lives on my fork. So this PR targets `main` and shows all 16
> commits — 15 of them are #1, already under review there. **The one commit that is
> new here is the last one, `feat(web): let the user keep an analysis instead of
> re-running it`.** Once #1 is merged this will collapse to that single commit on its
> own; no action needed from you.

## The problem

A whole-genome run is about half an hour, and the results only ever live in the tab
that ran it. Reload the page, close the laptop, or open a second tab, and the only
way back is to upload the file and wait again.

## What this does

A **Save results on this computer** button next to Export writes the analysis to
`~/.allelio/last_analysis.json`. On the next visit a banner offers to open it, or to
delete it.

It is opt-in — nothing is written unless the button is pressed — and there is no code
path that sends it anywhere. The file is the user's genotypes, so:

- written with `mkstemp` + `os.replace`, so it is mode `0600` rather than whatever the
  umask says, and a crash mid-write leaves the previous save intact instead of half a file
- `fsync` before the rename, so a power cut cannot land the rename and lose the contents
- a truncated or non-object file reads as "nothing saved" rather than wedging the page
  on a 500 forever
- both the encode and the decode run off the event loop — a 15 MB `json.dump` on it
  stalls every other request for the duration
- `DELETE` answers 200 only when the file is really gone. Reporting success over a
  genome still sitting on the disk is the one lie this feature cannot afford

## Why there is a Host check in here too

Saving the analysis means it can be fetched back, and that needs a boundary this app
did not have. Binding to `127.0.0.1` is not one on its own: a page on a domain whose
DNS re-resolves to `127.0.0.1` is same-origin by the browser's reckoning, and CORS
never enters into it. Without a check, any page the user happened to be visiting could
read the saved genome out of `GET /api/saved/data`.

So the app now rejects `Host` headers it does not recognise — loopback always, plus
whatever `--host` was given, plus anything `ALLELIO_ALLOWED_HOSTS` names.

Two details that shape the code:

- Starlette compares the `Host` header with the port already stripped, splitting on
  `":"` to do it. So no allow-list entry carries a port, and no IPv6 literal can ever
  match one — `serve` leaves those off the list and prints `localhost` rather than a
  URL that answers 400.
- A bind address is not a name a browser sends. `0.0.0.0` — and `0`, `0.0`, `0x0` and
  an empty `--host`, which all bind the same way — get the same treatment, with a
  warning that reaching the server from another machine means naming that machine.

A malformed allow-list pattern raises at import rather than on the first request, long
after the URL has been printed.

## Tests

`tests/test_web.py` goes from 107 to 133. The new ones cover saving being opt-in, the
round trip, the `0600` mode, a directory that already exists being left alone, a
truncated save, JSON that parses but is not an analysis, a delete that could not remove
the file, a failed save keeping the previous one, a rebound domain being refused, and
which hosts do and do not end up on the allow-list.

Three front-end fixes have no automated coverage, because there is no JS test
infrastructure in the repo — the stale category filter on a fresh set of results, the
banner's behaviour when the saved file cannot be read, and the confirm on delete. Those
were checked end to end instead, against a real 16 MB genotype file: a full run of
62,057 findings, saved, reloaded, restored in 4.1s with every card, the summary and all
50 explanations matching the live run, the category tabs still filtering afterwards, and
the delete both refused on cancel and honoured on confirm.
