### PR TITLE
feat(ai): run on any local OpenAI-compatible server, and name the model that wrote each explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ No programming experience is needed to use Allelio's web interface — just uplo
 2. **Looks up your variants** in two major scientific databases:
    - [ClinVar](https://www.ncbi.nlm.nih.gov/clinvar/) — clinically significant genetic variants curated by the NIH
    - [GWAS Catalog](https://www.ebi.ac.uk/gwas/) — genome-wide association studies linking variants to traits and conditions
-3. **Explains findings in plain English** using a local AI model (Ollama), so you don't need a genetics degree to understand the results
+3. **Explains findings in plain English** using a local AI model — Ollama, or any OpenAI-compatible server you already run — so you don't need a genetics degree to understand the results
 4. **Generates a report** you can save, print, or share with your doctor
 
 All of this runs entirely on your computer. Nothing is uploaded anywhere.
@@ -55,6 +55,7 @@ We take this seriously, and you'll see reminders throughout the tool.
   - [Download Ollama](https://ollama.com) and install it
   - Then open a terminal and run: `ollama pull llama3.1:8b` (downloads a ~4 GB model)
   - If you skip this, Allelio still works — you just won't get AI-written explanations
+  - Already running something else? See [Using a different local model](#using-a-different-local-model)
 
 ### Install Allelio
 
@@ -97,9 +98,59 @@ allelio analyze my_23andme_data.txt --top 50
 # Skip AI explanations for faster results
 allelio analyze my_23andme_data.txt --no-ai
 
+# Name the model to explain with
+allelio analyze my_23andme_data.txt --model mistral-nemo:12b
+
 # Only show trait associations (no disease risks)
 allelio analyze my_23andme_data.txt --traits-only
 ```
+
+---
+
+## Using a different local model
+
+Ollama is the default, not the requirement. If you already run a model server
+that speaks the OpenAI API — llama.cpp, LM Studio, vLLM, llama-swap — point
+Allelio at it:
+
+```bash
+# LM Studio
+export ALLELIO_OPENAI_BASE=http://127.0.0.1:1234/v1
+
+# llama.cpp --server, naming the model explicitly
+export ALLELIO_OPENAI_BASE=http://127.0.0.1:8080/v1
+export ALLELIO_MODEL=qwen2.5-14b-instruct
+```
+
+Include the `/v1` — that is the part servers disagree about. If you don't set
+`ALLELIO_MODEL`, Allelio asks the server what it is serving, and uses that name
+when the answer is a single model. Servers that keep a dozen configured — a
+llama-swap config, say — need `ALLELIO_MODEL`, because there is nothing to
+infer; the alias from your llama-swap config works there, not just the full
+model id. If the server lists what it serves and the name you gave is not
+in that list, Allelio says so, skips the explanations and writes the report
+anyway — the findings never needed a model, and no name is put on someone
+else's answers. A server that will not list its models at all, like a bare
+`llama.cpp`, is simply asked; if it has not got that model it says so, and
+again nothing is credited. `ALLELIO_MODEL` works with plain Ollama too.
+
+Whichever you use, the web interface and `allelio info` both print the model
+that is actually answering, and every explanation says who wrote it — the model
+by name, or nobody, in which case the card is the variant's own ClinVar and
+GWAS Catalog data and says so. A run where the model answers for some variants
+and not others is reported as exactly that, on the page and in the report.
+
+**The address has to be on your machine.** `127.0.0.1`, `::1` or a name that
+resolves to one of them — anything else is refused, with the reason, before any analysis starts.
+This is not a configuration preference: every prompt Allelio sends contains the
+variant it is asking about, so a hosted endpoint in that setting would be
+reading your genome. There is deliberately no way to send an API key, and no
+proxy is used even if one is configured for the rest of your system.
+
+Ollama's `-cloud` models are the exception the address check cannot see: the
+request goes to `127.0.0.1:11434` and the Ollama daemon forwards it to
+ollama.com. Allelio refuses those by name. Anything you have pulled locally is
+fine.
 
 ---
 
@@ -131,7 +182,12 @@ The reference databases are stored locally on your machine after the initial dow
 
 Your genome is deeply personal. Allelio was built with that in mind:
 
-- **No cloud processing** — analysis runs entirely on your hardware
+- **No cloud processing** — analysis runs entirely on your hardware, and the AI
+  model has to be running on this machine too, and a remote address or an Ollama
+  `-cloud` model is refused rather than warned about. The address is resolved
+  and then connected to by address, so a name cannot point somewhere else
+  afterwards; a proxy configured on the system is ignored rather than refused,
+  and a loopback port can still be a proxy Allelio cannot see through
 - **No accounts or sign-ups** — just install and use
 - **No telemetry or tracking** — Allelio doesn't phone home, ever
 - **No data storage** — your file is read during analysis and never saved by Allelio
@@ -148,7 +204,7 @@ allelio/
 ├── parsers/      # File readers for 23andMe, AncestryDNA, VCF
 ├── database/     # ClinVar and GWAS data download, storage, and querying
 ├── analysis/     # Variant annotation and cross-referencing
-├── ai/           # Local LLM integration via Ollama
+├── ai/           # Local LLM integration — Ollama or any OpenAI-compatible server
 ├── web/          # Flask-based web interface
 ├── cli.py        # Command-line interface
 └── report.py     # HTML report generation

--- a/allelio/ai/attribution.py
+++ b/allelio/ai/attribution.py
@@ -1,0 +1,59 @@
+"""Who wrote an explanation.
+
+A failed call still answers with the variant's own data wrapped in the
+disclaimer, and that reads exactly like an explanation. The difference used to
+be kept as a count on the engine, one number for a whole run, and every reader
+of it — the CLI's tally, the report's footer, the upload's payload — had its
+own idea of which cards the number covered. On a run that wrote some cards and
+not others they all agreed on the wrong thing.
+
+So the credit lives on the card. Nothing here imports anything.
+"""
+
+from typing import Dict, NamedTuple, Optional
+
+
+class Explanation(NamedTuple):
+    """One explanation and the name of whoever wrote it.
+
+    `model` is the full name of the model that answered — the same string the
+    page prints and the report records — or None when the call failed and
+    `text` is the variant's own data.
+
+    `error` is why it did not answer, in the server's own words, or None. It
+    rides on the card for the same reason the credit does: the engine has one
+    slot for it, and the batch runs three calls at a time into that one slot,
+    so a card asking why *it* has no model got whichever answer landed last.
+    """
+
+    text: str
+    model: Optional[str]
+    error: Optional[str] = None
+
+
+class Attribution(NamedTuple):
+    """Who wrote a set of cards, and how many of them.
+
+    `model` is None when no card in the set was written by a model.
+    """
+
+    model: Optional[str]
+    written: int
+    total: int
+
+
+def attribution(explanations: Dict[str, Explanation]) -> Attribution:
+    """Read the credit for a set of cards off the cards themselves.
+
+    The one place the CLI's tally, the report's footer and the upload's payload
+    derive it, so that they cannot derive it differently.
+    """
+    written = [e.model for e in explanations.values() if e.model]
+    # Sorted rather than first-wins: one run has one model, and if a set ever
+    # carries two, naming both is the honest answer and naming one is not.
+    names = sorted(set(written))
+    return Attribution(
+        model=", ".join(names) or None,
+        written=len(written),
+        total=len(explanations),
+    )

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -25,6 +25,10 @@ DEFAULT_HOST = "http://localhost:11434"
 # timeout fallback.
 REQUEST_TIMEOUT = 300
 
+# Fifty variants, three at a time, at the per-request timeout is over an hour
+# of staring at a progress bar. Cap the batch and keep what finished.
+BATCH_DEADLINE = 900
+
 
 class AIEngine:
     """
@@ -157,7 +161,8 @@ class AIEngine:
         self,
         results: List,
         max_concurrent: int = 3,
-        progress_callback: Optional[Callable[[int, int], None]] = None
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+        deadline: float = BATCH_DEADLINE
     ) -> Dict[str, str]:
         """
         Generate AI explanations for multiple variants with concurrency control.
@@ -184,16 +189,27 @@ class AIEngine:
         # Track completions for callback
         explanations = {}
         
-        # Create all tasks
-        tasks = [explain_with_semaphore(result) for result in results]
-        
-        # Execute with progress tracking
-        for coro in asyncio.as_completed(tasks):
-            rsid, explanation = await coro
-            explanations[rsid] = explanation
-            if progress_callback:
-                progress_callback(len(explanations), len(results))
-        
+        tasks = [
+            asyncio.ensure_future(explain_with_semaphore(result))
+            for result in results
+        ]
+
+        # Whatever is done when the clock runs out is what the user gets. The
+        # per-request timeout on its own lets 50 variants, three at a time,
+        # hold the upload open for well over an hour on a slow model.
+        try:
+            for coro in asyncio.as_completed(tasks, timeout=deadline):
+                rsid, explanation = await coro
+                explanations[rsid] = explanation
+                if progress_callback:
+                    progress_callback(len(explanations), len(results))
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
         return explanations
     
     async def generate_summary(self, results: List) -> str:

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -225,18 +225,20 @@ class AIEngine:
             if clinvar or (gwas and len(gwas) > 0):
                 # clinvar/gwas hold ClinVarEntry and GWASEntry objects, not dicts.
                 def _pathogenic(e) -> bool:
+                    # Same test the results list badges on, so the summary and
+                    # the cards cannot disagree about one variant.
                     sig = str(getattr(e, 'clinical_significance', '')).lower()
-                    return 'pathogenic' in sig and 'conflicting' not in sig
+                    if 'conflicting' in sig or 'benign' in sig:
+                        return False
+                    return 'pathogenic' in sig
 
                 has_clinvar_pathogenic = any(_pathogenic(e) for e in clinvar)
 
                 def _strong_gwas(e) -> bool:
-                    p = str(getattr(e, 'p_value', ''))
-                    if 'e-' not in p:
-                        return False
+                    p = getattr(e, 'p_value', None)
                     try:
-                        return float(p.split('e-')[1]) > 5
-                    except ValueError:
+                        return p is not None and float(p) < 1e-5
+                    except (TypeError, ValueError):
                         return False
 
                 if has_clinvar_pathogenic or any(_strong_gwas(e) for e in gwas):

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -220,16 +220,22 @@ class AIEngine:
             
             # Classify based on available data
             if clinvar or (gwas and len(gwas) > 0):
+                # clinvar/gwas hold ClinVarEntry and GWASEntry objects, not dicts.
                 has_clinvar_pathogenic = any(
-                    'pathogenic' in str(e.get('clinical_significance', '')).lower()
+                    'pathogenic' in str(getattr(e, 'clinical_significance', '')).lower()
                     for e in clinvar
                 )
-                
-                if has_clinvar_pathogenic or (gwas and any(
-                    float(e.get('p_value', '1.0').split('e-')[1]) > 5 
-                    for e in gwas 
-                    if 'e-' in str(e.get('p_value', ''))
-                )):
+
+                def _strong_gwas(e) -> bool:
+                    p = str(getattr(e, 'p_value', ''))
+                    if 'e-' not in p:
+                        return False
+                    try:
+                        return float(p.split('e-')[1]) > 5
+                    except ValueError:
+                        return False
+
+                if has_clinvar_pathogenic or any(_strong_gwas(e) for e in gwas):
                     high_impact.append(result)
                 elif clinvar or gwas:
                     moderate.append(result)
@@ -249,6 +255,27 @@ class AIEngine:
             summary_parts.append(f"- {len(moderate)} variant(s) with moderate research associations")
         if low:
             summary_parts.append(f"- {len(low)} variant(s) with limited available data")
+
+        # The model was previously handed counts alone and asked to summarise
+        # findings it had never been shown, so it answered by saying so. List them.
+        listed = (high_impact + moderate)[:25]
+        if listed:
+            summary_parts.append("\nThe findings:")
+            for r in listed:
+                gene = ""
+                for e in (r.clinvar_entries or []):
+                    gene = getattr(e, 'gene', '') or gene
+                for e in (r.gwas_entries or []):
+                    gene = gene or getattr(e, 'gene', '')
+                sig = ""
+                for e in (r.clinvar_entries or []):
+                    sig = getattr(e, 'clinical_significance', '') or sig
+                traits = [getattr(e, 'trait', '') for e in (r.gwas_entries or [])]
+                traits = [t for t in traits if t][:2]
+                bits = [b for b in (gene, sig, "; ".join(traits)) if b]
+                summary_parts.append(
+                    f"- {r.rsid} ({r.genotype}): " + (" — ".join(bits) if bits else "no annotation")
+                )
         
         summary_parts.append(
             "\nPlease provide a brief 2-3 paragraph executive summary of these findings, "

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -20,6 +20,11 @@ from .safety import check_safety, get_variant_warnings, wrap_with_disclaimer
 DEFAULT_MODEL = "llama3.1:8b"
 DEFAULT_HOST = "http://localhost:11434"
 
+# Sixty seconds is not enough for the default 8B model on a warm machine
+# once a few explanations run at once; every other one came back as a
+# timeout fallback.
+REQUEST_TIMEOUT = 300
+
 
 class AIEngine:
     """
@@ -127,7 +132,7 @@ class AIEngine:
                     ],
                     stream=False
                 ),
-                timeout=60
+                timeout=REQUEST_TIMEOUT
             )
             
             explanation = response['message']['content']
@@ -301,7 +306,7 @@ class AIEngine:
                     ],
                     stream=False
                 ),
-                timeout=60
+                timeout=REQUEST_TIMEOUT
             )
             
             summary = response['message']['content']

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -199,7 +199,15 @@ class AIEngine:
         # hold the upload open for well over an hour on a slow model.
         try:
             for coro in asyncio.as_completed(tasks, timeout=deadline):
-                rsid, explanation = await coro
+                try:
+                    rsid, explanation = await coro
+                except asyncio.TimeoutError:
+                    raise
+                except Exception:
+                    # One variant that fails outside explain_variant's own
+                    # guard used to cost one explanation. It should not cost
+                    # the whole upload, minutes after the analysis is done.
+                    continue
                 explanations[rsid] = explanation
                 if progress_callback:
                     progress_callback(len(explanations), len(results))

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -1,24 +1,267 @@
 """
-Ollama LLM integration for Allelio AI explanation engine.
+Local LLM integration for the Allelio AI explanation engine.
 
-This module provides async interfaces to an Ollama instance running locally
-for generating plain-language explanations of genetic variants.
+Explanations come from a model running on this machine: Ollama by default, or
+any OpenAI-compatible server — llama.cpp, LM Studio, vLLM, llama-swap — named
+by ALLELIO_OPENAI_BASE. Every prompt carries the variant it is explaining, so
+both paths are held to the same rule: the address has to resolve to this
+machine, and nothing else is accepted.
 """
 
 import asyncio
-from typing import Dict, List, Optional, Callable
+import ipaddress
+import os
+import re
+import socket
+from typing import Any, Dict, List, Optional, Callable
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
 
 try:
-    from ollama import AsyncClient
+    from ollama import AsyncClient, ResponseError as _OllamaResponseError
 except ImportError:
     AsyncClient = None
+    _OllamaResponseError = None
 
+# Bound now, not looked up on the module's `httpx` when it is needed: the test
+# suite patches `engine.httpx` with a double that has AsyncClient and nothing
+# else, and a late attribute lookup would raise AttributeError from inside the
+# handler that is meant to classify errors -- reporting every stubbed server as
+# down.
+_HTTPStatusError = httpx.HTTPStatusError
+
+# The exception classes that mean *something is there*. An error status is the
+# server talking: it is up, it just will not enumerate -- a bare llama.cpp
+# serves /v1/chat/completions and has no /v1/models at all. A listing that ran
+# past its five seconds is the same kind of thing: something accepted the
+# connection and is thinking about it, which is what a warming Ollama daemon
+# does. Connection refused, or a name that resolves to nothing, is nothing
+# answering, and a dead port says so in milliseconds.
+_ANSWERED = tuple(
+    e
+    for e in (_HTTPStatusError, _OllamaResponseError, asyncio.TimeoutError)
+    if e is not None
+)
+
+# Re-exported: an explanation and its credit are one value everywhere, and
+# every caller of this module already imports from it.
+from .attribution import Attribution, Explanation, attribution
 from .prompts import build_variant_prompt, SYSTEM_PROMPT
 from .safety import check_safety, get_variant_warnings, wrap_with_disclaimer
 
 
 DEFAULT_MODEL = "llama3.1:8b"
 DEFAULT_HOST = "http://localhost:11434"
+
+# Names a model for either provider, and wins over the built-in default.
+MODEL_ENV = "ALLELIO_MODEL"
+# Points at an OpenAI-compatible server on this machine, used instead of
+# Ollama — "http://127.0.0.1:1234/v1" for LM Studio, ":8080/v1" for llama.cpp.
+OPENAI_BASE_ENV = "ALLELIO_OPENAI_BASE"
+
+OLLAMA = "Ollama"
+OPENAI_COMPATIBLE = "OpenAI-compatible"
+
+# What the server said about itself when asked what it serves. One value rather
+# than the three booleans this used to be: every caller that recombined them by
+# hand -- the CLI, `allelio info`, the web upload, the library bridge -- got a
+# different answer for the same server, and the differences were the bugs.
+# `status` is computed in one place, in one order, and is the only thing any of
+# them branches on.
+UNREACHABLE = "unreachable"  # nothing answered at that address
+REFUSED = "refused"          # it answered, and what it serves is refused (-cloud)
+REFUTED = "refuted"          # it listed what it serves, and this model is not in it
+UNLISTED = "unlisted"        # it answered, but would not enumerate its models
+SERVING = "serving"          # it listed what it serves, and this model is in it
+
+# A model server names its own models, and that name is printed on the page and
+# written into the exported report. Wide enough for what the servers really use
+# — "llama3.1:8b", "hf.co/user/repo:Q4_K_M", "publisher/Model-7B-GGUF" — and
+# narrow enough that nothing with a bracket in it can be adopted.
+_PLAUSIBLE_MODEL_NAME = re.compile(r"[A-Za-z0-9][\w.:/+@-]{0,127}\Z")
+
+
+def pin_to_loopback(url: str, setting: str) -> str:
+    """Return the URL with its host pinned to a loopback address, or raise.
+
+    A prompt carries the variant it explains — rsID, genotype, gene, the ClinVar
+    call — so whatever is on the other end of this URL reads a piece of someone's
+    genome. The only host allowed to is this one, and resolving to a loopback
+    address is the whole test. A name that answers with one public address out
+    of four is a name that ships a genome three times out of four, so any
+    address that is not provably loopback fails the whole URL.
+
+    The returned URL carries the address rather than the name it was written
+    with, because checking a name and then connecting by it checks nothing: the
+    request resolves it again, and /api/analyze runs for half an hour after the
+    one time this function looked.
+    """
+    parts = urlsplit(url)
+    if parts.scheme not in ("http", "https") or not parts.hostname:
+        raise ValueError(
+            f"{setting}={url!r} is not a URL. It needs the scheme and the port, "
+            "like http://127.0.0.1:1234/v1"
+        )
+
+    try:
+        port = parts.port
+    except ValueError as exc:
+        raise ValueError(f"{setting}={url!r}: {exc}.") from None
+
+    if port == 0:
+        # Nonsense in, and the rewrite below would drop it and send the prompt
+        # to port 80 instead — wrong destination rather than an error.
+        raise ValueError(f"{setting}={url!r}: port 0 is not a port.")
+
+    try:
+        # An IP literal never leaves the machine here; getaddrinfo passes it
+        # straight back. A name is looked up, which is the point: "localhost"
+        # is only trustworthy if it still answers 127.0.0.1.
+        infos = socket.getaddrinfo(parts.hostname, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise ValueError(
+            f"{setting}={url!r}: {parts.hostname!r} does not resolve ({exc})."
+        ) from None
+
+    remote = []
+    loopback = []
+    for info in infos:
+        # A link-local IPv6 address arrives with a %scope suffix that
+        # ip_address will not parse.
+        address = info[4][0].split("%")[0]
+        try:
+            parsed = ipaddress.ip_address(address)
+        except ValueError:
+            # Not provably this machine is not this machine.
+            remote.append(address)
+            continue
+        # ::ffff:127.0.0.1 is the same address written the other way, but
+        # IPv6Address.is_loopback only learned to say so in 3.13 and this
+        # package claims 3.9. Unwrap it and the answer stops depending on
+        # which Python the user happens to have.
+        parsed = getattr(parsed, "ipv4_mapped", None) or parsed
+        (loopback if parsed.is_loopback else remote).append(parsed)
+
+    if remote or not loopback:
+        named = ", ".join(sorted(str(a) for a in set(remote))) or "nothing"
+        raise ValueError(
+            f"{setting}={url!r} points at {named}, "
+            "which is not this machine. Every prompt carries the variant it "
+            "explains, so that server would be reading your genome. Allelio only "
+            "talks to a model on 127.0.0.1 or ::1."
+        )
+
+    # IPv4 first. getaddrinfo promises no order and answers "localhost" with ::1
+    # ahead of 127.0.0.1 on macOS, while Ollama and LM Studio both bind 127.0.0.1
+    # and nothing else — pinning to the first answer would refuse the connection.
+    address = next((a for a in loopback if a.version == 4), loopback[0])
+    host = f"[{address}]" if address.version == 6 else str(address)
+    # Any userinfo in the original goes with the name it was attached to.
+    netloc = f"{host}:{port}" if port else host
+    # Query and fragment go too. This is a base to hang "/models" off, and
+    # keeping them turns "…/v1?a=b" into a request for "a=b/models" — a config
+    # that fails later as "the server is not answering".
+    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+
+def _model_names(response: Any) -> List[str]:
+    """Model identifiers out of a list() reply, whichever shape it arrives in."""
+    if isinstance(response, dict):
+        models = response.get("models", [])
+    elif hasattr(response, "models"):
+        models = response.models or []
+    else:
+        models = list(response) if response else []
+
+    names = []
+    for entry in models:
+        if isinstance(entry, dict):
+            name = entry.get("model") or entry.get("name") or ""
+        else:
+            name = getattr(entry, "model", None) or getattr(entry, "name", "") or ""
+        if name:
+            names.append(str(name))
+    return names
+
+
+def _aliases_of(entry: Any) -> List[str]:
+    """Other names one served model answers to.
+
+    llama-swap advertises them under meta.llamaswap.aliases and routes on them,
+    so `ALLELIO_MODEL=qwen36` is a working configuration whose name is nowhere
+    in the list of ids.
+    """
+    if not isinstance(entry, dict):
+        return []
+    meta = entry.get("meta")
+    if not isinstance(meta, dict):
+        return []
+    found = []
+    for section in meta.values():
+        if isinstance(section, dict):
+            aliases = section.get("aliases")
+            # Another process's JSON. A string iterates to single characters
+            # and an int raises, and the raise lands in check_connection's
+            # blanket except, where a server that answered is reported as down.
+            if not isinstance(aliases, (list, tuple)):
+                continue
+            found += [str(a) for a in aliases if a]
+    return found
+
+
+def _refuse_cloud(name: str) -> None:
+    """Raise if this names an Ollama Cloud model.
+
+    The one case where a request to 127.0.0.1:11434 is not a request to this
+    machine: the daemon forwards a `-cloud` tag to ollama.com, prompt and all.
+    Every address check in this file passes it, because the address really is
+    local — the name is the only place it shows.
+
+    Case-folded because Ollama resolves model names case-insensitively, so
+    `gpt-oss:120b-CLOUD` reaches the same relay as the lower-case spelling.
+
+    This is a name check and can only ever be one: `ollama cp gpt-oss:120b-cloud
+    mine` renames a cloud model past it, and so does a proxy on a loopback port.
+    Neither is visible from here.
+    """
+    if name.lower().endswith("-cloud"):
+        raise ValueError(
+            f"{name!r} is an Ollama Cloud model. It runs on Ollama's servers, "
+            "not yours, and the prompt carries the variant it explains. "
+            "Name a model you have pulled locally."
+        )
+
+
+def _raise_for_status(response: Any) -> None:
+    """raise_for_status, carrying the server's own sentence.
+
+    httpx's message is the status line and a link to MDN. The reason a person
+    needs is in the body, and on the OpenAI-compatible path that sentence is
+    the whole diagnostic: a server answers a name it does not have with
+    {"error": {"message": "model 'x' not found"}}, and httpx reports "Client
+    error '404 Not Found'".
+    """
+    if response.status_code < 400:
+        return
+    try:
+        body = response.json()
+        err = body.get("error") if isinstance(body, dict) else None
+        detail = (err.get("message") if isinstance(err, dict) else err) or ""
+    except Exception:
+        detail = ""
+    # Server-controlled text: capped here, escaped at every sink.
+    detail = str(detail or response.text)[:200]
+    raise _HTTPStatusError(
+        f"{response.status_code} {response.reason_phrase}: {detail}".strip(),
+        request=response.request,
+        response=response,
+    )
+
+
+def _tagged(name: str) -> str:
+    """Ollama reads a bare model name as ":latest"; spell that out before comparing."""
+    return name if ":" in name else f"{name}:latest"
 
 # Sixty seconds is not enough for the default 8B model on a warm machine
 # once a few explanations run at once; every other one came back as a
@@ -32,9 +275,62 @@ REQUEST_TIMEOUT = 300
 BATCH_DEADLINE = 1800
 
 
+# httpx trusts the environment by default: HTTP_PROXY, ALL_PROXY, .netrc, and on
+# macOS the proxy configured in System Settings, which an MDM-managed laptop ships
+# with. A proxy is a second machine, and this prompt has someone's genotype in it —
+# pinning the address to 127.0.0.1 counts for nothing if the connection is handed
+# to a proxy afterwards. Passed to every client here, ollama's included; it
+# forwards **kwargs to httpx.
+TRUST_ENV = False
+
+
+class _OpenAICompatClient:
+    """The two calls AIEngine makes, spoken to an OpenAI-style API instead.
+
+    Not a general client: no streaming, no tools, and no authentication. The
+    missing Authorization header is the point — this only ever talks to a
+    server on this machine, and a hosted provider that wants a key is exactly
+    what pin_to_loopback exists to turn away.
+    """
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+
+    async def list(self) -> Dict[str, Any]:
+        async with httpx.AsyncClient(
+            timeout=10, follow_redirects=False, trust_env=TRUST_ENV
+        ) as client:
+            response = await client.get(f"{self.base_url}/models")
+            _raise_for_status(response)
+            # `or []`: a server that answers {"data": null} would otherwise
+            # raise TypeError below and be reported as down.
+            served = response.json().get("data") or []
+            served = [m for m in served if isinstance(m, dict)]
+        # Aliases kept apart from ids: llama-swap answers to both, so a name
+        # has to be matched against both, but only the ids are worth printing
+        # back to someone choosing one.
+        return {
+            "models": [{"model": m["id"]} for m in served if m.get("id")],
+            "aliases": [a for m in served for a in _aliases_of(m)],
+        }
+
+    async def chat(self, model, messages, stream=False, **kwargs) -> Dict[str, Any]:
+        async with httpx.AsyncClient(
+            timeout=REQUEST_TIMEOUT, follow_redirects=False, trust_env=TRUST_ENV
+        ) as client:
+            response = await client.post(
+                f"{self.base_url}/chat/completions",
+                json={"model": model, "messages": messages, "stream": False},
+            )
+            _raise_for_status(response)
+            content = response.json()["choices"][0]["message"]["content"]
+        return {"message": {"content": content}}
+
+
 class AIEngine:
     """
-    AI explanation engine using Ollama for local LLM inference.
+    AI explanation engine driving a local LLM, via Ollama or an
+    OpenAI-compatible server on this machine.
     """
     
     def __init__(self, model: Optional[str] = None, host: Optional[str] = None):
@@ -42,86 +338,250 @@ class AIEngine:
         Initialize the AI engine.
         
         Args:
-            model: Model identifier (defaults to DEFAULT_MODEL)
+            model: Model identifier (defaults to $ALLELIO_MODEL, then DEFAULT_MODEL)
             host: Ollama host URL (defaults to http://localhost:11434)
+
+        Raises:
+            ValueError: if a configured server address is not on this machine.
         """
-        self.model = model or DEFAULT_MODEL
-        self.host = host or DEFAULT_HOST
-        
-        if AsyncClient is None:
-            self.client = None
+        named = model or os.environ.get(MODEL_ENV) or ""
+        if named:
+            _refuse_cloud(named)
+        self.model = named or DEFAULT_MODEL
+        # A server with a single model loaded calls it whatever it likes, and
+        # guessing "llama3.1:8b" would be wrong every time. An unnamed model is
+        # filled in from the server on connect; a named one is a choice, and stays.
+        self._model_named = bool(named)
+
+        openai_base = os.environ.get(OPENAI_BASE_ENV)
+        if openai_base:
+            self.provider = OPENAI_COMPATIBLE
+            self.host = pin_to_loopback(openai_base, OPENAI_BASE_ENV)
+            self.client = _OpenAICompatClient(self.host)
         else:
-            self.client = AsyncClient(host=self.host)
+            self.provider = OLLAMA
+            self.host = pin_to_loopback(host or DEFAULT_HOST, "host")
+            # follow_redirects: ollama's client turns it on by default, and a
+            # 307 is all it takes to walk a prompt off the address that was
+            # checked. httpx, and so _OpenAICompatClient, defaults to off.
+            self.client = (
+                None
+                if AsyncClient is None
+                else AsyncClient(
+                    host=self.host, follow_redirects=False, trust_env=TRUST_ENV
+                )
+            )
+            # ollama-python reads OLLAMA_API_KEY itself and turns it into a
+            # bearer token, which httpx's trust_env has no say over. The only
+            # server reachable from here is on this machine, so the header
+            # cannot authenticate anything — it can only hand an Ollama Cloud
+            # credential to whatever process got to :11434 first. getattr
+            # because a test double has no httpx client underneath it.
+            underlying = getattr(self.client, "_client", None)
+            if underlying is not None:
+                underlying.headers.pop("authorization", None)
         
+        # The three things check_connection learns, and the only stored state
+        # `status` is computed from. Nothing outside this class reads them.
+        #
+        # available: something answered at that address -- an answer includes an
+        #   error status and a listing that outran its clock.
         self.available = False
+        # listed: the listing came back and was parsed. Not "there is a listing
+        #   with something in it": a server that answered {"data": []} has said
+        #   it serves nothing, which is an answer, and a /v1/models that 404s
+        #   has said nothing at all.
+        self.listed = False
+        # Set when the server answered and what it serves was refused. That is
+        # not the same as nothing answering, and the caller prints the reason.
+        self.refusal: Optional[str] = None
+        # Why the last call failed, in the server's own words. Server-controlled
+        # text: capped where it is set, escaped at every sink.
+        self.last_error: Optional[str] = None
+        # Filled in by check_connection, and the only listing anything asks for.
+        self.served_models: List[str] = []
+        # Matched against, but never shown: see _aliases_of.
+        self.served_aliases: List[str] = []
     
     async def check_connection(self) -> bool:
         """
-        Check if connection to Ollama is available.
+        Check if the configured model server is reachable.
         
         Returns:
-            True if Ollama is reachable, False otherwise
+            True if it answers, False otherwise
         """
         if self.client is None:
             return False
         
+        self.refusal = None
+        self.last_error = None
         try:
             # Try a simple tags request to verify connection
-            await asyncio.wait_for(self.client.list(), timeout=5)
-            self.available = True
-            return True
-        except Exception:
-            self.available = False
-            return False
+            response = await asyncio.wait_for(self.client.list(), timeout=5)
+            self.served_models = _model_names(response)
+            self.served_aliases = (
+                [str(a) for a in response.get("aliases") or []]
+                if isinstance(response, dict)
+                else []
+            )
+            self.listed = True
+        except Exception as exc:
+            self.served_models = []
+            self.served_aliases = []
+            self.listed = False
+            self.last_error = str(exc)[:200]
+            # An error *status* is the server talking, and so is a listing that
+            # ran past its clock; both are silence about the models rather than
+            # silence from the host, so the chat call decides. Connection
+            # refused is nothing answering, and there is nothing to try.
+            self.available = isinstance(exc, _ANSWERED)
+            return self.available
+
+        if (
+            not self._model_named
+            and self.provider == OPENAI_COMPATIBLE
+            and len(self.served_models) == 1
+            and _PLAUSIBLE_MODEL_NAME.match(self.served_models[0])
+        ):
+            # One model loaded and nobody named it, so its name is not a
+            # guess — take it, and the interface can print what is actually
+            # answering. Two or more and there is nothing to infer: a
+            # llama-swap config lists a dozen, and picking whichever came
+            # first would load an 80B coder model to explain a genome.
+            # Ollama is left out of this for the same reason.
+            # Checked here too: __init__ never saw this name, and a signed-in
+            # Ollama with one cloud model pulled serves exactly one.
+            try:
+                _refuse_cloud(self.served_models[0])
+            except ValueError as exc:
+                # The server answered; it is the model that is refused. Calling
+                # that "no answer" sends them looking for a daemon that is
+                # running fine.
+                self.available = False
+                self.refusal = str(exc)
+                return False
+            self.model = self.served_models[0]
+            self._model_named = True
+
+        self.available = True
+        return True
     
-    async def check_model_available(self) -> bool:
+    def _serves(self, name: str) -> bool:
+        """Is this name in the listing -- ids or llama-swap aliases?
+
+        Compared whole, not as a substring: "llama3.1:8b" used to be answered
+        yes by a machine holding only "llama3.1:70b", and the run then failed
+        at the first explanation instead of here, where it can still say why.
+
+        Case-folded because Ollama resolves names case-insensitively -- measured,
+        ALLELIO_MODEL=LLAMA3.1:8B is served by Ollama and was refused here.
+        OpenAI-compatible ids are case-sensitive in principle, and folding them
+        only widens what this is willing to *try*: a server without that
+        spelling answers the chat call with a 404 and nothing is credited.
         """
-        Check if the configured model is available/pulled in Ollama.
+        served = self.served_models + self.served_aliases
+        return _tagged(name).lower() in {_tagged(n).lower() for n in served}
+
+    @property
+    def status(self) -> str:
+        """What the server said about itself: one of five words.
+
+        The order is the point. A refusal outranks everything -- the server
+        answered, and what it serves is not going to be used, so "not serving
+        that model" is the wrong thing to say about it. Nothing answering
+        outranks the listing, because there is no listing. And a listing that
+        never came back is silence, not a denial: a bare llama.cpp has no
+        /v1/models at all and explains perfectly well.
+        """
+        if self.refusal:
+            return REFUSED
+        if not self.available:
+            return UNREACHABLE
+        if not self.listed:
+            return UNLISTED
+        return SERVING if self._serves(self.model) else REFUTED
+
+    def will_explain(self) -> bool:
+        """Whether a prompt will be sent to this server at all.
+
+        The single gate. explain and generate_summary ask it themselves, so no
+        caller has to switch the engine off by assigning to `available` to stop
+        a prompt going out.
+        """
+        return self.status in (SERVING, UNLISTED)
+
+    def reason(self) -> Optional[str]:
+        """Why there will be no explanations, in one plain sentence, or None.
+
+        Plain text, no markup: the CLI escapes it and adds its own hint line,
+        the library bridge raises it, and the page has `status` instead. It can
+        carry the server's own words, so every sink escapes it.
+        """
+        state = self.status
+        if state == REFUSED:
+            return self.refusal
+        if state == UNREACHABLE:
+            said = f" ({self.last_error})" if self.last_error else ""
+            return (
+                f"No answer from {self.provider} at {self.host}{said}."
+            )
+        if state == REFUTED:
+            offered = ", ".join(self.served_models[:8])
+            return (
+                f"{self.provider} at {self.host} is not serving '{self.model}'."
+                + (f" It offers: {offered}" if offered else "")
+            )
+        return None
+
+    def check_model_available(self) -> bool:
+        """
+        Check whether the server actually has the configured model.
+
+        Answered from the listing check_connection already fetched, so it costs
+        no second request and cannot be asked before connecting.
 
         Returns:
             True if model is available, False otherwise
         """
-        if self.client is None or not self.available:
-            return False
+        return self.status == SERVING
 
-        try:
-            response = await asyncio.wait_for(self.client.list(), timeout=5)
-            # Handle both old dict format and new object format from ollama package
-            models = []
-            if isinstance(response, dict):
-                models = response.get('models', [])
-            elif hasattr(response, 'models'):
-                models = response.models or []
-            else:
-                models = list(response) if response else []
+    def model_refuted(self) -> bool:
+        """The server listed what it serves, and this model is not in it.
 
-            model_base = self.model.split(':')[0]
-            for m in models:
-                name = m.get('name', '') if isinstance(m, dict) else getattr(m, 'model', getattr(m, 'name', ''))
-                if model_base in str(name):
-                    return True
-            return False
-        except Exception:
-            return False
-    
-    async def explain_variant(self, result) -> str:
+        Not the same as `not check_model_available()`: a server that would not
+        list its models has not refuted anything, and neither has one that is
+        not there. This is the difference the CLI, `info`, the upload and the
+        library bridge all used to get wrong in four different ways.
         """
-        Generate an AI explanation for a single variant.
-        
-        Args:
-            result: A VariantResult object from allelio.analysis.lookup
-            
-        Returns:
-            Explanation string with safety checks and disclaimers applied
+        return self.status == REFUTED
+    
+    @property
+    def credit(self) -> str:
+        """The model's full name, as it is shown wherever its work is shown.
+
+        Read after the listing, never before: a server holding a single model
+        gets to name it, and that adopted name is the one the reader needs.
+        """
+        return f"{self.model} ({self.provider} at {self.host})"
+
+    async def explain(self, result) -> Explanation:
+        """The same call, as a record of what came back and who wrote it.
+
+        The fallback is the variant's own data wrapped in the disclaimer, which
+        reads like an explanation — `model` is the only thing that separates a
+        page the model wrote from one it did not.
         """
         # Check if AI is available
-        if self.client is None or not self.available:
-            return self._fallback_explanation(result)
-        
-        # Build the prompt
-        user_prompt = build_variant_prompt(result)
+        if self.client is None or not self.will_explain():
+            return Explanation(self._fallback_explanation(result), None)
         
         try:
+            # Inside the guard, not above it: a variant this cannot build a
+            # prompt from used to raise straight past every caller. The batch
+            # then lost one card to its own outer guard and the CLI lost the
+            # card entirely — no text, no row, no reason.
+            user_prompt = build_variant_prompt(result)
+
             # Call Ollama chat API
             response = await asyncio.wait_for(
                 self.client.chat(
@@ -152,12 +612,25 @@ class AIEngine:
             # Wrap with disclaimers
             final_explanation = wrap_with_disclaimer(explanation, variant_warnings)
             
-            return final_explanation
+            # A later failure must not print the reason a call that has since
+            # succeeded gave.
+            self.last_error = None
+            return Explanation(final_explanation, self.credit)
             
         except asyncio.TimeoutError:
-            return self._fallback_explanation(result, reason="Request timed out")
+            self.last_error = "Request timed out"
+            return Explanation(
+                self._fallback_explanation(result, reason="Request timed out"),
+                None,
+                "Request timed out",
+            )
         except Exception as e:
-            return self._fallback_explanation(result, reason=str(e))
+            # Kept for the connection and status paths, which are one call at a
+            # time; the card carries its own copy because the batch is not.
+            self.last_error = str(e)[:200]
+            return Explanation(
+                self._fallback_explanation(result, reason=str(e)), None, str(e)[:200]
+            )
     
     async def explain_variants_batch(
         self,
@@ -165,7 +638,7 @@ class AIEngine:
         max_concurrent: int = 3,
         progress_callback: Optional[Callable[[int, int], None]] = None,
         deadline: float = BATCH_DEADLINE
-    ) -> Dict[str, str]:
+    ) -> Dict[str, Explanation]:
         """
         Generate AI explanations for multiple variants with concurrency control.
         
@@ -175,7 +648,9 @@ class AIEngine:
             progress_callback: Optional callback function(completed, total) for progress tracking
             
         Returns:
-            Dictionary mapping rsID to explanation string
+            Dictionary mapping rsID to an Explanation — the text, and the name
+            of the model that wrote it, or None where the call did not answer
+            and the text is the variant's own data.
         """
         if not results:
             return {}
@@ -185,15 +660,17 @@ class AIEngine:
         
         async def explain_with_semaphore(result):
             async with semaphore:
-                explanation = await self.explain_variant(result)
-                return result.rsid, explanation
+                return result.rsid, await self.explain(result)
         
         # Seeded, not empty: a variant the deadline cuts off still deserves the
         # gene, the ClinVar call and the GWAS traits that _fallback_explanation
         # writes. A finished task overwrites its seed.
         explanations = {
-            r.rsid: self._fallback_explanation(
-                r, reason="Explanation ran past the time limit"
+            r.rsid: Explanation(
+                self._fallback_explanation(
+                    r, reason="Explanation ran past the time limit"
+                ),
+                None,
             )
             for r in results
         }
@@ -214,13 +691,16 @@ class AIEngine:
                 except asyncio.TimeoutError:
                     raise
                 except Exception:
-                    # One variant that fails outside explain_variant's own
+                    # One variant that fails outside explain's own
                     # guard used to cost one explanation. It should not cost
                     # the whole upload, minutes after the analysis is done.
                     done += 1
                     if progress_callback:
                         progress_callback(done, len(results))
                     continue
+                # The seed is replaced by what came back, credit and all. A
+                # task that finishes after the deadline is never awaited, so
+                # its seed stands — uncredited, which is what it is.
                 explanations[rsid] = explanation
                 done += 1
                 if progress_callback:
@@ -244,7 +724,7 @@ class AIEngine:
         Returns:
             Summary string grouped by category and highlighting significant findings
         """
-        if self.client is None or not self.available:
+        if self.client is None or not self.will_explain():
             return "AI summary generation is unavailable. Please review individual variant explanations."
         
         if not results:

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -26,8 +26,10 @@ DEFAULT_HOST = "http://localhost:11434"
 REQUEST_TIMEOUT = 300
 
 # Fifty variants, three at a time, at the per-request timeout is over an hour
-# of staring at a progress bar. Cap the batch and keep what finished.
-BATCH_DEADLINE = 900
+# of staring at a progress bar. Cap the batch and keep what finished. Thirty
+# minutes clears a full run of this project's own default model on an M1 Max
+# with room to spare; fifteen did not.
+BATCH_DEADLINE = 1800
 
 
 class AIEngine:
@@ -186,9 +188,17 @@ class AIEngine:
                 explanation = await self.explain_variant(result)
                 return result.rsid, explanation
         
-        # Track completions for callback
-        explanations = {}
+        # Seeded, not empty: a variant the deadline cuts off still deserves the
+        # gene, the ClinVar call and the GWAS traits that _fallback_explanation
+        # writes. A finished task overwrites its seed.
+        explanations = {
+            r.rsid: self._fallback_explanation(
+                r, reason="Explanation ran past the time limit"
+            )
+            for r in results
+        }
         
+        done = 0
         tasks = [
             asyncio.ensure_future(explain_with_semaphore(result))
             for result in results
@@ -207,10 +217,14 @@ class AIEngine:
                     # One variant that fails outside explain_variant's own
                     # guard used to cost one explanation. It should not cost
                     # the whole upload, minutes after the analysis is done.
+                    done += 1
+                    if progress_callback:
+                        progress_callback(done, len(results))
                     continue
                 explanations[rsid] = explanation
+                done += 1
                 if progress_callback:
-                    progress_callback(len(explanations), len(results))
+                    progress_callback(done, len(results))
         except asyncio.TimeoutError:
             pass
         finally:

--- a/allelio/ai/engine.py
+++ b/allelio/ai/engine.py
@@ -179,8 +179,6 @@ class AIEngine:
         async def explain_with_semaphore(result):
             async with semaphore:
                 explanation = await self.explain_variant(result)
-                if progress_callback:
-                    progress_callback(len(explanations), len(results))
                 return result.rsid, explanation
         
         # Track completions for callback
@@ -226,10 +224,11 @@ class AIEngine:
             # Classify based on available data
             if clinvar or (gwas and len(gwas) > 0):
                 # clinvar/gwas hold ClinVarEntry and GWASEntry objects, not dicts.
-                has_clinvar_pathogenic = any(
-                    'pathogenic' in str(getattr(e, 'clinical_significance', '')).lower()
-                    for e in clinvar
-                )
+                def _pathogenic(e) -> bool:
+                    sig = str(getattr(e, 'clinical_significance', '')).lower()
+                    return 'pathogenic' in sig and 'conflicting' not in sig
+
+                has_clinvar_pathogenic = any(_pathogenic(e) for e in clinvar)
 
                 def _strong_gwas(e) -> bool:
                     p = str(getattr(e, 'p_value', ''))
@@ -271,7 +270,7 @@ class AIEngine:
                 for e in (r.clinvar_entries or []):
                     gene = getattr(e, 'gene', '') or gene
                 for e in (r.gwas_entries or []):
-                    gene = gene or getattr(e, 'gene', '')
+                    gene = gene or getattr(e, 'mapped_gene', '')
                 sig = ""
                 for e in (r.clinvar_entries or []):
                     sig = getattr(e, 'clinical_significance', '') or sig

--- a/allelio/ai/explanations.py
+++ b/allelio/ai/explanations.py
@@ -16,22 +16,29 @@ async def generate_explanation(variant_result, model: Optional[str] = None) -> s
 
     Args:
         variant_result: A VariantResult object from allelio.analysis.lookup
-        model: Ollama model name (e.g. 'llama3.1:8b')
+        model: Model name (e.g. 'llama3.1:8b'); defaults to $ALLELIO_MODEL
 
     Returns:
-        Explanation string with disclaimers applied, or raises if Ollama unavailable.
+        Explanation string with disclaimers applied, or raises if no model answers.
     """
     engine = AIEngine(model=model)
 
-    connected = await engine.check_connection()
-    if not connected:
-        raise RuntimeError("Cannot connect to Ollama. Is it running? (ollama serve)")
+    await engine.check_connection()
+    # One gate, the same one the CLI and the upload use, and the engine's own
+    # sentence for why. A server that will not enumerate its models is not a
+    # server that is missing this one, and this used to say it was.
+    if not engine.will_explain():
+        raise RuntimeError(engine.reason())
 
-    model_ok = await engine.check_model_available()
-    if not model_ok:
+    written = await engine.explain(variant_result)
+    # "or raises if no model answers" is the documented contract, and until now
+    # a failed call returned the variant's own data instead — text that reads
+    # like an explanation to a caller that was promised an exception. The
+    # record answers it for this call, not for the run: a caller asking about
+    # one variant is told about that variant.
+    if written.model is None:
         raise RuntimeError(
-            f"Model '{engine.model}' not found in Ollama. "
-            f"Pull it with: ollama pull {engine.model}"
+            written.error
+            or f"{engine.provider} at {engine.host} did not answer for '{engine.model}'."
         )
-
-    return await engine.explain_variant(variant_result)
+    return written.text

--- a/allelio/cli.py
+++ b/allelio/cli.py
@@ -77,8 +77,8 @@ def setup():
 )
 @click.option(
     "--model",
-    default="llama3.1:8b",
-    help="Ollama model name for explanations",
+    default=None,
+    help="Model name for explanations (default: $ALLELIO_MODEL, else llama3.1:8b)",
 )
 @click.option(
     "--top",
@@ -97,7 +97,7 @@ def analyze(
     output: str,
     no_ai: bool,
     include_benign: bool,
-    model: str,
+    model: Optional[str],
     top: int,
     traits_only: bool,
 ):
@@ -122,7 +122,52 @@ def analyze(
             )
         )
         raise click.Abort()
-    
+
+    # Settle the model before anything is read. Construction only parses and
+    # resolves the address, and the listing call costs one request — both are
+    # cheap here and useless after half an hour of parsing and lookups, which is
+    # where a refusal or a stale model name used to surface.
+    engine = None
+    if not no_ai:
+        try:
+            from allelio.ai.engine import (
+                AIEngine,
+                attribution,
+                OLLAMA,
+                OPENAI_COMPATIBLE,
+                REFUSED,
+                REFUTED,
+                UNREACHABLE,
+            )
+        except ImportError:
+            console.print("  [yellow]⚠[/yellow] AI module not available (pip install ollama)")
+            console.print("    Skipping AI explanations.\n")
+        else:
+            try:
+                engine = AIEngine(model=model)
+            except ValueError as e:
+                console.print(f"\n[bold red]✗[/bold red] {escape(str(e))}\n", style="red")
+                raise click.Abort()
+
+            if engine.client is None:
+                # engine.py swallows the ImportError so the rest of the tool
+                # still runs, which leaves this as the only place the missing
+                # package can be told apart from a daemon that is not up.
+                console.print("  [yellow]⚠[/yellow] AI module not available (pip install ollama)")
+                console.print("    Skipping AI explanations.\n")
+                engine = None
+            elif engine.provider == OPENAI_COMPATIBLE:
+                # One thing has to be known before the genome is read: a server
+                # whose only model is an Ollama Cloud tag relays the prompt off
+                # this machine, and adoption — the only place that name appears —
+                # happens on this provider's path alone. Asking costs one
+                # request to loopback. Nothing else is decided here: the listing
+                # is advisory, and it is read again inside the explanation loop.
+                asyncio.run(engine.check_connection())
+                if engine.status == REFUSED:
+                    console.print(f"\n[bold red]✗[/bold red] {escape(engine.refusal)}\n", style="red")
+                    raise click.Abort()
+
     # Parse genotype file
     try:
         with Progress(
@@ -161,33 +206,105 @@ def analyze(
         raise click.Abort()
     
     # Generate AI explanations if enabled
+    # rsID -> Explanation: the text and, where the model wrote it, its name.
+    # Everything printed about who wrote what is counted off this, so there is
+    # no second number that can disagree with the pages in the report.
     explanations = {}
-    if not no_ai:
+    if engine is not None:
         # Sort by significance and take top N
         top_variants = sorted(
             results, key=lambda x: x.significance_rank
         )[:top]
 
         try:
-            from allelio.ai.engine import AIEngine
+            # One loop for the whole run, the listing included. asyncio.run()
+            # per variant closes the loop the ollama client's connection pool is
+            # bound to, so every second call came back "Event loop is closed" —
+            # swallowed into a fallback that reads like an explanation, on the
+            # default provider. That is also why the listing is fetched in here
+            # rather than beside the one above: for Ollama it would be the first
+            # use of that pool, on a loop that then closes.
+            async def explain_each():
+                # Asked here, on the loop the prompts will run on: ollama's
+                # client binds its connection pool to the first loop it is used
+                # on, so a listing fetched anywhere else leaves every prompt
+                # talking to a loop that has closed. The OpenAI-compatible
+                # client builds a fresh httpx client per call and was already
+                # asked above, for the refusal — so it is not asked twice.
+                if engine.provider == OLLAMA:
+                    await engine.check_connection()
+                if not engine.will_explain():
+                    return
+                # engine.model, not the option, and read after the listing —
+                # which is where a server holding a single model names it.
+                console.print(
+                    f"  Generating AI explanations for top {len(top_variants)} variants "
+                    f"using {escape(engine.model)} "
+                    f"({escape(engine.provider)} at {escape(engine.host)})...\n"
+                )
+                for idx, variant in enumerate(top_variants, 1):
+                    try:
+                        written = await engine.explain(variant)
+                        explanations[variant.rsid] = written
+                        # A failed call still returns text — the fallback, written
+                        # from ClinVar and the GWAS Catalog. This card's own
+                        # record says which of the two it got.
+                        if written.model:
+                            console.print(f"    [{idx}/{len(top_variants)}] {variant.rsid} ✓")
+                        else:
+                            # This card's own reason. The engine keeps one
+                            # slot for the last error, which is a different
+                            # sentence the moment anything runs concurrently.
+                            said = f" ({escape(written.error)})" if written.error else ""
+                            console.print(
+                                f"    [{idx}/{len(top_variants)}] {variant.rsid} ✗{said}"
+                            )
+                    except Exception as e:
+                        console.print(f"    [{idx}/{len(top_variants)}] {variant.rsid} ✗ ({escape(str(e))})")
 
-            engine = AIEngine(model=model)
-            # Skip model listing — just try to use the model directly
-            engine.available = True
+            asyncio.run(explain_each())
 
-            console.print(f"  Generating AI explanations for top {len(top_variants)} variants using {model}...\n")
-            for idx, variant in enumerate(top_variants, 1):
-                try:
-                    explanation = asyncio.run(engine.explain_variant(variant))
-                    explanations[variant.rsid] = explanation
-                    console.print(f"    [{idx}/{len(top_variants)}] {variant.rsid} ✓")
-                except Exception as e:
-                    console.print(f"    [{idx}/{len(top_variants)}] {variant.rsid} ✗ ({e})")
-
-            if explanations:
-                console.print(f"\n  [bold green]✓[/bold green] Generated {len(explanations)} AI explanations\n")
+            status = engine.status
+            if status == REFUSED:
+                # Unreachable as things stand — the OpenAI-compatible path is
+                # the only one that adopts a served name, and it was refused
+                # above, before the file was read. Kept because it is the lock
+                # on a prompt leaving this machine, and the cost of keeping it
+                # is one string comparison.
+                console.print(f"\n[bold red]✗[/bold red] {escape(engine.refusal)}\n", style="red")
+                raise click.Abort()
+            elif status in (REFUTED, UNREACHABLE):
+                # The analysis is still worth having; the attribution on it is
+                # not. Say which of the two happened and what fixes it.
+                console.print(f"\n  [yellow]⚠[/yellow] {escape(engine.reason())}")
+                if status == REFUTED and engine.provider == OLLAMA:
+                    console.print(
+                        f"  Pull it: [bold cyan]ollama pull {escape(engine.model)}[/bold cyan]"
+                    )
+                elif status == REFUTED:
+                    console.print(
+                        "  Name one with [bold cyan]ALLELIO_MODEL[/bold cyan], "
+                        "or run with [bold cyan]--no-ai[/bold cyan]."
+                    )
+                console.print("  Continuing without explanations.\n")
+            # Counted off the cards, not off the run: a failed call still
+            # returns text — the variant's own data, wrapped in the disclaimer —
+            # and counting those would credit the model for pages it never wrote.
+            elif attribution(explanations).written:
+                console.print(
+                    f"\n  [bold green]✓[/bold green] Generated "
+                    f"{attribution(explanations).written} AI explanations\n"
+                )
             else:
-                console.print(f"\n  [yellow]⚠[/yellow] No explanations generated. Is Ollama running? (ollama serve)\n")
+                # It answered and then wrote nothing. Its own sentence is the
+                # diagnostic — "model 'x' not found" — and it is server text.
+                # Read off the cards, like everything else here: the engine's
+                # own slot holds whichever call wrote to it last.
+                reasons = [w.error for w in explanations.values() if w.error]
+                said = f" ({escape(reasons[-1])})" if reasons else ""
+                console.print(
+                    f"\n  [yellow]⚠[/yellow] No explanations generated.{said}\n"
+                )
         except ImportError:
             console.print("  [yellow]⚠[/yellow] AI module not available (pip install ollama)")
             console.print("    Skipping AI explanations.\n")
@@ -239,7 +356,6 @@ def analyze(
         metadata = {
             "generated_at": __import__("datetime").datetime.now().isoformat(),
             "db_version": db.version(),
-            "model_used": model if not no_ai else "none",
             "file_analyzed": Path(file).name,
             "total_variants": len(variants),
             "significant_variants": len(significant),
@@ -396,20 +512,67 @@ def info():
         
         console.print(info_table)
         
-        # Check Ollama status
+        # Which model would answer, and where it is running. Asked through the
+        # engine rather than Ollama's own port, so this still tells the truth
+        # when ALLELIO_OPENAI_BASE has pointed the tool somewhere else.
         console.print("\n[bold]AI/LLM Status[/bold]")
         try:
-            import httpx
-            response = httpx.get("http://localhost:11434/api/tags", timeout=2.0)
-            if response.status_code == 200:
-                console.print("[bold green]✓[/bold green] Ollama available at localhost:11434")
-                models = response.json().get("models", [])
-                if models:
-                    console.print(f"  Installed models: {', '.join([m.get('name', 'unknown') for m in models[:3]])}")
-            else:
-                console.print("[bold yellow]⚠[/bold yellow] Ollama not responding")
+            from allelio.ai.engine import (
+                AIEngine,
+                OLLAMA,
+                REFUSED,
+                REFUTED,
+                UNREACHABLE,
+            )
+
+            engine = AIEngine()
+        except ValueError as e:
+            console.print(f"[bold red]✗[/bold red] {escape(str(e))}")
         except Exception:
-            console.print("[bold yellow]⚠[/bold yellow] Ollama not available (install for AI features)")
+            console.print("[bold yellow]⚠[/bold yellow] AI module not available (pip install ollama)")
+        else:
+            if engine.client is None:
+                # engine.py swallows the ImportError, so nothing above this can
+                # tell the missing package from a server that is not answering.
+                console.print("[bold yellow]⚠[/bold yellow] AI module not available (pip install ollama)")
+            else:
+                # The same five-way answer `analyze` gets, so the diagnostic
+                # command and the one doing the work cannot disagree about the
+                # same server — which they did, in both directions.
+                asyncio.run(engine.check_connection())
+                status = engine.status
+                if status == REFUSED:
+                    console.print(f"[bold red]✗[/bold red] {escape(engine.refusal)}")
+                elif status == UNREACHABLE:
+                    console.print(
+                        f"[bold yellow]⚠[/bold yellow] {escape(engine.reason())} "
+                        "(optional — Allelio runs without it)"
+                    )
+                else:
+                    console.print(
+                        f"[bold green]✓[/bold green] {escape(engine.provider)} answering at "
+                        f"{escape(engine.host)}"
+                    )
+                    console.print(f"  Model: [bold cyan]{escape(engine.model)}[/bold cyan]")
+                    if status == REFUTED:
+                        console.print(
+                            f"  [bold yellow]⚠[/bold yellow] {escape(engine.model)} is not on that server."
+                        )
+                        if engine.provider == OLLAMA:
+                            console.print(
+                                f"  Pull it: [bold cyan]ollama pull {escape(engine.model)}[/bold cyan]"
+                            )
+                        elif engine.served_models:
+                            # A llama-swap config lists a dozen and none of them
+                            # is named llama3.1:8b, so print the menu rather
+                            # than a command that cannot work here.
+                            offered = ", ".join(engine.served_models[:8])
+                            console.print(f"  That server offers: {escape(offered)}")
+                            console.print(
+                                "  Name one with [bold cyan]ALLELIO_MODEL[/bold cyan]."
+                            )
+                    # UNLISTED says nothing about the model: this server does
+                    # not enumerate, so there is nothing to contradict it with.
         
         console.print()
     except Exception as e:

--- a/allelio/cli.py
+++ b/allelio/cli.py
@@ -2,11 +2,13 @@
 
 import asyncio
 import os
+import socket
 from pathlib import Path
 from typing import Optional
 
 import click
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
@@ -278,13 +280,61 @@ def serve(port: int, host: str):
     Start an interactive web server for variant analysis and exploration.
     """
     console.print("\n[bold cyan]Allelio Web Interface[/bold cyan]\n")
-    console.print(f"Starting Allelio web interface on {host}:{port}...\n")
-    console.print(f"Open [bold cyan]http://{host}:{port}[/bold cyan] in your browser\n")
-    
+    # escape: rich reads "[" as the start of a style tag, and --host takes
+    # whatever the shell hands it.
+    console.print(f"Starting Allelio web interface on {escape(host)}:{port}...\n")
+
+    # The app rejects Host headers it does not recognise, which is what stops a
+    # remote page from reaching this server by pointing its own domain at
+    # 127.0.0.1. Whatever the operator chose to bind belongs on the list; it has
+    # to be set before the app module is imported.
+    # An empty --host binds everywhere; there is no URL in it to print.
+    browse_to = host or "localhost"
+    if not os.environ.get("ALLELIO_ALLOWED_HOSTS"):
+        try:
+            # inet_aton takes every legacy spelling of "all interfaces" — 0,
+            # 0.0, 0x0 — that comparing against "0.0.0.0" would miss, and it
+            # does no lookups, so a hostname simply raises.
+            binds_everywhere = socket.inet_aton(host) == b"\x00\x00\x00\x00"
+        except OSError:
+            binds_everywhere = False
+
+        # Starlette strips the port by splitting the Host header on ":", so no
+        # IPv6 literal on the list could ever match; neither could a bind
+        # address nobody types into a browser. Lowercased because that is how
+        # browsers send it and starlette compares exactly.
+        # An empty --host binds everywhere too: asyncio special-cases it into a
+        # getaddrinfo with AI_PASSIVE, which answers 0.0.0.0 and ::.
+        extra = [] if binds_everywhere or not host or ":" in host else [host.lower()]
+        os.environ["ALLELIO_ALLOWED_HOSTS"] = ",".join(
+            dict.fromkeys(["localhost", "127.0.0.1"] + extra)
+        )
+        if not extra:
+            # Printing the bound address here would send them to a URL that
+            # answers 400.
+            browse_to = "localhost"
+            console.print(
+                f"[bold yellow]⚠[/bold yellow] Bound to {escape(host) or 'every interface'}, but "
+                "browse to "
+                "localhost — "
+                "the host check has no way to match that address.\n"
+                "  That check is what stops a web page you visit from reading your genome "
+                "off this server, which has no password on it.\n"
+                "  To let another machine reach it, name that machine: "
+                "ALLELIO_ALLOWED_HOSTS=192.168.1.50 allelio serve --host 0.0.0.0\n",
+                style="yellow",
+            )
+
+    # A bare IPv6 literal needs brackets or the browser reads the last colon as
+    # the port separator, and rich reads "[::1]" as a style tag.
+    url = f"http://[{browse_to}]:{port}" if ":" in browse_to else f"http://{browse_to}:{port}"
+    console.print(f"Open [bold cyan]{escape(url)}[/bold cyan] in your browser\n")
+
     try:
         import uvicorn
+
         from allelio.web.app import app
-        
+
         uvicorn.run(app, host=host, port=port, log_level="info")
     except ImportError:
         console.print("[bold red]✗[/bold red] Web server dependencies not installed\n", style="red")

--- a/allelio/database/store.py
+++ b/allelio/database/store.py
@@ -27,7 +27,7 @@ class AllelioDB:
     
     def _connect(self) -> None:
         """Establish database connection and enable WAL mode."""
-        self.conn = sqlite3.connect(str(self.db_path))
+        self.conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
         self.cursor = self.conn.cursor()
         # Enable WAL mode for better concurrent read performance

--- a/allelio/report.py
+++ b/allelio/report.py
@@ -3,7 +3,9 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 import html as html_escape
+from urllib.parse import quote
 
+from allelio.ai.attribution import Explanation, attribution
 from allelio.analysis.lookup import _get_review_stars
 
 
@@ -74,7 +76,7 @@ def _format_explanation_html(text: str) -> str:
 
 def generate_html_report(
     results: List[Any],
-    explanations: Dict[str, str],
+    explanations: Dict[str, Explanation],
     summary: str,
     metadata: Dict[str, Any],
 ) -> str:
@@ -82,10 +84,12 @@ def generate_html_report(
 
     Args:
         results: List of VariantResult objects with analysis data
-        explanations: Dict mapping rsid -> AI explanation text
+        explanations: Dict mapping rsid -> Explanation — the text, and the
+                      name of the model that wrote it where one did
         summary: Executive summary string
-        metadata: Dict with keys: generated_at, db_version, model_used,
-                  file_analyzed, total_variants, significant_variants
+        metadata: Dict with keys: generated_at, db_version, file_analyzed,
+                  total_variants, significant_variants. Who wrote the
+                  explanations is not among them — see below.
 
     Returns:
         Complete HTML report as a string
@@ -94,7 +98,12 @@ def generate_html_report(
     # Prepare data
     generated_at = metadata.get("generated_at", datetime.now().isoformat())
     db_version = metadata.get("db_version", "Unknown")
-    model_used = metadata.get("model_used", "None")
+    # Read off the cards this report is about to render, never passed in
+    # beside them: a name and a count that travel separately from the pages
+    # they describe are a name and a count that can describe other pages.
+    credit = attribution(explanations)
+    model_used = credit.model or "none"
+    explained_count = credit.written
     file_analyzed = metadata.get("file_analyzed", "Unknown")
     total_variants = metadata.get("total_variants", 0)
     significant_variants = metadata.get("significant_variants", 0)
@@ -108,7 +117,13 @@ def generate_html_report(
     other = [r for r in results if r.category in ("Unknown",)]
 
     def generate_variant_card(variant, explanation=None):
-        """Generate HTML for a single variant card."""
+        """Generate HTML for a single variant card.
+
+        `explanation` is an Explanation — the text and, where a model wrote it,
+        its name. The heading over that text says which of the two the reader
+        is looking at: a fallback card reads like an explanation and used to be
+        headed "AI Analysis" all the same.
+        """
         category_colors = {
             "Health Conditions": "#dc2626",
             "Risk Factors": "#ea580c",
@@ -125,8 +140,9 @@ def generate_html_report(
         review_stars_html = _get_review_stars_html(variant)
         genotype = variant.genotype or "-"
 
-        clinvar_url = f"https://www.ncbi.nlm.nih.gov/clinvar/?term={variant.rsid}"
-        pubmed_url = f"https://pubmed.ncbi.nlm.nih.gov/?term={gene}+{variant.rsid}" if gene != "Unknown" else "#"
+        rsid = html_escape.escape(quote(str(variant.rsid or ""), safe=""))
+        clinvar_url = f"https://www.ncbi.nlm.nih.gov/clinvar/?term={rsid}"
+        pubmed_url = f"https://pubmed.ncbi.nlm.nih.gov/?term={quote(gene, safe='')}+{rsid}" if gene != "Unknown" else "#"
 
         # Rank label
         rank = variant.significance_rank
@@ -146,8 +162,8 @@ def generate_html_report(
         card_html = f'''
         <div class="variant-card" style="border-left: 5px solid {color};">
             <div class="variant-header">
-                <h3>{variant.rsid}</h3>
-                <span class="badge" style="background-color: {color};">{variant.category}</span>
+                <h3>{html_escape.escape(str(variant.rsid or ""))}</h3>
+                <span class="badge" style="background-color: {color};">{html_escape.escape(str(variant.category or ""))}</span>
                 <span class="significance" style="background-color: {rank_color}20; color: {rank_color};">{rank_label}</span>
             </div>
 
@@ -179,15 +195,20 @@ def generate_html_report(
                 </div>
                 <div class="info-row">
                     <span class="label">Chromosome:</span>
-                    <span class="value">{variant.chromosome or "N/A"}</span>
+                    <span class="value">{html_escape.escape(str(variant.chromosome or "N/A"))}</span>
                 </div>
             </div>
 '''
         if explanation:
+            heading = (
+                f"AI Analysis — {html_escape.escape(explanation.model)}"
+                if explanation.model
+                else "No model wrote this — data from ClinVar and the GWAS Catalog"
+            )
             card_html += f'''
             <div class="explanation">
-                <h4>AI Analysis</h4>
-                {_format_explanation_html(explanation)}
+                <h4>{heading}</h4>
+                {_format_explanation_html(explanation.text)}
             </div>
 '''
 
@@ -246,10 +267,18 @@ def generate_html_report(
             categories_html += generate_variant_card(variant, explanation)
         categories_html += '</div>\n</section>\n'
 
-    # AI explanation count
+    # Says which cards, not how many pages there are: a variant whose call
+    # failed still gets an entry — its own data, wrapped in the disclaimer —
+    # and reporting that as the model's work credits it for pages it never
+    # wrote. On a run where every call answered the two numbers are the same
+    # and it reads as it always did.
     ai_note = ""
-    if explanations:
-        ai_note = f'<div class="ai-note"><strong>AI Explanations:</strong> {len(explanations)} variants analyzed with {model_used}</div>'
+    if explained_count:
+        ai_note = (
+            f'<div class="ai-note"><strong>AI Explanations:</strong> '
+            f'{explained_count} of {credit.total} variants analyzed with '
+            f'{html_escape.escape(str(model_used))}</div>'
+        )
 
     html = f'''<!DOCTYPE html>
 <html lang="en">
@@ -646,7 +675,7 @@ def generate_html_report(
                 <div class="stat-label">Significant Findings</div>
             </div>
             <div class="stat-card">
-                <div class="stat-value">{len(explanations)}</div>
+                <div class="stat-value">{explained_count}</div>
                 <div class="stat-label">AI Explanations</div>
             </div>
         </div>
@@ -669,7 +698,7 @@ def generate_html_report(
             <div class="footer-section">
                 <strong>Analysis Details</strong><br>
                 File: {html_escape.escape(file_analyzed)}<br>
-                AI Model: {html_escape.escape(model_used)}<br>
+                AI Model: {html_escape.escape(str(model_used))}<br>
                 Generated: {generated_at}
             </div>
 

--- a/allelio/web/app.py
+++ b/allelio/web/app.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from fastapi.middleware.cors import CORSMiddleware
 
 from allelio import __version__, __app_name__
 
@@ -15,16 +14,9 @@ app = FastAPI(
     description="Privacy-first local genomics analysis powered by AI",
 )
 
-# The UI is served from this same app, so CORS only needs to cover a dev
-# server on another loopback port. A wildcard with credentials let any page
-# the user visited POST their genome to localhost and read the result back.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# No CORS middleware: the UI is served from this same app, so nothing here is
+# cross-origin. The wildcard that used to sit here, with credentials allowed,
+# let any page the user happened to visit read their genome off localhost.
 
 # Template directory
 TEMPLATE_DIR = Path(__file__).parent / "templates"

--- a/allelio/web/app.py
+++ b/allelio/web/app.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from allelio import __version__, __app_name__
 
@@ -17,6 +18,54 @@ app = FastAPI(
 # No CORS middleware: the UI is served from this same app, so nothing here is
 # cross-origin. The wildcard that used to sit here, with credentials allowed,
 # let any page the user happened to visit read their genome off localhost.
+
+# Binding to 127.0.0.1 is not on its own a boundary: a page on a domain whose
+# DNS re-resolves to 127.0.0.1 is same-origin by the browser's reckoning, and
+# CORS never enters into it. Checking the Host header is what closes that, and
+# it costs nothing when the host is what we bound to. `serve` widens this to
+# whatever --host it was given.
+#
+# Starlette compares against the Host header with the port already stripped, so
+# entries carry no port. It splits on ":" to do it, which leaves no spelling of
+# a bracketed IPv6 literal that can ever match — "localhost" is how you reach
+# this over IPv6.
+# Loopback always stays on the list. It is the address the person running this
+# actually types, and naming a LAN address should not lock them out of their own
+# machine. It costs nothing: a rebound domain arrives in the Host header as its
+# own name, never as "localhost", so this is not a way in.
+#
+# Lowercased because browsers send the host lowercased and starlette compares it
+# exactly — an entry with a capital in it could never match.
+ALLOWED_HOSTS = list(
+    dict.fromkeys(
+        ["localhost", "127.0.0.1"]
+        + [
+            h.strip().lower()
+            for h in os.environ.get("ALLELIO_ALLOWED_HOSTS", "").split(",")
+            if h.strip()
+        ]
+    )
+)
+
+# TrustedHostMiddleware only checks its patterns when the stack is first built,
+# which is on the first request — a typo in the environment would otherwise take
+# down a run that had already printed its URL. It checks with an assert, so it
+# would also stop checking under -O. Both halves of starlette's rule, restated
+# here and raising for real: no "*" past the first character, and a leading one
+# has to be the "*." of a subdomain wildcard. "*example.com" fails both its
+# check and this one — it is a forgotten dot, not a pattern.
+_bad = [
+    h
+    for h in ALLOWED_HOSTS
+    if "*" in h[1:] or (h.startswith("*") and h != "*" and not h.startswith("*."))
+]
+if _bad:
+    raise ValueError(
+        f"ALLELIO_ALLOWED_HOSTS: {', '.join(_bad)} — a wildcard host has to look "
+        "like '*.example.com', or be '*' on its own."
+    )
+
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=ALLOWED_HOSTS)
 
 # Template directory
 TEMPLATE_DIR = Path(__file__).parent / "templates"

--- a/allelio/web/app.py
+++ b/allelio/web/app.py
@@ -15,10 +15,12 @@ app = FastAPI(
     description="Privacy-first local genomics analysis powered by AI",
 )
 
-# Add CORS middleware for local development
+# The UI is served from this same app, so CORS only needs to cover a dev
+# server on another loopback port. A wildcard with credentials let any page
+# the user visited POST their genome to localhost and read the result back.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -69,6 +69,33 @@ async def get_status() -> Dict[str, Any]:
     }
 
 
+def _gene_of(variant) -> Optional[str]:
+    """Gene symbol for a result, from ClinVar first and GWAS as a fallback."""
+    for entry in (variant.clinvar_entries or []):
+        if entry.gene:
+            return entry.gene
+    for entry in (variant.gwas_entries or []):
+        if entry.mapped_gene:
+            return entry.mapped_gene
+    return None
+
+
+def _significance_of(variant) -> str:
+    """Bucket a result into the four badges the results list knows how to draw."""
+    for entry in (variant.clinvar_entries or []):
+        significance = (entry.clinical_significance or "").lower()
+        if "pathogenic" in significance and "benign" not in significance:
+            return "pathogenic"
+        if "risk" in significance:
+            return "risk"
+    if variant.gwas_entries:
+        return "risk"
+    for entry in (variant.clinvar_entries or []):
+        if "benign" in (entry.clinical_significance or "").lower():
+            return "benign"
+    return "trait"
+
+
 @router.post("/api/analyze")
 async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
     """
@@ -179,8 +206,12 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 "category": variant.category if hasattr(variant, 'category') else "Unknown",
                 "significance_rank": i + 1,
                 "explanation": explanations.get(variant.rsid, ""),
-                "clinvar_data": variant.clinvar_data if hasattr(variant, 'clinvar_data') else None,
-                "gwas_data": variant.gwas_data if hasattr(variant, 'gwas_data') else None,
+                "gene": _gene_of(variant),
+                "significance": _significance_of(variant),
+                "pubmed_id": next(
+                    (e.pubmed_id for e in (variant.gwas_entries or []) if e.pubmed_id),
+                    None,
+                ),
                 "warnings": warnings,
             }
             formatted_results.append(result_dict)

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -85,21 +85,26 @@ def _significance_of(variant) -> str:
     """Bucket a result into the badges the results list knows how to draw.
 
     ClinVar has the last word. "Conflicting classifications of pathogenicity"
-    is 130,833 rsIDs and sorts to the very top of the report, so it needs to
-    say so rather than borrow either neighbour's colour.
+    is 130,833 rsIDs and "Uncertain significance" is 1,236,063 — both sort high
+    enough to reach the report, and neither is a trait or a benign call.
     """
     for entry in (variant.clinvar_entries or []):
         significance = (entry.clinical_significance or "").lower()
         if "conflicting" in significance:
             return "conflicting"
+        if "uncertain" in significance:
+            return "uncertain"
         if "pathogenic" in significance and "benign" not in significance:
             return "pathogenic"
-        if "benign" in significance:
+        if "benign" in significance or "protective" in significance:
             return "benign"
         if "risk" in significance:
             return "risk"
     if variant.gwas_entries:
-        return "risk"
+        # A GWAS row on its own is an association, not a risk — 37,108 of the
+        # 62,057 findings on a real genome. The analyser has already read the
+        # trait text and decided which of them are risk factors.
+        return "risk" if variant.category == "Risk Factors" else "trait"
     return "trait"
 
 
@@ -116,15 +121,18 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         if not file.filename:
             raise HTTPException(status_code=400, detail="No filename provided")
 
-        # Save uploaded file to temp location
-        temp_dir = tempfile.gettempdir()
-        temp_file_path = Path(temp_dir) / file.filename
-        
         content = await file.read()
         if not content:
             raise HTTPException(status_code=400, detail="Uploaded file is empty")
-        
-        with open(temp_file_path, "wb") as f:
+
+        # The multipart filename is raw header data: "../../../.zshenv" resolves
+        # out of the temp directory, and multipart is CORS-safelisted, so any
+        # page could have posted here. mkstemp picks the name and the mode —
+        # this file is the user's entire genome and the temp directory is shared.
+        # Only the .gz suffix matters to the parser.
+        suffix = ".gz" if file.filename.endswith(".gz") else ""
+        fd, temp_file_path = tempfile.mkstemp(prefix="allelio_upload_", suffix=suffix)
+        with os.fdopen(fd, "wb") as f:
             f.write(content)
 
         _progress.update(stage="Reading your file", done=0, total=0)
@@ -132,7 +140,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         # Parse genotype file
         loop = asyncio.get_event_loop()
         genotypes = await loop.run_in_executor(
-            None, parse_genotype_file, str(temp_file_path)
+            None, parse_genotype_file, temp_file_path
         )
         
         if not genotypes:
@@ -330,7 +338,9 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
 
         # The safety layer computes these for BRCA1/2, TP53, Lynch and APOE.
         # A report that omits them is the one place they matter most.
-        warnings = "".join(
+        # explain_variant runs these through wrap_with_disclaimer, so for the
+        # variants that got an explanation they are already in it.
+        warnings = "" if result.get("explanation") else "".join(
             f'<p class="warning">{escape(str(w))}</p>'
             for w in (result.get("warnings") or [])
         )

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -7,7 +7,6 @@ from typing import List, Dict, Any, Optional
 
 from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
-from starlette.concurrency import run_in_executor
 
 from allelio import __version__
 from allelio.parsers import parse_genotype_file
@@ -24,7 +23,7 @@ router = APIRouter()
 async def read_root(request: Request) -> str:
     """Serve the main HTML page."""
     try:
-        return templates.TemplateResponse("index.html", {"request": request})
+        return templates.TemplateResponse(request, "index.html")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to load index page: {str(e)}")
 
@@ -35,7 +34,7 @@ async def get_status() -> Dict[str, Any]:
     try:
         # Check ollama availability
         ai_engine = AIEngine()
-        ollama_available = ai_engine.check_connection()
+        ollama_available = await ai_engine.check_connection()
     except Exception:
         ollama_available = False
 
@@ -51,7 +50,7 @@ async def get_status() -> Dict[str, Any]:
         db = AllelioDB()
         db_ready = db.is_initialized()
         if db_ready:
-            stats = db.get_statistics()
+            stats = db.get_stats()
             db_stats = {
                 "clinvar_entries": stats.get("clinvar_entries", 0),
                 "gwas_entries": stats.get("gwas_entries", 0),
@@ -125,7 +124,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
 
         # Create AI engine and check connection
         ai_engine = AIEngine()
-        if not ai_engine.check_connection():
+        if not await ai_engine.check_connection():
             raise HTTPException(
                 status_code=503,
                 detail="AI service (Ollama) is not available"
@@ -168,10 +167,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         # Format results
         formatted_results = []
         for i, variant in enumerate(analysis_results):
-            warnings = get_variant_warnings(
-                variant.rsid,
-                variant.genotype if hasattr(variant, 'genotype') else None,
-            )
+            warnings = get_variant_warnings(variant)
             
             result_dict = {
                 "rsid": variant.rsid,

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -180,7 +180,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             )
 
         # Generate executive summary
-        _progress.update(stage="Summarising", done=0, total=0)
+        _progress.update(stage="Summarizing", done=0, total=0)
         try:
             if not ai_available:
                 raise RuntimeError("ollama unavailable")

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -17,7 +17,8 @@ from allelio import __version__
 from allelio.parsers import parse_genotype_file
 from allelio.database.store import AllelioDB
 from allelio.analysis.lookup import analyze_variants
-from allelio.ai.engine import AIEngine
+from allelio.ai.attribution import Explanation, attribution
+from allelio.ai.engine import AIEngine, REFUSED, UNREACHABLE
 from allelio.ai.safety import get_variant_warnings
 from allelio.web.app import templates
 
@@ -35,13 +36,52 @@ async def read_root(request: Request) -> str:
 
 @router.get("/api/status")
 async def get_status() -> Dict[str, Any]:
-    """Get system status including ollama availability and database info."""
+    """System status: which model is answering, and whether the database is built."""
+    # Named, not just "connected": with a model server configurable by
+    # environment, "AI ready" on its own does not tell anyone which model wrote
+    # the explanations they are about to read, or where it is running.
+    ai: Dict[str, Any] = {
+        "available": False,
+        "model_available": False,
+        # The five-way answer the pill switches on. Present even when there is
+        # no engine to ask, because a key that appears only sometimes is a key
+        # the page has to guess about.
+        "status": UNREACHABLE,
+        "provider": None,
+        "model": None,
+        "host": None,
+        "error": None,
+    }
     try:
-        # Check ollama availability
         ai_engine = AIEngine()
-        ollama_available = await ai_engine.check_connection()
+    except ValueError as exc:
+        # A model server that is not on this machine, refused rather than used.
+        # Say that on the page; "disconnected" would send them looking for a
+        # crash that never happened.
+        ai["error"] = str(exc)
+        ai_engine = None
     except Exception:
-        ollama_available = False
+        ai_engine = None
+
+    if ai_engine is not None:
+        await ai_engine.check_connection()
+        ai["available"] = ai_engine.available
+        # "Reachable", "not serving that", "will not say what it serves" and
+        # "nothing there" are four different things to put on a status pill, and
+        # two booleans cannot carry four.
+        ai["status"] = ai_engine.status
+        # A server that answered with a model this tool will not use is not a
+        # server that is down, and the page should not say it is.
+        ai["error"] = ai_engine.refusal
+        # Reachable is not the same as loaded: a server answering with a dozen
+        # models it will happily list, none of them the one configured, would
+        # otherwise show green beside a name that explains nothing.
+        ai["model_available"] = ai_engine.check_model_available()
+        ai["provider"] = ai_engine.provider
+        # Read after check_connection, which is where a server holding a single
+        # model gets to name it.
+        ai["model"] = ai_engine.model
+        ai["host"] = ai_engine.host
 
     # Get database stats
     db_ready = False
@@ -65,11 +105,21 @@ async def get_status() -> Dict[str, Any]:
         pass
 
     return {
-        "ollama_available": ollama_available,
+        "ai": ai,
         "db_ready": db_ready,
         "db_stats": db_stats,
         "version": __version__,
     }
+
+
+def _text_of(explanation) -> str:
+    """The card's text. Nothing was written for it below the top 50."""
+    return explanation.text if explanation is not None else ""
+
+
+def _model_of(explanation) -> Optional[str]:
+    """Who wrote the card, or None — including "nobody asked" below the top 50."""
+    return explanation.model if explanation is not None else None
 
 
 def _gene_of(variant) -> Optional[str]:
@@ -120,6 +170,17 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
     """
     temp_file_path = None
     try:
+        # Settle the model address first. A local model is optional — the README
+        # promises the tool still works without one, minus the plain-English
+        # explanations — but an address that is not on this machine is a refusal,
+        # and it should arrive now rather than half an hour into the analysis.
+        # Construction only parses and resolves; nothing is contacted yet, so an
+        # empty upload still gets its 400 without waiting on a connect timeout.
+        try:
+            ai_engine = AIEngine()
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
         # Validate file
         if not file.filename:
             raise HTTPException(status_code=400, detail="No filename provided")
@@ -127,6 +188,18 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         content = await file.read()
         if not content:
             raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+        await ai_engine.check_connection()
+        # Refused, not unreachable: the same answer construction gives a remote
+        # address, for the same reason. Reporting it as a run with no
+        # explanations would hide why there are none.
+        if ai_engine.status == REFUSED:
+            raise HTTPException(status_code=400, detail=ai_engine.refusal)
+        # Nothing to switch off here any more. A listing that contradicts the
+        # configured name, a server that is not there, and one that will not
+        # enumerate are all answered by engine.will_explain(), which explain
+        # and generate_summary ask themselves — so no caller has to reach in and
+        # set `available = False` to keep a prompt from going out.
 
         # The multipart filename is raw header data: "../../../.zshenv" resolves
         # out of the temp directory, and multipart is CORS-safelisted, so any
@@ -172,11 +245,6 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 detail="No variants found in database"
             )
 
-        # Create AI engine. Ollama is optional — the README promises the tool
-        # still works without it, minus the plain-English explanations.
-        ai_engine = AIEngine()
-        ai_available = await ai_engine.check_connection()
-
         # analyze_variants already returns these most-significant-first, so the
         # top 50 are the 50 worth spending an AI call on.
         top_variants = analysis_results[:50]
@@ -190,6 +258,8 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         def on_explained(done: int, total: int) -> None:
             _progress.update(done=done, total=total)
 
+        # rsID -> Explanation. The credit rides on the card from here to the
+        # browser; nothing else on this payload decides who wrote what.
         explanations = await ai_engine.explain_variants_batch(
             top_variants, progress_callback=on_explained
         )
@@ -197,8 +267,8 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         # Generate executive summary
         _progress.update(stage="Summarizing", done=0, total=0)
         try:
-            if not ai_available:
-                raise RuntimeError("ollama unavailable")
+            if not ai_engine.will_explain():
+                raise RuntimeError("no model server answering")
             summary = await ai_engine.generate_summary(top_variants)
         except Exception:
             summary = ("AI summary unavailable. Variant findings below come "
@@ -217,7 +287,11 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 "genotype": variant.genotype if hasattr(variant, 'genotype') else None,
                 "category": variant.category if hasattr(variant, 'category') else "Unknown",
                 "significance_rank": i + 1,
-                "explanation": explanations.get(variant.rsid, ""),
+                "explanation": _text_of(explanations.get(variant.rsid)),
+                # Null on a card the model did not write. The page reads this
+                # and nothing else: a card cannot be credited to a model that
+                # did not write it, because the credit is on the card.
+                "explained_by": _model_of(explanations.get(variant.rsid)),
                 "gene": _gene_of(variant),
                 "significance": _significance_of(variant),
                 "pubmed_id": next(
@@ -233,6 +307,10 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             "results": formatted_results,
             "total_variants": len(analysis_results),
             "analyzed_at": _get_timestamp(),
+            # Counted off the cards above, for the saved-analysis report and
+            # for anything reading the payload that is not the page. "none" is
+            # a run where no card was written by a model.
+            "model_used": attribution(explanations).model or "none",
         }
         return payload
 
@@ -449,9 +527,39 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     total_variants = escape(str(analysis_data.get("total_variants", 0)))
     analyzed_at = escape(str(analysis_data.get("analyzed_at") or "Unknown"))
 
+    # The table below stops at a hundred rows, and this line describes the rows
+    # underneath it rather than the run they came from — so it is counted off
+    # the same hundred. Counted off all of them, a genome with four hundred
+    # significant variants reads "340 of 512" over a table holding a hundred.
+    rows = results[:100]
+
+    # Counted off the cards in the payload, by the same rule the analysis used
+    # when it wrote them.
+    cards = [r for r in rows if isinstance(r, dict)]
+    if any("explained_by" in r for r in cards):
+        credit = attribution({
+            # Keyed by position: two rows with one rsID would otherwise count
+            # as one.
+            i: Explanation(str(r.get("explanation") or ""), r.get("explained_by"))
+            for i, r in enumerate(cards)
+        })
+        model_used = (
+            f"{escape(str(credit.model))} "
+            f"({credit.written} of {credit.total} explanations)"
+            if credit.model
+            else "none"
+        )
+    elif analysis_data.get("model_used"):
+        # Saved before the cards carried their own credit: one name for the
+        # whole run is all there is, and it is reported as that.
+        model_used = escape(str(analysis_data["model_used"])) + " (whole run)"
+    else:
+        # Saved before even that. Not "no model" — nobody wrote it down.
+        model_used = "not recorded"
+
     # Build results table HTML
     results_html = ""
-    for result in results[:100]:  # Limit to first 100 for report
+    for result in rows:
         # These come from the uploaded file and the model, and the report is
         # opened in a browser — none of it is trusted markup.
         def field(name):
@@ -466,7 +574,7 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
 
         # The safety layer computes these for BRCA1/2, TP53, Lynch and APOE.
         # A report that omits them is the one place they matter most.
-        # explain_variant folds these into the explanation via
+        # explain folds these into the explanation via
         # wrap_with_disclaimer — but only on the path where the model answered.
         # A fallback explanation carries no warning, so test the text itself.
         explanation_text = str(result.get("explanation") or "")
@@ -548,6 +656,7 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         <div class="metadata">
             <p><strong>Analysis Date:</strong> {analyzed_at}</p>
             <p><strong>Total Variants Analyzed:</strong> {total_variants}</p>
+            <p><strong>AI Model:</strong> {model_used}</p>
         </div>
         
         <h2>Executive Summary</h2>

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -4,7 +4,7 @@ import asyncio
 import tempfile
 from html import escape
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 
 from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
@@ -12,7 +12,7 @@ from fastapi.responses import FileResponse, HTMLResponse
 from allelio import __version__
 from allelio.parsers import parse_genotype_file
 from allelio.database.store import AllelioDB
-from allelio.analysis.lookup import analyze_variants, VariantResult
+from allelio.analysis.lookup import analyze_variants
 from allelio.ai.engine import AIEngine
 from allelio.ai.safety import get_variant_warnings
 from allelio.web.app import templates
@@ -285,17 +285,6 @@ async def export_report(analysis_data: Dict[str, Any]) -> FileResponse:
         )
 
 
-def _get_top_categories(results: List[VariantResult]) -> List[str]:
-    """Extract top categories from analysis results."""
-    categories = {}
-    for result in results:
-        category = result.category if hasattr(result, 'category') else "Unknown"
-        categories[category] = categories.get(category, 0) + 1
-    
-    sorted_cats = sorted(categories.items(), key=lambda x: x[1], reverse=True)
-    return [cat[0] for cat in sorted_cats[:5]]
-
-
 def _get_timestamp() -> str:
     """Get current timestamp in ISO format."""
     from datetime import datetime
@@ -306,8 +295,8 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     """Generate HTML report from analysis data."""
     summary = escape(str(analysis_data.get("summary") or "No summary available"))
     results = analysis_data.get("results", [])
-    total_variants = analysis_data.get("total_variants", 0)
-    analyzed_at = analysis_data.get("analyzed_at", "Unknown")
+    total_variants = escape(str(analysis_data.get("total_variants", 0)))
+    analyzed_at = escape(str(analysis_data.get("analyzed_at") or "Unknown"))
 
     # Build results table HTML
     results_html = ""

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -1,6 +1,7 @@
 """API routes for Allelio web interface."""
 
 import asyncio
+import os
 import tempfile
 from html import escape
 from pathlib import Path
@@ -8,6 +9,7 @@ from typing import Dict, Any, Optional
 
 from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
+from starlette.background import BackgroundTask
 
 from allelio import __version__
 from allelio.parsers import parse_genotype_file
@@ -80,20 +82,24 @@ def _gene_of(variant) -> Optional[str]:
 
 
 def _significance_of(variant) -> str:
-    """Bucket a result into the four badges the results list knows how to draw."""
+    """Bucket a result into the badges the results list knows how to draw.
+
+    ClinVar has the last word. "Conflicting classifications of pathogenicity"
+    is 130,833 rsIDs and sorts to the very top of the report, so it needs to
+    say so rather than borrow either neighbour's colour.
+    """
     for entry in (variant.clinvar_entries or []):
         significance = (entry.clinical_significance or "").lower()
         if "conflicting" in significance:
-            continue
+            return "conflicting"
         if "pathogenic" in significance and "benign" not in significance:
             return "pathogenic"
+        if "benign" in significance:
+            return "benign"
         if "risk" in significance:
             return "risk"
     if variant.gwas_entries:
         return "risk"
-    for entry in (variant.clinvar_entries or []):
-        if "benign" in (entry.clinical_significance or "").lower():
-            return "benign"
     return "trait"
 
 
@@ -166,18 +172,16 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
 
         # Generate AI explanations for significant variants. One call per
         # variant, run a few at a time — sequentially this took 12 minutes.
-        explanations = {}
-        if ai_available:
-            _progress.update(
-                stage="Writing explanations", done=0, total=len(top_variants)
-            )
+        _progress.update(
+            stage="Writing explanations", done=0, total=len(top_variants)
+        )
 
-            def on_explained(done: int, total: int) -> None:
-                _progress.update(done=done, total=total)
+        def on_explained(done: int, total: int) -> None:
+            _progress.update(done=done, total=total)
 
-            explanations = await ai_engine.explain_variants_batch(
-                top_variants, progress_callback=on_explained
-            )
+        explanations = await ai_engine.explain_variants_batch(
+            top_variants, progress_callback=on_explained
+        )
 
         # Generate executive summary
         _progress.update(stage="Summarizing", done=0, total=0)
@@ -263,17 +267,20 @@ async def export_report(analysis_data: Dict[str, Any]) -> FileResponse:
         # Generate HTML report (using report generator when available)
         html_content = _generate_html_report(analysis_data)
 
-        # Create temp file for report
-        temp_dir = tempfile.gettempdir()
-        temp_report_path = Path(temp_dir) / f"allelio_report_{_get_timestamp()}.html"
-
-        with open(temp_report_path, "w") as f:
+        # mkstemp gives the file 0600, and the report holds the user's
+        # genotypes. Explicit encoding because the report declares UTF-8 and
+        # the model writes em dashes.
+        fd, temp_report_path = tempfile.mkstemp(
+            prefix="allelio_report_", suffix=".html"
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(html_content)
 
         return FileResponse(
-            path=str(temp_report_path),
+            path=temp_report_path,
             filename=f"allelio_report_{_get_timestamp()}.html",
             media_type="text/html",
+            background=BackgroundTask(_unlink, temp_report_path),
         )
 
     except HTTPException:
@@ -283,6 +290,14 @@ async def export_report(analysis_data: Dict[str, Any]) -> FileResponse:
             status_code=500,
             detail=f"Report generation failed: {str(e)}"
         )
+
+
+def _unlink(path: str) -> None:
+    """Remove the exported report once it has been sent."""
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
 
 
 def _get_timestamp() -> str:
@@ -312,7 +327,14 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         genotype = field("genotype")
         category = field("category")
         explanation = field("explanation")
-        
+
+        # The safety layer computes these for BRCA1/2, TP53, Lynch and APOE.
+        # A report that omits them is the one place they matter most.
+        warnings = "".join(
+            f'<p class="warning">{escape(str(w))}</p>'
+            for w in (result.get("warnings") or [])
+        )
+
         results_html += f"""
         <tr>
             <td>{rsid}</td>
@@ -320,7 +342,7 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
             <td>{pos}</td>
             <td>{genotype}</td>
             <td>{category}</td>
-            <td>{explanation}</td>
+            <td>{explanation}{warnings}</td>
         </tr>
         """
 
@@ -331,6 +353,13 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         <meta charset="UTF-8">
         <title>Allelio Analysis Report</title>
         <style>
+            .warning {{
+                margin: 0.5em 0 0;
+                padding: 0.5em;
+                border-left: 3px solid #B45309;
+                background: #FEF3C7;
+                color: #78350F;
+            }}
             body {{
                 font-family: Arial, sans-serif;
                 margin: 20px;

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -101,10 +101,11 @@ def _significance_of(variant) -> str:
         if "risk" in significance:
             return "risk"
     if variant.gwas_entries:
-        # A GWAS row on its own is an association, not a risk — 37,108 of the
-        # 62,057 findings on a real genome. The analyser has already read the
-        # trait text and decided which of them are risk factors.
-        return "risk" if variant.category == "Risk Factors" else "trait"
+        # A GWAS row on its own is an association and nothing stronger — 37,108
+        # of the 62,057 findings on a real genome. Calling them all a risk
+        # over-states every one; calling them all a trait quietly demotes type 2
+        # diabetes and coronary artery disease. Say what the row actually is.
+        return "association"
     return "trait"
 
 
@@ -202,7 +203,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                        "straight from ClinVar and the GWAS Catalog.")
 
         # Format results
-        _progress.update(stage="Building your report")
+        _progress.update(stage="Building your report", done=0, total=0)
         formatted_results = []
         for i, variant in enumerate(analysis_results):
             warnings = get_variant_warnings(variant)
@@ -338,11 +339,14 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
 
         # The safety layer computes these for BRCA1/2, TP53, Lynch and APOE.
         # A report that omits them is the one place they matter most.
-        # explain_variant runs these through wrap_with_disclaimer, so for the
-        # variants that got an explanation they are already in it.
-        warnings = "" if result.get("explanation") else "".join(
+        # explain_variant folds these into the explanation via
+        # wrap_with_disclaimer — but only on the path where the model answered.
+        # A fallback explanation carries no warning, so test the text itself.
+        explanation_text = str(result.get("explanation") or "")
+        warnings = "".join(
             f'<p class="warning">{escape(str(w))}</p>'
             for w in (result.get("warnings") or [])
+            if str(w) not in explanation_text
         )
 
         results_html += f"""

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -1,6 +1,8 @@
 """API routes for Allelio web interface."""
 
 import asyncio
+import json
+import os
 import tempfile
 from pathlib import Path
 from typing import List, Dict, Any, Optional
@@ -91,6 +93,8 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         with open(temp_file_path, "wb") as f:
             f.write(content)
 
+        _progress.update(stage="Reading your file", done=0, total=0)
+
         # Parse genotype file
         loop = asyncio.get_event_loop()
         genotypes = await loop.run_in_executor(
@@ -112,6 +116,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             )
 
         # Analyze variants
+        _progress.update(stage=f"Matching {len(genotypes):,} variants against ClinVar and GWAS")
         analysis_results = await loop.run_in_executor(
             None, analyze_variants, genotypes, db
         )
@@ -122,13 +127,10 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 detail="No variants found in database"
             )
 
-        # Create AI engine and check connection
+        # Create AI engine. Ollama is optional — the README promises the tool
+        # still works without it, minus the plain-English explanations.
         ai_engine = AIEngine()
-        if not await ai_engine.check_connection():
-            raise HTTPException(
-                status_code=503,
-                detail="AI service (Ollama) is not available"
-            )
+        ai_available = await ai_engine.check_connection()
 
         # Get top 50 significant variants
         sorted_results = sorted(
@@ -138,33 +140,33 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         )
         top_variants = sorted_results[:50]
 
-        # Generate AI explanations for significant variants
+        # Generate AI explanations for significant variants. One call per
+        # variant, run a few at a time — sequentially this took 12 minutes.
         explanations = {}
-        for i, variant in enumerate(top_variants):
-            try:
-                explanation = await ai_engine.generate_explanation(
-                    variant.rsid,
-                    variant.chromosome,
-                    variant.position,
-                    variant.genotype,
-                    variant.clinvar_data if hasattr(variant, 'clinvar_data') else None,
-                    variant.gwas_data if hasattr(variant, 'gwas_data') else None,
-                )
-                explanations[variant.rsid] = explanation
-            except Exception:
-                explanations[variant.rsid] = "Explanation generation failed"
+        if ai_available:
+            _progress.update(
+                stage="Writing explanations", done=0, total=len(top_variants)
+            )
+
+            def on_explained(done: int, total: int) -> None:
+                _progress.update(done=done, total=total)
+
+            explanations = await ai_engine.explain_variants_batch(
+                top_variants, progress_callback=on_explained
+            )
 
         # Generate executive summary
+        _progress.update(stage="Summarising", done=0, total=0)
         try:
-            summary = await ai_engine.generate_summary(
-                total_variants=len(analysis_results),
-                significant_variants=len(top_variants),
-                top_categories=_get_top_categories(analysis_results),
-            )
+            if not ai_available:
+                raise RuntimeError("ollama unavailable")
+            summary = await ai_engine.generate_summary(top_variants)
         except Exception:
-            summary = "Unable to generate summary at this time"
+            summary = ("AI summary unavailable. Variant findings below come "
+                       "straight from ClinVar and the GWAS Catalog.")
 
         # Format results
+        _progress.update(stage="Building your report")
         formatted_results = []
         for i, variant in enumerate(analysis_results):
             warnings = get_variant_warnings(variant)
@@ -183,12 +185,14 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             }
             formatted_results.append(result_dict)
 
-        return {
+        payload = {
             "summary": summary,
             "results": formatted_results,
             "total_variants": len(analysis_results),
             "analyzed_at": _get_timestamp(),
         }
+        _save_last_analysis(payload)
+        return payload
 
     except HTTPException:
         raise
@@ -199,11 +203,42 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         )
     finally:
         # Clean up temp file
+        _progress.update(stage="idle", done=0, total=0)
         if temp_file_path and Path(temp_file_path).exists():
             try:
                 Path(temp_file_path).unlink()
             except Exception:
                 pass
+
+
+LAST_ANALYSIS_PATH = Path(os.path.expanduser("~/.allelio/last_analysis.json"))
+
+# A whole-genome run takes minutes. Without real numbers the page looks hung,
+# so the analyse route publishes its stage here and the browser polls it.
+_progress: Dict[str, Any] = {"stage": "idle", "done": 0, "total": 0}
+
+
+@router.get("/api/progress")
+async def get_progress() -> Dict[str, Any]:
+    """Where the current analysis has got to."""
+    return _progress
+
+
+def _save_last_analysis(payload: Dict[str, Any]) -> None:
+    """Keep the most recent run so a page reload does not mean a re-upload."""
+    try:
+        LAST_ANALYSIS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        LAST_ANALYSIS_PATH.write_text(json.dumps(payload))
+    except Exception:
+        pass
+
+
+@router.get("/api/last")
+async def get_last_analysis() -> Dict[str, Any]:
+    """Return the most recent analysis, or 404 if there has not been one."""
+    if not LAST_ANALYSIS_PATH.exists():
+        raise HTTPException(status_code=404, detail="No previous analysis")
+    return json.loads(LAST_ANALYSIS_PATH.read_text())
 
 
 @router.post("/api/export")

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -1,8 +1,10 @@
 """API routes for Allelio web interface."""
 
 import asyncio
+import json
 import os
 import tempfile
+from datetime import datetime
 from html import escape
 from pathlib import Path
 from typing import Dict, Any, Optional
@@ -302,16 +304,141 @@ async def export_report(analysis_data: Dict[str, Any]) -> FileResponse:
 
 
 def _unlink(path: str) -> None:
-    """Remove the exported report once it has been sent."""
+    """Delete a file we are done with, where failing to is not worth reporting."""
     try:
         os.unlink(path)
     except OSError:
         pass
 
 
+# A whole-genome run is half an hour, and the results only live in the tab that
+# ran it — a reload throws them away. Saving is opt-in and stays on this
+# machine: the file is the user's genome and never leaves it.
+SAVED_ANALYSIS_PATH = os.path.expanduser("~/.allelio/last_analysis.json")
+
+
+# No lock around any of this, and none needed: every writer gets its own mkstemp
+# temp file, os.replace is atomic, and the delete treats "already gone" as
+# success. Concurrent saves and deletes can only order differently, never tear.
+def _write_saved_analysis(analysis_data: Dict[str, Any]) -> None:
+    """Write the saved analysis atomically, readable only by its owner."""
+    directory = os.path.dirname(SAVED_ANALYSIS_PATH)
+    # 0700 only bites when this creates the directory; ~/.allelio usually
+    # already exists for the database, and silently tightening a directory
+    # this module does not own is not this feature's call to make.
+    os.makedirs(directory, mode=0o700, exist_ok=True)
+
+    # Same directory so os.replace stays on one filesystem, and mkstemp so a
+    # crash mid-write leaves the previous save intact rather than a half file.
+    fd, temp_path = tempfile.mkstemp(prefix=".last_analysis_", dir=directory)
+    try:
+        # os.fdopen owns the descriptor once it succeeds; if it raises, nothing
+        # else is going to close it.
+        try:
+            handle = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with handle as f:
+            json.dump(analysis_data, f)
+            # os.replace orders this rename against other renames, not against
+            # the data blocks. Without the fsync a power cut can land the
+            # rename and lose the contents — the truncated file this whole
+            # dance exists to prevent.
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temp_path, SAVED_ANALYSIS_PATH)
+    except BaseException:
+        # BaseException on purpose: a KeyboardInterrupt here would otherwise
+        # strand 15 MB of genotypes under a dotfile name nothing cleans up.
+        _unlink(temp_path)
+        raise
+
+
+def _read_saved_analysis() -> Optional[Dict[str, Any]]:
+    """Return the saved analysis, or None if there isn't a usable one."""
+    try:
+        with open(SAVED_ANALYSIS_PATH, encoding="utf-8") as f:
+            analysis_data = json.load(f)
+    except (OSError, ValueError):
+        # Missing, unreadable, or truncated by a crash mid-write. Any of those
+        # means "nothing to restore" — none of them should wedge the page.
+        return None
+    # A file holding a valid JSON list, string or number parses fine and then
+    # fails serialisation on the way out as a 500. It is not a saved analysis.
+    return analysis_data if isinstance(analysis_data, dict) else None
+
+
+@router.get("/api/saved")
+async def get_saved_analysis_info() -> Dict[str, Any]:
+    """Whether there is a saved analysis worth offering to restore."""
+    try:
+        saved_at = os.path.getmtime(SAVED_ANALYSIS_PATH)
+    except OSError:
+        return {"saved": False, "saved_at": None}
+    # Reading it to answer costs a parse of 15 MB on every page load, so the
+    # banner is offered on the strength of the file existing. /api/saved/data
+    # is the one that can still say no; the page handles that.
+    return {
+        "saved": True,
+        "saved_at": datetime.fromtimestamp(saved_at).isoformat(timespec="seconds"),
+    }
+
+
+@router.get("/api/saved/data")
+async def get_saved_analysis() -> Dict[str, Any]:
+    """The saved analysis itself, for restoring the results view."""
+    analysis_data = await asyncio.to_thread(_read_saved_analysis)
+    if analysis_data is None:
+        raise HTTPException(status_code=404, detail="No saved analysis")
+    return analysis_data
+
+
+@router.post("/api/saved")
+async def save_analysis(analysis_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Save the current analysis to this machine, at the user's request."""
+    if not analysis_data:
+        raise HTTPException(status_code=400, detail="No analysis data provided")
+
+    try:
+        # A whole genome is 15 MB of JSON and encoding it takes a quarter of a
+        # second, which on the event loop is a quarter of a second nothing else
+        # is served. FastAPI has already spent its own on decoding the body;
+        # this is the half we get to move off.
+        await asyncio.to_thread(_write_saved_analysis, analysis_data)
+    except (OSError, TypeError, ValueError):
+        # The path is under the user's home directory — saying which home is
+        # not the browser's business.
+        raise HTTPException(status_code=500, detail="Could not save the analysis")
+
+    return {"saved": True}
+
+
+def _delete_saved_analysis() -> None:
+    """Remove the saved analysis. Absent already is success, not an error."""
+    try:
+        os.unlink(SAVED_ANALYSIS_PATH)
+    except FileNotFoundError:
+        pass
+
+
+@router.delete("/api/saved")
+async def delete_saved_analysis() -> Dict[str, Any]:
+    """Forget the saved analysis, and only say so if it is really gone."""
+    try:
+        await asyncio.to_thread(_delete_saved_analysis)
+    except OSError:
+        # The page says "deleted" on any 200. Reporting success over a genome
+        # file still sitting on the disk is the one lie this feature cannot
+        # afford.
+        raise HTTPException(
+            status_code=500, detail="Could not delete the saved analysis"
+        )
+    return {"saved": False}
+
+
 def _get_timestamp() -> str:
     """Get current timestamp in ISO format."""
-    from datetime import datetime
     return datetime.now().isoformat().replace(":", "-").split(".")[0]
 
 

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -367,6 +367,9 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         <meta charset="UTF-8">
         <title>Allelio Analysis Report</title>
         <style>
+            td {{
+                white-space: pre-wrap;
+            }}
             .warning {{
                 margin: 0.5em 0 0;
                 padding: 0.5em;

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -1,9 +1,8 @@
 """API routes for Allelio web interface."""
 
 import asyncio
-import json
-import os
 import tempfile
+from html import escape
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
@@ -84,6 +83,8 @@ def _significance_of(variant) -> str:
     """Bucket a result into the four badges the results list knows how to draw."""
     for entry in (variant.clinvar_entries or []):
         significance = (entry.clinical_significance or "").lower()
+        if "conflicting" in significance:
+            continue
         if "pathogenic" in significance and "benign" not in significance:
             return "pathogenic"
         if "risk" in significance:
@@ -159,13 +160,9 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         ai_engine = AIEngine()
         ai_available = await ai_engine.check_connection()
 
-        # Get top 50 significant variants
-        sorted_results = sorted(
-            analysis_results,
-            key=lambda x: x.significance_score if hasattr(x, 'significance_score') else 0,
-            reverse=True
-        )
-        top_variants = sorted_results[:50]
+        # analyze_variants already returns these most-significant-first, so the
+        # top 50 are the 50 worth spending an AI call on.
+        top_variants = analysis_results[:50]
 
         # Generate AI explanations for significant variants. One call per
         # variant, run a few at a time — sequentially this took 12 minutes.
@@ -222,7 +219,6 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             "total_variants": len(analysis_results),
             "analyzed_at": _get_timestamp(),
         }
-        _save_last_analysis(payload)
         return payload
 
     except HTTPException:
@@ -242,8 +238,6 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 pass
 
 
-LAST_ANALYSIS_PATH = Path(os.path.expanduser("~/.allelio/last_analysis.json"))
-
 # A whole-genome run takes minutes. Without real numbers the page looks hung,
 # so the analyse route publishes its stage here and the browser polls it.
 _progress: Dict[str, Any] = {"stage": "idle", "done": 0, "total": 0}
@@ -253,23 +247,6 @@ _progress: Dict[str, Any] = {"stage": "idle", "done": 0, "total": 0}
 async def get_progress() -> Dict[str, Any]:
     """Where the current analysis has got to."""
     return _progress
-
-
-def _save_last_analysis(payload: Dict[str, Any]) -> None:
-    """Keep the most recent run so a page reload does not mean a re-upload."""
-    try:
-        LAST_ANALYSIS_PATH.parent.mkdir(parents=True, exist_ok=True)
-        LAST_ANALYSIS_PATH.write_text(json.dumps(payload))
-    except Exception:
-        pass
-
-
-@router.get("/api/last")
-async def get_last_analysis() -> Dict[str, Any]:
-    """Return the most recent analysis, or 404 if there has not been one."""
-    if not LAST_ANALYSIS_PATH.exists():
-        raise HTTPException(status_code=404, detail="No previous analysis")
-    return json.loads(LAST_ANALYSIS_PATH.read_text())
 
 
 @router.post("/api/export")
@@ -327,7 +304,7 @@ def _get_timestamp() -> str:
 
 def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     """Generate HTML report from analysis data."""
-    summary = analysis_data.get("summary", "No summary available")
+    summary = escape(str(analysis_data.get("summary") or "No summary available"))
     results = analysis_data.get("results", [])
     total_variants = analysis_data.get("total_variants", 0)
     analyzed_at = analysis_data.get("analyzed_at", "Unknown")
@@ -335,12 +312,17 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     # Build results table HTML
     results_html = ""
     for result in results[:100]:  # Limit to first 100 for report
-        rsid = result.get("rsid", "N/A")
-        chrom = result.get("chromosome", "N/A")
-        pos = result.get("position", "N/A")
-        genotype = result.get("genotype", "N/A")
-        category = result.get("category", "N/A")
-        explanation = result.get("explanation", "N/A")
+        # These come from the uploaded file and the model, and the report is
+        # opened in a browser — none of it is trusted markup.
+        def field(name):
+            return escape(str(result.get(name) or "N/A"))
+
+        rsid = field("rsid")
+        chrom = field("chromosome")
+        pos = field("position")
+        genotype = field("genotype")
+        category = field("category")
+        explanation = field("explanation")
         
         results_html += f"""
         <tr>

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -867,39 +867,7 @@
         document.addEventListener('DOMContentLoaded', () => {
             setupEventListeners();
             fetchStatus();
-            loadLastAnalysis();
         });
-
-        // Restore the previous run so a reload does not require re-uploading.
-        async function loadLastAnalysis() {
-            try {
-                const response = await fetch('/api/last');
-                if (!response.ok) return;
-                analysisResults = await response.json();
-                displayResults();
-                document.getElementById('resultsSection').classList.remove('hidden');
-                // A restored run is finished: no progress bar, no upload prompt.
-                document.getElementById('progressSection').classList.add('hidden');
-                // Hide the upload panel so a finished run does not look like a
-                // prompt, but leave one way back to it.
-                const upload = document.getElementById('uploadSection');
-                if (upload) {
-                    upload.classList.add('hidden');
-                    const again = document.createElement('button');
-                    again.className = 'export-button';
-                    again.textContent = 'Analyze another file';
-                    again.style.cssText = 'display:block;margin:0 auto 1.5rem;';
-                    again.onclick = () => {
-                        upload.classList.remove('hidden');
-                        again.remove();
-                    };
-                    const results = document.getElementById('resultsSection');
-                    results.parentNode.insertBefore(again, results);
-                }
-            } catch (e) {
-                // No previous run — the upload panel stands on its own.
-            }
-        }
 
         // Setup Event Listeners
         function setupEventListeners() {
@@ -1046,6 +1014,21 @@
         }
 
         // Display Results
+        // Result fields are read out of the uploaded file or written by the
+        // model; neither is trusted markup.
+        function esc(value) {
+            if (value === null || value === undefined) return '';
+            const div = document.createElement('div');
+            div.textContent = value;
+            return div.innerHTML;
+        }
+
+        // ClinVar and PubMed IDs land inside a URL, where escaping HTML is not
+        // enough — anything but digits is not an ID.
+        function idFor(value) {
+            return /^\d+$/.test(String(value ?? '')) ? String(value) : '';
+        }
+
         // "Health Conditions" -> "health_conditions"
         function slugify(category) {
             return (category || '').toLowerCase().replace(/ /g, '_');
@@ -1063,10 +1046,11 @@
             }
 
             // Create Category Tabs
-            const categories = ['all', 'health_conditions', 'risk_factors', 'pharmacogenomics', 'traits'];
+            const categories = ['all', 'health_conditions', 'carrier_status', 'risk_factors', 'pharmacogenomics', 'traits'];
             const categoryLabels = {
                 'all': 'All',
                 'health_conditions': 'Health Conditions',
+                'carrier_status': 'Carrier Status',
                 'risk_factors': 'Risk Factors',
                 'pharmacogenomics': 'Pharmacogenomics',
                 'traits': 'Traits'
@@ -1141,6 +1125,7 @@
 
             const categoryBadgeClass = {
                 'health_conditions': 'badge-category',
+                'carrier_status': 'badge-category',
                 'risk_factors': 'badge-category',
                 'pharmacogenomics': 'badge-category',
                 'traits': 'badge-category'
@@ -1149,20 +1134,20 @@
             card.innerHTML = `
                 <div class="result-header">
                     <div class="result-title">
-                        <div class="result-rsid">${result.rsid}</div>
-                        <div class="result-gene">${result.gene || 'Gene: Unknown'}</div>
+                        <div class="result-rsid">${esc(result.rsid)}</div>
+                        <div class="result-gene">${esc(result.gene) || 'Gene: Unknown'}</div>
                         <div class="result-meta">
-                            <span class="badge ${categoryBadgeClass}">${result.category.replace('_', ' ')}</span>
-                            <span class="badge ${significanceBadgeClass}">${significance}</span>
+                            <span class="badge ${categoryBadgeClass}">${esc(result.category).replace('_', ' ')}</span>
+                            <span class="badge ${significanceBadgeClass}">${esc(significance)}</span>
                         </div>
                     </div>
-                    <div class="result-genotype">${result.genotype}</div>
+                    <div class="result-genotype">${esc(result.genotype)}</div>
                 </div>
                 <div class="result-body">
-                    <div class="result-explanation">${result.explanation || 'No explanation available.'}</div>
+                    <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
                     <div class="result-sources">
-                        ${result.clinvar_id ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/${result.clinvar_id}/" target="_blank" class="source-link">ClinVar</a>` : ''}
-                        ${result.pubmed_id ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${result.pubmed_id}/" target="_blank" class="source-link">PubMed</a>` : ''}
+                        ${idFor(result.clinvar_id) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/${idFor(result.clinvar_id)}/" target="_blank" class="source-link">ClinVar</a>` : ''}
+                        ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" class="source-link">PubMed</a>` : ''}
                     </div>
                 </div>
             `;

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1046,14 +1046,15 @@
             }
 
             // Create Category Tabs
-            const categories = ['all', 'health_conditions', 'carrier_status', 'risk_factors', 'pharmacogenomics', 'traits'];
+            const categories = ['all', 'health_conditions', 'carrier_status', 'risk_factors', 'pharmacogenomics', 'traits', 'unknown'];
             const categoryLabels = {
                 'all': 'All',
                 'health_conditions': 'Health Conditions',
                 'carrier_status': 'Carrier Status',
                 'risk_factors': 'Risk Factors',
                 'pharmacogenomics': 'Pharmacogenomics',
-                'traits': 'Traits'
+                'traits': 'Traits',
+                'unknown': 'Uncategorized'
             };
 
             const tabsContainer = document.getElementById('resultsTabs');
@@ -1062,6 +1063,7 @@
             categories.forEach(cat => {
                 const button = document.createElement('button');
                 button.className = 'tab-button' + (cat === 'all' ? ' active' : '');
+                button.dataset.category = cat;
                 button.textContent = categoryLabels[cat];
                 button.addEventListener('click', () => selectCategory(cat));
                 tabsContainer.appendChild(button);
@@ -1075,9 +1077,11 @@
         function selectCategory(category) {
             currentCategory = category;
 
-            // Update active tab
-            document.querySelectorAll('.tab-button').forEach((btn, idx) => {
-                btn.classList.toggle('active', btn.textContent === document.querySelectorAll('.tab-button')[['all', 'health_conditions', 'risk_factors', 'pharmacogenomics', 'traits'].indexOf(category)].textContent);
+            // Update active tab. This used to look the tab up by position in a
+            // second, hardcoded category list; anything missing from that list
+            // indexed to -1 and threw.
+            document.querySelectorAll('.tab-button').forEach(btn => {
+                btn.classList.toggle('active', btn.dataset.category === category);
             });
 
             renderResultCards();
@@ -1126,6 +1130,7 @@
             const categoryBadgeClass = {
                 'health_conditions': 'badge-category',
                 'carrier_status': 'badge-category',
+                'unknown': 'badge-category',
                 'risk_factors': 'badge-category',
                 'pharmacogenomics': 'badge-category',
                 'traits': 'badge-category'

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -653,6 +653,16 @@
             color: #D1D5DB;
         }
 
+        .result-credit {
+            margin-bottom: 1rem;
+            font-size: 0.8rem;
+            color: var(--gray-600);
+        }
+
+        body.dark-mode .result-credit {
+            color: #9CA3AF;
+        }
+
         .result-warning {
             margin-top: 0.75rem;
             padding: 0.75rem;
@@ -921,10 +931,10 @@
                 </div>
             </div>
             <div class="status-item">
-                <div class="status-indicator" id="ollamaIndicator"></div>
+                <div class="status-indicator" id="aiIndicator"></div>
                 <div class="status-text">
-                    <div class="status-label">Ollama Status</div>
-                    <div class="status-value" id="ollamaStatus">Loading...</div>
+                    <div class="status-label">AI Model</div>
+                    <div class="status-value" id="aiStatus">Loading...</div>
                 </div>
             </div>
         </div>
@@ -970,6 +980,10 @@
                 <div class="summary-title">Analysis Summary</div>
                 <div class="summary-text" id="summaryText"></div>
             </div>
+
+            <!-- Who wrote the explanations below, for this run. The status pill
+                 at the top is read once at page load and can be stale by now. -->
+            <div class="summary-text" id="modelUsed" style="display: none;"></div>
 
             <!-- Category Tabs -->
             <div class="results-tabs" id="resultsTabs"></div>
@@ -1067,15 +1081,36 @@
                     dbStatus.textContent = 'Database Not Set Up';
                 }
 
-                // Update Ollama Status
-                const ollamaIndicator = document.getElementById('ollamaIndicator');
-                const ollamaStatus = document.getElementById('ollamaStatus');
-                if (data.ollama_available) {
-                    ollamaIndicator.classList.add('connected');
-                    ollamaStatus.textContent = 'Ollama Connected';
+                // The model by name, not just "connected": the explanations
+                // below are written by whatever this says, and which model wrote
+                // them is the difference between two very different reports.
+                const ai = data.ai || {};
+                const aiIndicator = document.getElementById('aiIndicator');
+                const aiStatus = document.getElementById('aiStatus');
+                const aiItem = aiIndicator.parentElement;
+                // Five states, from the one word the engine answers with. The
+                // dot used to follow the listing, so a server that will not
+                // enumerate its models — a bare llama.cpp has no /v1/models at
+                // all — showed red beside a model that was about to write every
+                // explanation on the page.
+                const serving = ai.status === 'serving';
+                const unlisted = ai.status === 'unlisted';
+                aiIndicator.classList.toggle('connected', serving || unlisted);
+                if (serving) {
+                    aiStatus.textContent = `${ai.model} · ${ai.provider}`;
+                    aiItem.title = `${ai.model} running on ${ai.provider} at ${ai.host}`;
+                } else if (unlisted) {
+                    aiStatus.textContent = `${ai.model} · ${ai.provider}`;
+                    aiItem.title = `${ai.provider} at ${ai.host} did not list its models, so this is the name it will be asked for`;
+                } else if (ai.status === 'refuted') {
+                    aiStatus.textContent = `${ai.model} not in this server's list`;
+                    aiItem.title = `${ai.provider} answered at ${ai.host}, but it is not serving ${ai.model}`;
+                } else if (ai.error) {
+                    aiStatus.textContent = 'Model server refused';
+                    aiItem.title = ai.error;
                 } else {
-                    ollamaIndicator.classList.remove('connected');
-                    ollamaStatus.textContent = 'Ollama Disconnected';
+                    aiStatus.textContent = 'No model connected';
+                    aiItem.title = ai.host ? `Nothing answering at ${ai.host}` : '';
                 }
             } catch (error) {
                 console.error('Error fetching status:', error);
@@ -1175,14 +1210,29 @@
             return /^\d+$/.test(String(value ?? '')) ? String(value) : '';
         }
 
+        // credit-line start
+        // Keyed on the presence of explained_by, not on its value: a payload
+        // saved before the cards carried their credit has no key at all, and
+        // telling that reader the model's own prose came from ClinVar is worse
+        // than telling them nothing.
+        function creditLine(result) {
+            if (!result.explanation || !('explained_by' in result)) return '';
+            return `<div class="result-credit">${result.explained_by
+                ? `Written by ${esc(result.explained_by)}.`
+                : 'No model wrote this. Data from ClinVar and the GWAS Catalog.'}</div>`;
+        }
+        // credit-line end
+
         function rsidFor(value) {
             return /^(rs|i)\d+$/.test(String(value ?? '')) ? String(value) : '';
         }
 
         // "Health Conditions" -> "health_conditions"
+        // slugify start
         function slugify(category) {
             return (category || '').toLowerCase().replace(/ /g, '_');
         }
+        // slugify end
 
         function displayResults() {
             if (!analysisResults) return;
@@ -1200,6 +1250,7 @@
                 summaryText.textContent = analysisResults.summary;
                 executiveSummary.style.display = 'block';
             }
+
 
             // Create Category Tabs
             const categories = ['all', 'health_conditions', 'carrier_status', 'risk_factors', 'pharmacogenomics', 'traits', 'unknown'];
@@ -1243,12 +1294,57 @@
             renderResultCards();
         }
 
+        // Counted off the cards themselves, never off a run-level name: a run
+        // where some calls answered and some did not used to print one model's
+        // name over every card in the batch. Each card carries explained_by —
+        // the model that wrote it, or null.
+        //
+        // Takes the cards it is describing rather than reading the whole
+        // payload: the tabs filter the list underneath this line, and "12 of
+        // 50" over three pharmacogenomics cards is a count of a set the reader
+        // cannot see.
+        // attribution-block start
+        function renderAttribution(results) {
+            const modelUsed = document.getElementById('modelUsed');
+            const cards = (results || []).filter(r => r && typeof r === 'object');
+            const explained = cards.filter(r => r.explanation);
+            const written = explained.filter(r => r.explained_by);
+            const names = [...new Set(written.map(r => r.explained_by))].sort();
+            if (!cards.some(r => 'explained_by' in r)) {
+                // A payload saved before the cards carried their credit.
+                // Saying "no model wrote these" over cards a model did write
+                // is worse than saying nothing.
+                modelUsed.style.display = 'none';
+            } else if (names.length) {
+                // "12 of 50", not a bare name: the reader can tell the two
+                // apart, and the cards the model did not write say so in their
+                // own text.
+                modelUsed.textContent = written.length === explained.length
+                    ? `Explanations written by ${names.join(', ')}.`
+                    : `${written.length} of ${explained.length} explanations written by ${names.join(', ')}. The rest come straight from ClinVar and the GWAS Catalog.`;
+                modelUsed.style.display = 'block';
+            } else {
+                // About the cards, not about the summary above them: the
+                // summary is a separate call and can succeed while every
+                // explanation fails.
+                modelUsed.textContent = 'No model wrote the explanations below. They come straight from ClinVar and the GWAS Catalog.';
+                modelUsed.style.display = 'block';
+            }
+        }
+        // attribution-block end
+
         // Render Result Cards
+        // render-cards start
         function renderResultCards() {
             const container = document.getElementById('resultsContainer');
             container.innerHTML = '';
 
-            if (!analysisResults || !analysisResults.results) return;
+            if (!analysisResults || !analysisResults.results) {
+                // The cards are cleared above; the line describing them must
+                // not outlive them and go on counting a previous analysis.
+                renderAttribution([]);
+                return;
+            }
 
             let results = analysisResults.results;
 
@@ -1258,6 +1354,10 @@
                 // "Health Conditions", so every tab but All matched nothing.
                 results = results.filter(r => slugify(r.category) === currentCategory);
             }
+
+            // After the filter, and on every render rather than once per
+            // analysis: the line sits above these cards and counts these cards.
+            renderAttribution(results);
 
             if (results.length === 0) {
                 container.innerHTML = '<p style="text-align: center; color: var(--gray-600); padding: 2rem;">No results found for this category.</p>';
@@ -1269,6 +1369,7 @@
                 container.appendChild(card);
             });
         }
+        // render-cards end
 
         // Create Result Card
         function createResultCard(result) {
@@ -1301,6 +1402,7 @@
                 ${(result.warnings || []).filter(w => !String(result.explanation || '').includes(w)).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
+                    ${creditLine(result)}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -477,6 +477,10 @@
             border-left-color: #6B7280;
         }
 
+        .result-card.association {
+            border-left-color: #06B6D4;
+        }
+
         .result-card.benign {
             border-left-color: #10B981;
         }
@@ -576,6 +580,16 @@
         body.dark-mode .badge-trait {
             background-color: #1E3A8A;
             color: #93C5FD;
+        }
+
+        .badge-association {
+            background-color: #CFFAFE;
+            color: #155E75;
+        }
+
+        body.dark-mode .badge-association {
+            background-color: #164E63;
+            color: #A5F3FC;
         }
 
         .badge-uncertain {
@@ -1183,6 +1197,7 @@
                 'pathogenic': 'badge-pathogenic',
                 'conflicting': 'badge-conflicting',
                 'uncertain': 'badge-uncertain',
+                'association': 'badge-association',
                 'risk': 'badge-risk',
                 'benign': 'badge-benign',
                 'trait': 'badge-trait'
@@ -1202,7 +1217,7 @@
                 </div>
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
-                    ${result.explanation ? '' : (result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
+                    ${(result.warnings || []).filter(w => !String(result.explanation || '').includes(w)).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -431,6 +431,7 @@
         .summary-text {
             font-size: 0.95rem;
             line-height: 1.6;
+            white-space: pre-wrap;
         }
 
         /* Result Card */
@@ -593,6 +594,7 @@
             margin-bottom: 1rem;
             color: var(--gray-700);
             line-height: 1.7;
+            white-space: pre-wrap;
         }
 
         body.dark-mode .result-explanation {
@@ -1155,8 +1157,8 @@
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
                     <div class="result-sources">
-                        ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" class="source-link">ClinVar</a>` : ''}
-                        ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" class="source-link">PubMed</a>` : ''}
+                        ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
+                        ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}
                     </div>
                 </div>
             `;

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1023,10 +1023,14 @@
             return div.innerHTML;
         }
 
-        // ClinVar and PubMed IDs land inside a URL, where escaping HTML is not
-        // enough — anything but digits is not an ID.
+        // These land inside a URL, where escaping HTML is not enough. A PubMed
+        // ID is digits; an rsID is rs or i followed by digits.
         function idFor(value) {
             return /^\d+$/.test(String(value ?? '')) ? String(value) : '';
+        }
+
+        function rsidFor(value) {
+            return /^(rs|i)\d+$/.test(String(value ?? '')) ? String(value) : '';
         }
 
         // "Health Conditions" -> "health_conditions"
@@ -1151,7 +1155,7 @@
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
                     <div class="result-sources">
-                        ${idFor(result.clinvar_id) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/${idFor(result.clinvar_id)}/" target="_blank" class="source-link">ClinVar</a>` : ''}
+                        ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" class="source-link">PubMed</a>` : ''}
                     </div>
                 </div>

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -886,7 +886,7 @@
                 if (upload) {
                     upload.classList.add('hidden');
                     const again = document.createElement('button');
-                    again.className = 'btn btn-secondary';
+                    again.className = 'export-button';
                     again.textContent = 'Analyze another file';
                     again.style.cssText = 'display:block;margin:0 auto 1.5rem;';
                     again.onclick = () => {

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -473,6 +473,10 @@
             border-left-color: #8B5CF6;
         }
 
+        .result-card.uncertain {
+            border-left-color: #6B7280;
+        }
+
         .result-card.benign {
             border-left-color: #10B981;
         }
@@ -572,6 +576,16 @@
         body.dark-mode .badge-trait {
             background-color: #1E3A8A;
             color: #93C5FD;
+        }
+
+        .badge-uncertain {
+            background-color: #E5E7EB;
+            color: #374151;
+        }
+
+        body.dark-mode .badge-uncertain {
+            background-color: #374151;
+            color: #D1D5DB;
         }
 
         .badge-conflicting {
@@ -1168,6 +1182,7 @@
             const significanceBadgeClass = {
                 'pathogenic': 'badge-pathogenic',
                 'conflicting': 'badge-conflicting',
+                'uncertain': 'badge-uncertain',
                 'risk': 'badge-risk',
                 'benign': 'badge-benign',
                 'trait': 'badge-trait'
@@ -1187,7 +1202,7 @@
                 </div>
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
-                    ${(result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
+                    ${result.explanation ? '' : (result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1120,19 +1120,7 @@
                 return;
             }
 
-            // Cap the DOM: a full genome yields tens of thousands of results and
-            // rendering them all locks the browser. Results are already ordered
-            // by significance, so the cap keeps the ones that matter.
-            const RENDER_LIMIT = 200;
-            const shown = results.slice(0, RENDER_LIMIT);
-            if (results.length > RENDER_LIMIT) {
-                const note = document.createElement('p');
-                note.style.cssText = 'text-align:center;color:var(--gray-600);padding:1rem;';
-                note.textContent = `Showing the top ${RENDER_LIMIT} of ${results.length.toLocaleString()} findings. Export the report for the full set.`;
-                container.appendChild(note);
-            }
-
-            shown.forEach((result, idx) => {
+            results.forEach((result, idx) => {
                 const card = createResultCard(result);
                 container.appendChild(card);
             });

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -738,6 +738,59 @@
             transform: none;
         }
 
+        .export-button.secondary {
+            background-color: transparent;
+            color: var(--primary);
+            border: 1px solid var(--primary);
+            margin-left: 0.75rem;
+        }
+
+        .export-button.secondary:hover {
+            background-color: var(--primary);
+            color: white;
+        }
+
+        /* Saved analysis banner */
+        .saved-banner {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+            padding: 1rem 1.25rem;
+            border-radius: var(--border-radius);
+            border-left: 3px solid var(--primary);
+            background-color: #CCFBF1;
+            color: #134E4A;
+        }
+
+        body.dark-mode .saved-banner {
+            background-color: #134E4A;
+            color: #CCFBF1;
+        }
+
+        .saved-banner-text {
+            flex: 1;
+            min-width: 12rem;
+        }
+
+        .saved-banner button {
+            border: none;
+            padding: 0.5rem 1rem;
+            border-radius: var(--border-radius);
+            cursor: pointer;
+            font-weight: 600;
+            transition: var(--transition);
+            background-color: var(--primary);
+            color: white;
+        }
+
+        .saved-banner button.ghost {
+            background-color: transparent;
+            color: inherit;
+            border: 1px solid currentColor;
+        }
+
         /* Alert/Toast */
         .alert {
             padding: 1rem 1.5rem;
@@ -878,6 +931,11 @@
 
         <!-- Upload Section -->
         <div id="uploadSection" class="section">
+            <div class="saved-banner hidden" id="savedBanner">
+                <div class="saved-banner-text" id="savedBannerText"></div>
+                <button id="restoreSavedButton">Open it</button>
+                <button class="ghost" id="deleteSavedButton">Delete</button>
+            </div>
             <div class="card">
                 <div class="upload-zone" id="uploadZone">
                     <div class="upload-icon">📤</div>
@@ -922,6 +980,7 @@
             <!-- Export -->
             <div class="export-container">
                 <button class="export-button" id="exportButton">📥 Export Report</button>
+                <button class="export-button secondary" id="saveButton">💾 Save results on this computer</button>
             </div>
         </div>
     </div>
@@ -936,6 +995,7 @@
         document.addEventListener('DOMContentLoaded', () => {
             setupEventListeners();
             fetchStatus();
+            fetchSavedInfo();
         });
 
         // Setup Event Listeners
@@ -976,6 +1036,11 @@
 
             // Export Button
             document.getElementById('exportButton').addEventListener('click', exportReport);
+
+            // Saving results on this machine — opt-in, and reversible
+            document.getElementById('saveButton').addEventListener('click', saveResults);
+            document.getElementById('restoreSavedButton').addEventListener('click', restoreSaved);
+            document.getElementById('deleteSavedButton').addEventListener('click', deleteSaved);
         }
 
         // Dark Mode Toggle
@@ -1121,6 +1186,12 @@
 
         function displayResults() {
             if (!analysisResults) return;
+
+            // The tab bar below is rebuilt with All marked active, but the
+            // filter renderResultCards applies is this module-level variable.
+            // Leave it on the last tab clicked and a fresh set of results comes
+            // up reading "All" while showing only pharmacogenomics.
+            currentCategory = 'all';
 
             // Executive Summary
             const executiveSummary = document.getElementById('executiveSummary');
@@ -1281,6 +1352,96 @@
                 showAlert('Error exporting report: ' + error.message, 'error');
                 document.getElementById('exportButton').disabled = false;
             }
+        }
+
+        // Saved analysis
+        // A run is half an hour and the results only live in this tab. Saving
+        // writes them to a file on this computer, and only when asked.
+        async function fetchSavedInfo() {
+            const banner = document.getElementById('savedBanner');
+            try {
+                const response = await fetch('/api/saved');
+                if (!response.ok) return;
+                const info = await response.json();
+                if (!info.saved) {
+                    banner.classList.add('hidden');
+                    return;
+                }
+                document.getElementById('savedBannerText').textContent =
+                    `You saved an analysis on this computer (${info.saved_at.replace('T', ' ')}).`;
+                banner.classList.remove('hidden');
+            } catch (error) {
+                // No banner is the right failure here — the upload path works
+                // without it.
+            }
+        }
+
+        async function saveResults() {
+            if (!analysisResults) return;
+
+            const button = document.getElementById('saveButton');
+            button.disabled = true;
+            try {
+                const response = await fetch('/api/saved', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(analysisResults)
+                });
+                if (!response.ok) throw new Error('Save failed');
+                showAlert('Saved on this computer. It will be offered next time you open Allelio.', 'success');
+                fetchSavedInfo();
+            } catch (error) {
+                console.error('Error saving results:', error);
+                showAlert('Error saving results: ' + error.message, 'error');
+            }
+            button.disabled = false;
+        }
+
+        async function restoreSaved() {
+            const button = document.getElementById('restoreSavedButton');
+            button.disabled = true;
+            try {
+                const response = await fetch('/api/saved/data');
+                // The banner is offered on the file existing, not on it
+                // parsing — reading 15 MB to draw a banner is not worth it. A
+                // save cut short by a crash lands here. Say so and leave Delete
+                // reachable; the file really is still there, so hiding the
+                // banner would only mean claiming otherwise.
+                if (response.status === 404) {
+                    document.getElementById('savedBannerText').textContent =
+                        'The saved analysis cannot be opened — it was removed, or cut short by a crash. Delete it and run your file again.';
+                    button.disabled = true;
+                    return;
+                }
+                if (!response.ok) throw new Error('Could not open the saved analysis');
+                analysisResults = await response.json();
+                displayResults();
+                document.getElementById('uploadSection').classList.add('hidden');
+                document.getElementById('resultsSection').classList.remove('hidden');
+            } catch (error) {
+                console.error('Error opening saved analysis:', error);
+                showAlert('Error opening saved analysis: ' + error.message, 'error');
+            }
+            button.disabled = false;
+        }
+
+        async function deleteSaved() {
+            // Irreversible, sits next to "Open it", and re-earning it costs
+            // half an hour.
+            if (!confirm('Delete the saved analysis? Running the file again takes about half an hour.')) return;
+
+            const button = document.getElementById('deleteSavedButton');
+            button.disabled = true;
+            try {
+                const response = await fetch('/api/saved', { method: 'DELETE' });
+                if (!response.ok) throw new Error('the file is still on the disk');
+                document.getElementById('savedBanner').classList.add('hidden');
+                showAlert('Saved analysis deleted.', 'success');
+            } catch (error) {
+                console.error('Error deleting saved analysis:', error);
+                showAlert('Could not delete the saved analysis — ' + error.message, 'error');
+            }
+            button.disabled = false;
         }
 
         // Show Alert

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1043,8 +1043,20 @@
                     progressText.textContent = p.total
                         ? `${p.stage} — ${p.done} of ${p.total}`
                         : `${p.stage}...`;
+                    // Only the explanation phase has a count. Without this the
+                    // bar sits at 10% through every other stage, one of which
+                    // can take half an hour.
+                    const stageWidths = {
+                        'Reading your file': 5,
+                        'Summarizing': 92,
+                        'Building your report': 96
+                    };
                     if (p.total) {
                         progressBar.style.width = (10 + 80 * p.done / p.total) + '%';
+                    } else if (p.stage in stageWidths) {
+                        progressBar.style.width = stageWidths[p.stage] + '%';
+                    } else if (p.stage.startsWith('Matching')) {
+                        progressBar.style.width = '8%';
                     }
                 } catch (e) {
                     // Server busy or restarting — the next tick tries again.
@@ -1215,9 +1227,9 @@
                     </div>
                     <div class="result-genotype">${esc(result.genotype)}</div>
                 </div>
+                ${(result.warnings || []).filter(w => !String(result.explanation || '').includes(w)).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
-                    ${(result.warnings || []).filter(w => !String(result.explanation || '').includes(w)).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1046,6 +1046,11 @@
         }
 
         // Display Results
+        // "Health Conditions" -> "health_conditions"
+        function slugify(category) {
+            return (category || '').toLowerCase().replace(/ /g, '_');
+        }
+
         function displayResults() {
             if (!analysisResults) return;
 
@@ -1105,7 +1110,9 @@
 
             // Filter by category
             if (currentCategory !== 'all') {
-                results = results.filter(r => r.category === currentCategory);
+                // The tabs are keyed on slugs; the analyser emits labels like
+                // "Health Conditions", so every tab but All matched nothing.
+                results = results.filter(r => slugify(r.category) === currentCategory);
             }
 
             if (results.length === 0) {

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -925,7 +925,7 @@
                 // Update Database Status
                 const dbIndicator = document.getElementById('dbIndicator');
                 const dbStatus = document.getElementById('dbStatus');
-                if (data.database_ready) {
+                if (data.db_ready) {
                     dbIndicator.classList.add('connected');
                     dbStatus.textContent = 'Database Ready';
                 } else {
@@ -936,7 +936,7 @@
                 // Update Ollama Status
                 const ollamaIndicator = document.getElementById('ollamaIndicator');
                 const ollamaStatus = document.getElementById('ollamaStatus');
-                if (data.ollama_connected) {
+                if (data.ollama_available) {
                     ollamaIndicator.classList.add('connected');
                     ollamaStatus.textContent = 'Ollama Connected';
                 } else {

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -867,7 +867,39 @@
         document.addEventListener('DOMContentLoaded', () => {
             setupEventListeners();
             fetchStatus();
+            loadLastAnalysis();
         });
+
+        // Restore the previous run so a reload does not require re-uploading.
+        async function loadLastAnalysis() {
+            try {
+                const response = await fetch('/api/last');
+                if (!response.ok) return;
+                analysisResults = await response.json();
+                displayResults();
+                document.getElementById('resultsSection').classList.remove('hidden');
+                // A restored run is finished: no progress bar, no upload prompt.
+                document.getElementById('progressSection').classList.add('hidden');
+                // Hide the upload panel so a finished run does not look like a
+                // prompt, but leave one way back to it.
+                const upload = document.getElementById('uploadSection');
+                if (upload) {
+                    upload.classList.add('hidden');
+                    const again = document.createElement('button');
+                    again.className = 'btn btn-secondary';
+                    again.textContent = 'Analyze another file';
+                    again.style.cssText = 'display:block;margin:0 auto 1.5rem;';
+                    again.onclick = () => {
+                        upload.classList.remove('hidden');
+                        again.remove();
+                    };
+                    const results = document.getElementById('resultsSection');
+                    results.parentNode.insertBefore(again, results);
+                }
+            } catch (e) {
+                // No previous run — the upload panel stands on its own.
+            }
+        }
 
         // Setup Event Listeners
         function setupEventListeners() {
@@ -959,14 +991,28 @@
             document.getElementById('progressSection').classList.remove('hidden');
             document.getElementById('resultsSection').classList.add('hidden');
 
-            // Animate progress bar
-            let progress = 0;
+            // Poll the server for real progress. A whole genome takes minutes;
+            // a bar that fakes its way to 90% and stops looks like a hang.
             const progressBar = document.getElementById('progressBar');
-            const progressInterval = setInterval(() => {
-                progress += Math.random() * 30;
-                if (progress > 90) progress = 90;
-                progressBar.style.width = progress + '%';
-            }, 500);
+            const progressText = document.getElementById('progressText');
+            progressBar.style.width = '2%';
+            progressText.textContent = 'Uploading...';
+            const progressInterval = setInterval(async () => {
+                try {
+                    const r = await fetch('/api/progress');
+                    if (!r.ok) return;
+                    const p = await r.json();
+                    if (p.stage === 'idle') return;
+                    progressText.textContent = p.total
+                        ? `${p.stage} — ${p.done} of ${p.total}`
+                        : `${p.stage}...`;
+                    if (p.total) {
+                        progressBar.style.width = (10 + 80 * p.done / p.total) + '%';
+                    }
+                } catch (e) {
+                    // Server busy or restarting — the next tick tries again.
+                }
+            }, 1000);
 
             try {
                 const response = await fetch('/api/analyze', {
@@ -1067,7 +1113,19 @@
                 return;
             }
 
-            results.forEach((result, idx) => {
+            // Cap the DOM: a full genome yields tens of thousands of results and
+            // rendering them all locks the browser. Results are already ordered
+            // by significance, so the cap keeps the ones that matter.
+            const RENDER_LIMIT = 200;
+            const shown = results.slice(0, RENDER_LIMIT);
+            if (results.length > RENDER_LIMIT) {
+                const note = document.createElement('p');
+                note.style.cssText = 'text-align:center;color:var(--gray-600);padding:1rem;';
+                note.textContent = `Showing the top ${RENDER_LIMIT} of ${results.length.toLocaleString()} findings. Export the report for the full set.`;
+                container.appendChild(note);
+            }
+
+            shown.forEach((result, idx) => {
                 const card = createResultCard(result);
                 container.appendChild(card);
             });

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -469,6 +469,10 @@
             border-left-color: #3B82F6;
         }
 
+        .result-card.conflicting {
+            border-left-color: #8B5CF6;
+        }
+
         .result-card.benign {
             border-left-color: #10B981;
         }
@@ -560,6 +564,26 @@
             color: #6EE7B7;
         }
 
+        .badge-trait {
+            background-color: #DBEAFE;
+            color: #1E3A8A;
+        }
+
+        body.dark-mode .badge-trait {
+            background-color: #1E3A8A;
+            color: #93C5FD;
+        }
+
+        .badge-conflicting {
+            background-color: #EDE9FE;
+            color: #5B21B6;
+        }
+
+        body.dark-mode .badge-conflicting {
+            background-color: #4C1D95;
+            color: #C4B5FD;
+        }
+
         .result-genotype {
             font-family: 'Courier New', monospace;
             font-weight: 600;
@@ -599,6 +623,21 @@
 
         body.dark-mode .result-explanation {
             color: #D1D5DB;
+        }
+
+        .result-warning {
+            margin-top: 0.75rem;
+            padding: 0.75rem;
+            border-left: 3px solid #B45309;
+            border-radius: 4px;
+            background-color: #FEF3C7;
+            color: #78350F;
+            font-size: 0.875rem;
+        }
+
+        body.dark-mode .result-warning {
+            background-color: #451A03;
+            color: #FCD34D;
         }
 
         .result-sources {
@@ -1128,19 +1167,11 @@
             const significance = result.significance || 'benign';
             const significanceBadgeClass = {
                 'pathogenic': 'badge-pathogenic',
+                'conflicting': 'badge-conflicting',
                 'risk': 'badge-risk',
                 'benign': 'badge-benign',
-                'trait': 'badge-benign'
+                'trait': 'badge-trait'
             }[significance] || 'badge-benign';
-
-            const categoryBadgeClass = {
-                'health_conditions': 'badge-category',
-                'carrier_status': 'badge-category',
-                'unknown': 'badge-category',
-                'risk_factors': 'badge-category',
-                'pharmacogenomics': 'badge-category',
-                'traits': 'badge-category'
-            }[result.category] || 'badge-category';
 
             card.innerHTML = `
                 <div class="result-header">
@@ -1148,7 +1179,7 @@
                         <div class="result-rsid">${esc(result.rsid)}</div>
                         <div class="result-gene">${esc(result.gene) || 'Gene: Unknown'}</div>
                         <div class="result-meta">
-                            <span class="badge ${categoryBadgeClass}">${esc(result.category).replace('_', ' ')}</span>
+                            <span class="badge badge-category">${esc(result.category).replace('_', ' ')}</span>
                             <span class="badge ${significanceBadgeClass}">${esc(significance)}</span>
                         </div>
                     </div>
@@ -1156,6 +1187,7 @@
                 </div>
                 <div class="result-body">
                     <div class="result-explanation">${esc(result.explanation) || 'No explanation available.'}</div>
+                    ${(result.warnings || []).map(w => `<div class="result-warning">${esc(w)}</div>`).join('')}
                     <div class="result-sources">
                         ${rsidFor(result.rsid) ? `<a href="https://www.ncbi.nlm.nih.gov/clinvar/?term=${rsidFor(result.rsid)}" target="_blank" rel="noopener noreferrer" class="source-link">ClinVar</a>` : ''}
                         ${idFor(result.pubmed_id) ? `<a href="https://www.ncbi.nlm.nih.gov/pubmed/${idFor(result.pubmed_id)}/" target="_blank" rel="noopener noreferrer" class="source-link">PubMed</a>` : ''}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-    "fastapi>=0.104.0",
+    "fastapi>=0.108.0",  # TemplateResponse(request, name) needs starlette >= 0.29
     "uvicorn[standard]>=0.24.0",
     "click>=8.1.0",
     "ollama>=0.4.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,24 @@ import sqlite3
 from allelio.database.store import AllelioDB
 
 
+@pytest.fixture(autouse=True)
+def no_ambient_model_config(monkeypatch) -> None:
+    """Whatever is exported in the shell does not get to decide these tests.
+
+    ALLELIO_OPENAI_BASE in particular would send every AIEngine() in the suite
+    to a different provider than the one the test set up.
+    """
+    for name in (
+        "ALLELIO_OPENAI_BASE",
+        "ALLELIO_MODEL",
+        # ollama-python reads these two itself, so a developer signed in to
+        # Ollama Cloud would otherwise get different results than CI.
+        "OLLAMA_HOST",
+        "OLLAMA_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
 @pytest.fixture
 def tmp_dir() -> Generator[str, None, None]:
     """Create a temporary directory for test files.

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,3 +1,4 @@
+import asyncio
 """Tests for the web interface.
 
 The web module went unexercised long enough to accumulate a startup crash, two
@@ -261,3 +262,108 @@ def test_export_does_not_leave_the_report_in_the_temp_directory() -> None:
 
     assert response.status_code == 200
     assert set(temp_dir.glob("allelio_report_*")) == before
+
+
+def test_upload_cannot_choose_where_it_lands() -> None:
+    """The multipart filename is raw header data, and multipart is a
+    CORS-safelisted content type, so any page could have posted this. The route
+    writes the body to the name it is given and then unlinks it, so the damage
+    is an overwrite followed by a delete."""
+    import tempfile
+    from pathlib import Path
+
+    victim_dir = Path(tempfile.mkdtemp(prefix="allelio_probe_"))
+    victim = victim_dir / "victim.txt"
+    victim.write_text("do not touch")
+
+    client = TestClient(app)
+    client.post(
+        "/api/analyze",
+        files={
+            "file": (
+                f"{victim_dir.name}/victim.txt",
+                b"rs1\t1\t1\tAA\n",
+            )
+        },
+    )
+
+    assert victim.exists(), "the upload deleted a file it chose the name of"
+    assert victim.read_text() == "do not touch"
+    victim.unlink()
+    victim_dir.rmdir()
+
+
+def test_a_gwas_association_is_not_a_risk() -> None:
+    """37,108 of the 62,057 findings on a real genome are GWAS-only traits.
+    They were all badged RISK while their own tab said Traits."""
+    from allelio.web.routes import _significance_of
+
+    trait = VariantResult(
+        rsid="rs1",
+        gwas_entries=[GWASEntry(rsid="rs1", trait="Height")],
+        category="Traits",
+    )
+    risk = VariantResult(
+        rsid="rs2",
+        gwas_entries=[GWASEntry(rsid="rs2", trait="Coronary artery disease risk")],
+        category="Risk Factors",
+    )
+    assert _significance_of(trait) == "trait"
+    assert _significance_of(risk) == "risk"
+
+
+def test_uncertain_significance_is_not_a_trait() -> None:
+    """1,236,063 ClinVar rows — the plurality — say "Uncertain significance".
+    Drawn as a trait, a variant nobody can interpret reads as harmless."""
+    from allelio.web.routes import _significance_of
+
+    variant = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[
+            ClinVarEntry(rsid="rs1", clinical_significance="Uncertain significance")
+        ],
+    )
+    assert _significance_of(variant) == "uncertain"
+
+
+@pytest.mark.asyncio
+async def test_explanations_give_up_and_return_what_finished() -> None:
+    """Fifty variants at three at a time, each allowed 300s, can hold the
+    upload open for over an hour."""
+    from allelio.ai.engine import AIEngine
+
+    engine = AIEngine()
+    engine.available = True
+
+    async def slow_or_not(result):
+        if result.rsid == "rs_slow":
+            await asyncio.sleep(30)
+        return "done"
+
+    engine.explain_variant = slow_or_not
+
+    explanations = await engine.explain_variants_batch(
+        [VariantResult(rsid="rs_fast"), VariantResult(rsid="rs_slow")],
+        deadline=0.5,
+    )
+
+    assert explanations == {"rs_fast": "done"}
+
+
+def test_a_warning_is_not_printed_twice() -> None:
+    """explain_variant already folds the counselling warning into the
+    explanation via wrap_with_disclaimer."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {
+            "results": [
+                {
+                    "rsid": "rs1",
+                    "explanation": "Note: talk to a genetic counselor.",
+                    "warnings": ["Note: talk to a genetic counselor."],
+                }
+            ]
+        }
+    )
+    assert html.count("talk to a genetic counselor.") == 1

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -105,3 +105,20 @@ async def test_summary_prompt_lists_the_variants() -> None:
     prompt = engine.client.prompts[0]
     assert "rs1" in prompt and "rs2" in prompt
     assert "APOE" in prompt
+
+
+def test_result_cards_get_a_gene_and_a_significance() -> None:
+    """The list drew every variant as "Gene: Unknown" and BENIGN, including the
+    pathogenic ones, because the route sent fields the page does not read."""
+    from allelio.web.routes import _gene_of, _significance_of
+
+    variant = _variant()
+    assert _gene_of(variant) == "APOE"
+    assert _significance_of(variant) == "pathogenic"
+
+    benign = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[ClinVarEntry(rsid="rs1", clinical_significance="Benign")],
+    )
+    assert _significance_of(benign) == "benign"
+    assert _gene_of(benign) is None

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,4 +1,3 @@
-import asyncio
 """Tests for the web interface.
 
 The web module went unexercised long enough to accumulate a startup crash, two
@@ -6,6 +5,8 @@ missing awaits and three wrong method names, so these cover the wiring: the
 routes answer, CORS is not open to the world, and the AI engine's two entry
 points survive a round trip against a stubbed client.
 """
+
+import asyncio
 
 import pytest
 from fastapi.testclient import TestClient
@@ -240,6 +241,9 @@ def test_exported_report_carries_the_counselling_warnings() -> None:
             "results": [
                 {
                     "rsid": "rs1",
+                    # What _fallback_explanation writes: no disclaimer, because
+                    # only the path where the model answered adds one.
+                    "explanation": "ClinVar: Pathogenic. Gene: BRCA1.",
                     "warnings": ["Talk to a genetic counselor."],
                 }
             ]
@@ -293,23 +297,24 @@ def test_upload_cannot_choose_where_it_lands() -> None:
     victim_dir.rmdir()
 
 
-def test_a_gwas_association_is_not_a_risk() -> None:
-    """37,108 of the 62,057 findings on a real genome are GWAS-only traits.
-    They were all badged RISK while their own tab said Traits."""
+def test_a_gwas_row_is_an_association_and_nothing_stronger() -> None:
+    """37,108 of the 62,057 findings on a real genome are GWAS-only. Badging
+    them all RISK over-states height; badging them all TRAIT demotes type 2
+    diabetes. Only 2,068 of the 553,549 GWAS rsIDs have a trait string the
+    analyser can tell apart, so neither guess is available."""
     from allelio.web.routes import _significance_of
 
-    trait = VariantResult(
-        rsid="rs1",
-        gwas_entries=[GWASEntry(rsid="rs1", trait="Height")],
-        category="Traits",
-    )
-    risk = VariantResult(
-        rsid="rs2",
-        gwas_entries=[GWASEntry(rsid="rs2", trait="Coronary artery disease risk")],
-        category="Risk Factors",
-    )
-    assert _significance_of(trait) == "trait"
-    assert _significance_of(risk) == "risk"
+    for trait, category in [
+        ("Height", "Traits"),
+        ("Type 2 diabetes", "Traits"),
+        ("Coronary artery disease risk", "Risk Factors"),
+    ]:
+        variant = VariantResult(
+            rsid="rs1",
+            gwas_entries=[GWASEntry(rsid="rs1", trait=trait)],
+            category=category,
+        )
+        assert _significance_of(variant) == "association"
 
 
 def test_uncertain_significance_is_not_a_trait() -> None:
@@ -367,3 +372,19 @@ def test_a_warning_is_not_printed_twice() -> None:
         }
     )
     assert html.count("talk to a genetic counselor.") == 1
+
+
+def test_a_fallback_explanation_still_gets_its_warning() -> None:
+    """explain_variant only runs wrap_with_disclaimer on the path where the
+    model answered. Without Ollama every top-50 variant takes the other one."""
+    from allelio.web.routes import _generate_html_report
+
+    warning = "Genetic counseling is strongly recommended."
+    wrapped = _generate_html_report(
+        {"results": [{"rsid": "rs1", "explanation": f"x {warning}", "warnings": [warning]}]}
+    )
+    fallback = _generate_html_report(
+        {"results": [{"rsid": "rs1", "explanation": "ClinVar: Pathogenic.", "warnings": [warning]}]}
+    )
+    assert wrapped.count(warning) == 1
+    assert fallback.count(warning) == 1

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,107 @@
+"""Tests for the web interface.
+
+The web module went unexercised long enough to accumulate a startup crash, two
+missing awaits and three wrong method names, so these cover the wiring: the
+routes answer, CORS is not open to the world, and the AI engine's two entry
+points survive a round trip against a stubbed client.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from allelio.ai.engine import AIEngine
+from allelio.analysis.lookup import ClinVarEntry, VariantResult
+from allelio.web.app import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+class StubClient:
+    """Stands in for ollama.AsyncClient, recording what it was asked."""
+
+    def __init__(self, reply: str = "A plain-English explanation."):
+        self.reply = reply
+        self.prompts = []
+
+    async def list(self):
+        return {"models": [{"name": "llama3.1:8b"}]}
+
+    async def chat(self, model, messages, stream=False, **kwargs):
+        self.prompts.append(messages[-1]["content"])
+        return {"message": {"content": self.reply}}
+
+
+def _variant(rsid: str = "rs429358") -> VariantResult:
+    return VariantResult(
+        rsid=rsid,
+        genotype="CT",
+        chromosome="19",
+        position=44908684,
+        clinvar_entries=[
+            ClinVarEntry(
+                rsid=rsid,
+                gene="APOE",
+                clinical_significance="Pathogenic",
+                conditions="Alzheimer disease",
+                review_status="reviewed by expert panel",
+            )
+        ],
+        gwas_entries=[],
+    )
+
+
+def test_index_page_renders(client: TestClient) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Allelio" in response.text
+
+
+def test_status_reports_database_and_ai(client: TestClient) -> None:
+    response = client.get("/api/status")
+    assert response.status_code == 200
+    body = response.json()
+    assert "db_ready" in body
+    assert "ollama_available" in body
+
+
+def test_progress_starts_idle(client: TestClient) -> None:
+    assert client.get("/api/progress").json()["stage"] == "idle"
+
+
+def test_cors_rejects_foreign_origins(client: TestClient) -> None:
+    """A page on the open web must not be able to read a genome off localhost."""
+    allowed = client.get("/api/status", headers={"Origin": "http://localhost:3000"})
+    assert allowed.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+    blocked = client.get("/api/status", headers={"Origin": "https://example.com"})
+    assert "access-control-allow-origin" not in blocked.headers
+
+
+@pytest.mark.asyncio
+async def test_explain_variant_uses_the_model() -> None:
+    engine = AIEngine()
+    engine.client = StubClient()
+    engine.available = True
+
+    explanation = await engine.explain_variant(_variant())
+
+    assert "plain-English explanation" in explanation
+    assert "rs429358" in engine.client.prompts[0]
+
+
+@pytest.mark.asyncio
+async def test_summary_prompt_lists_the_variants() -> None:
+    """The prompt used to carry counts alone, so the model had nothing to summarise."""
+    engine = AIEngine()
+    engine.client = StubClient(reply="Two findings of note.")
+    engine.available = True
+
+    summary = await engine.generate_summary([_variant("rs1"), _variant("rs2")])
+
+    assert "Two findings of note." in summary
+    prompt = engine.client.prompts[0]
+    assert "rs1" in prompt and "rs2" in prompt
+    assert "APOE" in prompt

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -174,3 +174,41 @@ def test_exported_report_escapes_the_uploaded_file() -> None:
     assert "<img src=x" not in html
     assert "&lt;script&gt;" in html
     assert "&lt;img src=x" in html
+
+
+def test_exported_report_escapes_its_own_header() -> None:
+    """/api/export takes an arbitrary dict, so the report's own two fields are
+    no more trusted than the rows."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {"analyzed_at": "<script>alert(1)</script>", "total_variants": "<b>x</b>"}
+    )
+    assert "<script>alert(1)</script>" not in html
+    assert "<b>x</b>" not in html
+
+
+def test_strong_gwas_reads_the_smallest_p_values() -> None:
+    """p_value is a float column; 6,271 rows hold 0.0, which has no exponent to
+    string-slice, so the strongest associations were read as the weakest."""
+    from allelio.ai.engine import AIEngine
+
+    engine = AIEngine()
+    engine.client = StubClient(reply="Noted.")
+    engine.available = True
+
+    import asyncio
+
+    strong = VariantResult(
+        rsid="rs3",
+        gwas_entries=[GWASEntry(rsid="rs3", trait="Height", p_value=0.0)],
+    )
+    weak = VariantResult(
+        rsid="rs4",
+        gwas_entries=[GWASEntry(rsid="rs4", trait="Height", p_value=0.5)],
+    )
+    # Weak one first: only a working p-value test reorders them.
+    asyncio.run(engine.generate_summary([weak, strong]))
+    prompt = engine.client.prompts[0]
+
+    assert prompt.index("rs3") < prompt.index("rs4")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -10,7 +10,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from allelio.ai.engine import AIEngine
-from allelio.analysis.lookup import ClinVarEntry, VariantResult
+from allelio.analysis.lookup import ClinVarEntry, GWASEntry, VariantResult
 from allelio.web.app import app
 
 
@@ -71,13 +71,14 @@ def test_progress_starts_idle(client: TestClient) -> None:
     assert client.get("/api/progress").json()["stage"] == "idle"
 
 
-def test_cors_rejects_foreign_origins(client: TestClient) -> None:
-    """A page on the open web must not be able to read a genome off localhost."""
-    allowed = client.get("/api/status", headers={"Origin": "http://localhost:3000"})
-    assert allowed.headers.get("access-control-allow-origin") == "http://localhost:3000"
+def test_no_cross_origin_reads(client: TestClient) -> None:
+    """A page on the open web must not be able to read a genome off localhost.
 
-    blocked = client.get("/api/status", headers={"Origin": "https://example.com"})
-    assert "access-control-allow-origin" not in blocked.headers
+    The UI is same-origin with the API, so the app grants no origin anything.
+    """
+    for origin in ("https://example.com", "http://localhost:3000"):
+        response = client.get("/api/status", headers={"Origin": origin})
+        assert "access-control-allow-origin" not in response.headers
 
 
 @pytest.mark.asyncio
@@ -122,3 +123,54 @@ def test_result_cards_get_a_gene_and_a_significance() -> None:
     )
     assert _significance_of(benign) == "benign"
     assert _gene_of(benign) is None
+
+
+def test_conflicting_interpretations_are_not_pathogenic() -> None:
+    """ClinVar's commonest ambiguous term contains the word "pathogenic"; a
+    substring match painted those variants with the red badge."""
+    from allelio.web.routes import _significance_of
+
+    conflicting = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[
+            ClinVarEntry(
+                rsid="rs1",
+                clinical_significance="Conflicting interpretations of pathogenicity",
+            )
+        ],
+    )
+    assert _significance_of(conflicting) != "pathogenic"
+
+
+@pytest.mark.asyncio
+async def test_summary_prompt_names_the_gwas_gene() -> None:
+    """GWASEntry calls it mapped_gene, so reading .gene left GWAS-only variants
+    reaching the model with no gene at all."""
+    engine = AIEngine()
+    engine.client = StubClient(reply="Noted.")
+    engine.available = True
+
+    variant = VariantResult(
+        rsid="rs2",
+        gwas_entries=[GWASEntry(rsid="rs2", trait="Height", mapped_gene="HMGA2")],
+    )
+    await engine.generate_summary([variant])
+
+    assert "HMGA2" in engine.client.prompts[0]
+
+
+def test_exported_report_escapes_the_uploaded_file() -> None:
+    """Genotypes are copied verbatim out of the user's file and the report is
+    opened in a browser."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {
+            "summary": "<script>alert(1)</script>",
+            "results": [{"rsid": "rs1", "genotype": "<img src=x onerror=alert(1)>"}],
+        }
+    )
+    assert "<script>alert(1)</script>" not in html
+    assert "<img src=x" not in html
+    assert "&lt;script&gt;" in html
+    assert "&lt;img src=x" in html

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -352,7 +352,10 @@ async def test_explanations_give_up_and_return_what_finished() -> None:
         deadline=0.5,
     )
 
-    assert explanations == {"rs_fast": "done"}
+    assert explanations["rs_fast"] == "done"
+    # Cut off, not dropped: an empty string would leave the card reading "No
+    # explanation available", which is worse than having no model at all.
+    assert "rs_slow" in explanations["rs_slow"]
 
 
 def test_a_warning_is_not_printed_twice() -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -7,6 +7,8 @@ points survive a round trip against a stubbed client.
 """
 
 import asyncio
+import os
+from unittest import mock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -18,7 +20,7 @@ from allelio.web.app import app
 
 @pytest.fixture
 def client() -> TestClient:
-    return TestClient(app)
+    return TestClient(app, base_url="http://127.0.0.1")
 
 
 class StubClient:
@@ -261,7 +263,7 @@ def test_export_does_not_leave_the_report_in_the_temp_directory() -> None:
     temp_dir = Path(tempfile.gettempdir())
     before = set(temp_dir.glob("allelio_report_*"))
 
-    client = TestClient(app)
+    client = TestClient(app, base_url="http://127.0.0.1")
     response = client.post("/api/export", json={"results": [{"rsid": "rs1"}]})
 
     assert response.status_code == 200
@@ -280,7 +282,7 @@ def test_upload_cannot_choose_where_it_lands() -> None:
     victim = victim_dir / "victim.txt"
     victim.write_text("do not touch")
 
-    client = TestClient(app)
+    client = TestClient(app, base_url="http://127.0.0.1")
     client.post(
         "/api/analyze",
         files={
@@ -391,3 +393,272 @@ def test_a_fallback_explanation_still_gets_its_warning() -> None:
     )
     assert wrapped.count(warning) == 1
     assert fallback.count(warning) == 1
+
+
+@pytest.fixture
+def saved_path(tmp_path, monkeypatch):
+    """Point the saved-analysis file at a temp directory, not the real one."""
+    path = tmp_path / "allelio" / "last_analysis.json"
+    monkeypatch.setattr("allelio.web.routes.SAVED_ANALYSIS_PATH", str(path))
+    return path
+
+
+def test_saving_is_opt_in(client: TestClient, saved_path) -> None:
+    """Nothing reaches the disk until the user asks for it. An analysis is the
+    user's genome, and a run that writes it by default is a decision made for
+    them."""
+    assert client.get("/api/saved").json() == {"saved": False, "saved_at": None}
+    assert client.get("/api/saved/data").status_code == 404
+
+    # The route that produces an analysis is not the route that saves one. Its
+    # own outcome does not matter here; that it wrote nothing does.
+    client.post("/api/analyze", files={"file": ("g.txt", b"rs1\t1\t1\tAA\n")})
+
+    assert not saved_path.exists()
+    assert client.get("/api/saved").json()["saved"] is False
+
+
+def test_a_saved_analysis_comes_back_and_can_be_forgotten(
+    client: TestClient, saved_path
+) -> None:
+    analysis = {"summary": "s", "results": [{"rsid": "rs429358"}], "total_variants": 1}
+
+    assert client.post("/api/saved", json=analysis).status_code == 200
+    assert client.get("/api/saved").json()["saved"] is True
+    assert client.get("/api/saved/data").json() == analysis
+
+    assert client.delete("/api/saved").status_code == 200
+    assert not saved_path.exists()
+    assert client.get("/api/saved").json()["saved"] is False
+    assert client.get("/api/saved/data").status_code == 404
+
+    # Deleting what is already gone is what the user asked for, not an error.
+    assert client.delete("/api/saved").status_code == 200
+
+
+def test_an_empty_body_is_not_a_saved_analysis(client: TestClient, saved_path) -> None:
+    assert client.post("/api/saved", json={}).status_code == 400
+    assert not saved_path.exists()
+
+
+def test_an_existing_data_directory_is_left_as_it_was(
+    client: TestClient, saved_path
+) -> None:
+    """~/.allelio normally exists already, holding the database. Silently
+    re-permissioning a directory this feature does not own is not its call —
+    but the file it writes there is private either way."""
+    import stat
+
+    saved_path.parent.mkdir(parents=True)
+    os.chmod(saved_path.parent, 0o755)
+
+    client.post("/api/saved", json={"results": [{"rsid": "rs1"}]})
+
+    assert stat.S_IMODE(saved_path.parent.stat().st_mode) == 0o755
+    assert stat.S_IMODE(saved_path.stat().st_mode) == 0o600
+
+
+def test_the_saved_analysis_is_readable_only_by_its_owner(
+    client: TestClient, saved_path
+) -> None:
+    """It holds the user's genotypes. The home directory is not private on a
+    shared machine; the file has to be."""
+    import stat
+
+    client.post("/api/saved", json={"results": [{"rsid": "rs1", "genotype": "AA"}]})
+
+    assert stat.S_IMODE(saved_path.stat().st_mode) == 0o600
+    # Nothing existed under tmp_path, so this save is what created the directory
+    # and the 0700 applies. On a real install `setup` gets there first and
+    # leaves it 0755 — the test above is the one that covers that.
+    assert stat.S_IMODE(saved_path.parent.stat().st_mode) == 0o700
+
+
+def test_a_truncated_save_does_not_wedge_the_page(
+    client: TestClient, saved_path
+) -> None:
+    """A crash mid-write leaves half a file. Restoring should offer nothing,
+    not answer 500 forever."""
+    saved_path.parent.mkdir(parents=True, exist_ok=True)
+    saved_path.write_text('{"results": [{"rsid":')
+
+    assert client.get("/api/saved/data").status_code == 404
+
+
+@pytest.mark.parametrize("contents", ["[1, 2, 3]", '"hello"', "123", "null"])
+def test_json_that_is_not_an_analysis_is_a_404_not_a_500(
+    saved_path, contents: str
+) -> None:
+    """These parse, so the guarded read waves them through and they die in
+    response serialisation instead — a 500 the page has no answer for."""
+    saved_path.parent.mkdir(parents=True, exist_ok=True)
+    saved_path.write_text(contents)
+
+    client = TestClient(app, base_url="http://127.0.0.1", raise_server_exceptions=False)
+    assert client.get("/api/saved/data").status_code == 404
+
+
+def test_delete_does_not_claim_a_file_it_could_not_remove(
+    saved_path, monkeypatch
+) -> None:
+    """The page says "deleted" on any 200. Over a file holding the user's
+    genotypes, that is the one lie this feature cannot afford."""
+    client = TestClient(app, base_url="http://127.0.0.1", raise_server_exceptions=False)
+    client.post("/api/saved", json={"results": [{"rsid": "rs1"}]})
+
+    def denied(path):
+        raise PermissionError(13, "Permission denied", path)
+
+    monkeypatch.setattr("allelio.web.routes.os.unlink", denied)
+
+    assert client.delete("/api/saved").status_code == 500
+    assert saved_path.exists(), "the test itself failed to keep the file"
+
+
+def test_a_failed_save_keeps_the_previous_one(saved_path, monkeypatch) -> None:
+    """The write is a temp file plus a rename for this reason: the user pays
+    half an hour for each analysis, so a bad save must not eat the good one."""
+    client = TestClient(app, base_url="http://127.0.0.1", raise_server_exceptions=False)
+    good = {"summary": "the one that finished", "results": []}
+    assert client.post("/api/saved", json=good).status_code == 200
+
+    # Out of disk part-way through the dump — the case the rename exists for,
+    # and the one where the temp file already has bytes in it.
+    import json as json_module
+
+    real_dump = json_module.dump
+
+    def full_disk(obj, fp):
+        fp.write("{" * 100)
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr("allelio.web.routes.json.dump", full_disk)
+
+    assert client.post("/api/saved", json={"summary": "the one that ran out"}).status_code == 500
+
+    # Put json.dump back and nothing else: monkeypatch.undo() would also drop
+    # the saved_path fixture's patch and send the read at the real home
+    # directory.
+    monkeypatch.setattr("allelio.web.routes.json.dump", real_dump)
+    assert client.get("/api/saved/data").json() == good
+    assert list(saved_path.parent.glob(".last_analysis_*")) == []
+
+
+def test_a_rebound_domain_cannot_read_the_saved_genome(saved_path) -> None:
+    """Binding to 127.0.0.1 is not a boundary. A page on a domain whose DNS
+    re-resolves to 127.0.0.1 is same-origin to the browser, so CORS never
+    applies; the Host header is the only thing that tells the two apart."""
+    client = TestClient(app, base_url="http://attacker.example")
+
+    assert client.get("/api/saved").status_code == 400
+    assert client.get("/api/saved/data").status_code == 400
+    assert client.post("/api/saved", json={"results": []}).status_code == 400
+    assert client.delete("/api/saved").status_code == 400
+
+    # Starlette strips the port before matching, so a port on the URL changes
+    # nothing — which is exactly why no allow-list entry carries one.
+    assert TestClient(app, base_url="http://127.0.0.1:8080").get("/api/saved").status_code == 200
+    assert TestClient(app, base_url="http://localhost").get("/api/saved").status_code == 200
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        # A bind address is never a Host header anyone types, and starlette
+        # strips the port by splitting on ":", so no IPv6 literal can match.
+        # None of these belong on the list; localhost is how you reach them.
+        ("0.0.0.0", ["localhost", "127.0.0.1"]),
+        ("::", ["localhost", "127.0.0.1"]),
+        ("::1", ["localhost", "127.0.0.1"]),
+        # inet_aton takes all of these as "every interface", and so does the
+        # bind — comparing against the dotted quad alone would let them past.
+        ("0", ["localhost", "127.0.0.1"]),
+        ("0.0", ["localhost", "127.0.0.1"]),
+        ("0x0", ["localhost", "127.0.0.1"]),
+        # asyncio turns an empty host into a passive getaddrinfo, which binds
+        # every interface as surely as 0.0.0.0 does.
+        ("", ["localhost", "127.0.0.1"]),
+        ("127.0.0.1", ["localhost", "127.0.0.1"]),
+        # A real name the operator can browse to does belong on it — lowercased,
+        # because that is how the browser will send it.
+        ("192.168.1.50", ["localhost", "127.0.0.1", "192.168.1.50"]),
+        ("MyBox.local", ["localhost", "127.0.0.1", "mybox.local"]),
+    ],
+)
+def test_only_hosts_a_browser_can_actually_send_go_on_the_allow_list(host, expected) -> None:
+    from click.testing import CliRunner
+
+    from allelio.cli import allelio
+
+    with mock.patch.dict(os.environ, {}, clear=False):
+        # An empty value has to count as unset: app.py drops empties and falls
+        # back, so leaving it would 400 every request with no warning printed.
+        os.environ["ALLELIO_ALLOWED_HOSTS"] = ""
+        with mock.patch("uvicorn.run") as run:
+            result = CliRunner().invoke(allelio, ["serve", "--host", host, "--port", "9999"])
+        assert run.called
+        assert os.environ["ALLELIO_ALLOWED_HOSTS"].split(",") == expected
+        # Rich wraps to the terminal width, so match on collapsed whitespace.
+        # A host that could not go on the list gets told where to browse
+        # instead; one that did needs no warning it would learn to ignore.
+        printed = " ".join(result.output.split())
+        browsable = host in ("127.0.0.1", "192.168.1.50", "MyBox.local")
+        assert ("browse to localhost" in printed) != browsable
+        # And the URL it tells them to open is one that will actually answer.
+        assert (f"http://{host}:9999" in printed) == browsable
+
+
+def test_a_users_own_host_list_is_left_alone() -> None:
+    from click.testing import CliRunner
+
+    from allelio.cli import allelio
+
+    with mock.patch.dict(os.environ, {"ALLELIO_ALLOWED_HOSTS": "Allelio.Local"}, clear=False):
+        with mock.patch("uvicorn.run"):
+            CliRunner().invoke(allelio, ["serve", "--host", "0.0.0.0", "--port", "9999"])
+        assert os.environ["ALLELIO_ALLOWED_HOSTS"] == "Allelio.Local"
+
+    import importlib
+
+    import allelio.web.app as app_module
+
+    with mock.patch.dict(os.environ, {"ALLELIO_ALLOWED_HOSTS": "Allelio.Local"}, clear=False):
+        try:
+            hosts = importlib.reload(app_module).ALLOWED_HOSTS
+        finally:
+            os.environ.pop("ALLELIO_ALLOWED_HOSTS", None)
+            importlib.reload(app_module)
+
+    # Lowercased, because a browser sends the host lowercased and starlette
+    # compares it exactly. Loopback stays on: naming a LAN address should not
+    # lock the operator out of the machine the server is running on.
+    assert hosts == ["localhost", "127.0.0.1", "allelio.local"]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        # A "*" anywhere past the first character.
+        "192.168.*.5",
+        # And a leading one that is not the "*." of a subdomain wildcard: a
+        # forgotten dot, which starlette rejects on its own second assert.
+        "*example.com",
+    ],
+)
+def test_a_typo_in_the_host_list_fails_at_startup_not_mid_run(monkeypatch, bad) -> None:
+    """Starlette only checks its patterns when the stack is first built, which is
+    on the first request — long after the URL has been printed and opened — and
+    it checks with an assert, which -O removes. Hence our own check at import."""
+    import importlib
+
+    import allelio.web.app as app_module
+
+    monkeypatch.setenv("ALLELIO_ALLOWED_HOSTS", bad)
+    try:
+        with pytest.raises(ValueError, match="wildcard host"):
+            importlib.reload(app_module)
+    finally:
+        # Put the module back whether or not the check fired: a failure here
+        # would otherwise hand every later test an app built from the bad list.
+        monkeypatch.delenv("ALLELIO_ALLOWED_HOSTS")
+        importlib.reload(app_module)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -8,11 +8,16 @@ points survive a round trip against a stubbed client.
 
 import asyncio
 import os
+import pathlib
+import subprocess
+import shutil
+import json
 from unittest import mock
 
 import pytest
 from fastapi.testclient import TestClient
 
+from allelio.ai.attribution import Explanation, attribution
 from allelio.ai.engine import AIEngine
 from allelio.analysis.lookup import ClinVarEntry, GWASEntry, VariantResult
 from allelio.web.app import app
@@ -21,6 +26,10 @@ from allelio.web.app import app
 @pytest.fixture
 def client() -> TestClient:
     return TestClient(app, base_url="http://127.0.0.1")
+
+
+# The full name a run puts on the cards it wrote, as the engine builds it.
+NAMED = "llama3.1:8b (Ollama at http://127.0.0.1:11434)"
 
 
 class StubClient:
@@ -68,7 +77,20 @@ def test_status_reports_database_and_ai(client: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
     assert "db_ready" in body
-    assert "ollama_available" in body
+    # Named, not just reachable: the page has to be able to print which model
+    # is about to write the explanations, and where it is running.
+    assert set(body["ai"]) == {
+        "available",
+        "model_available",
+        "status",
+        "provider",
+        "model",
+        "host",
+        "error",
+    }
+    assert body["ai"]["provider"] == "Ollama"
+    assert body["ai"]["model"]
+    assert body["ai"]["host"] == "http://127.0.0.1:11434"
 
 
 def test_progress_starts_idle(client: TestClient) -> None:
@@ -86,14 +108,15 @@ def test_no_cross_origin_reads(client: TestClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_explain_variant_uses_the_model() -> None:
+async def test_explain_uses_the_model() -> None:
     engine = AIEngine()
     engine.client = StubClient()
     engine.available = True
 
-    explanation = await engine.explain_variant(_variant())
+    written = await engine.explain(_variant())
 
-    assert "plain-English explanation" in explanation
+    assert "plain-English explanation" in written.text
+    assert written.model == engine.credit
     assert "rs429358" in engine.client.prompts[0]
 
 
@@ -345,23 +368,27 @@ async def test_explanations_give_up_and_return_what_finished() -> None:
     async def slow_or_not(result):
         if result.rsid == "rs_slow":
             await asyncio.sleep(30)
-        return "done"
+        return Explanation("done", NAMED)
 
-    engine.explain_variant = slow_or_not
+    engine.explain = slow_or_not
 
     explanations = await engine.explain_variants_batch(
         [VariantResult(rsid="rs_fast"), VariantResult(rsid="rs_slow")],
         deadline=0.5,
     )
 
-    assert explanations["rs_fast"] == "done"
+    assert explanations["rs_fast"].text == "done"
     # Cut off, not dropped: an empty string would leave the card reading "No
     # explanation available", which is worse than having no model at all.
-    assert "rs_slow" in explanations["rs_slow"]
+    assert "rs_slow" in explanations["rs_slow"].text
+    # And the card the clock cut off is not credited to the model that was
+    # still writing it.
+    assert explanations["rs_slow"].model is None
+    assert attribution(explanations).written == 1
 
 
 def test_a_warning_is_not_printed_twice() -> None:
-    """explain_variant already folds the counselling warning into the
+    """explain already folds the counselling warning into the
     explanation via wrap_with_disclaimer."""
     from allelio.web.routes import _generate_html_report
 
@@ -380,7 +407,7 @@ def test_a_warning_is_not_printed_twice() -> None:
 
 
 def test_a_fallback_explanation_still_gets_its_warning() -> None:
-    """explain_variant only runs wrap_with_disclaimer on the path where the
+    """explain only runs wrap_with_disclaimer on the path where the
     model answered. Without Ollama every top-50 variant takes the other one."""
     from allelio.web.routes import _generate_html_report
 
@@ -662,3 +689,2426 @@ def test_a_typo_in_the_host_list_fails_at_startup_not_mid_run(monkeypatch, bad) 
         # would otherwise hand every later test an app built from the bad list.
         monkeypatch.delenv("ALLELIO_ALLOWED_HOSTS")
         importlib.reload(app_module)
+
+
+# --- Choosing a model server -------------------------------------------------
+#
+# The engine will talk to Ollama or to any OpenAI-compatible server, and the
+# prompts it sends carry the variant they are asking about. So the address is a
+# privacy boundary, not a preference, and these cover both halves: that it only
+# ever resolves to this machine, and that whatever it does end up using can be
+# named on screen.
+
+
+class FakeHttpx:
+    """Stands in for the httpx module inside the engine, answering from a handler.
+
+    Patched in as `engine.httpx` rather than onto httpx itself, so the test
+    client the rest of this file uses is left alone.
+    """
+
+    def __init__(self, handler):
+        self._handler = handler
+        self.built = []
+
+    def AsyncClient(self, **kwargs):
+        import httpx as real
+
+        self.built.append(kwargs)
+
+        return real.AsyncClient(transport=real.MockTransport(self._handler), **kwargs)
+
+
+def _openai_server(
+    monkeypatch,
+    served=("qwen2.5-14b-instruct",),
+    reply="Plain English.",
+    lists=True,
+    answers_anything=False,
+):
+    """Wire the engine to a stubbed OpenAI-compatible server; returns the requests.
+
+    Honest by default, which the first version of this was not: both real
+    servers answer a completion for a model they do not serve with a 404 and
+    {"error": {"message": "model 'x' not found"}} — measured, Ollama in 2.2 ms
+    and llama-swap in 0.9 ms. A stub that answers anything hides the only
+    evidence there is that a name was wrong.
+
+    lists=False is a bare llama.cpp: it serves completions and has no
+    /v1/models at all. answers_anything=True is the server that ignores the
+    field it was sent, which is the case the attribution rule exists for.
+    """
+    import httpx as real
+
+    from allelio.ai import engine as engine_module
+
+    seen = []
+
+    def handler(request: "real.Request") -> "real.Response":
+        seen.append(request)
+        if request.url.path.endswith("/models"):
+            if not lists:
+                return real.Response(
+                    404, json={"error": {"message": "no /v1/models here"}}
+                )
+            return real.Response(200, json={"data": [{"id": name} for name in served]})
+        if request.url.path.endswith("/chat/completions"):
+            import json as _json
+
+            asked = _json.loads(request.content).get("model")
+            if not answers_anything and asked not in served:
+                return real.Response(
+                    404, json={"error": {"message": f"model '{asked}' not found"}}
+                )
+            return real.Response(
+                200, json={"choices": [{"message": {"content": reply}}]}
+            )
+        return real.Response(404)
+
+    monkeypatch.setattr(engine_module, "httpx", FakeHttpx(handler))
+    return seen
+
+
+@pytest.mark.parametrize(
+    "url,pinned",
+    [
+        ("http://127.0.0.1:1234/v1", "http://127.0.0.1:1234/v1"),
+        # The name is replaced by what it resolved to, so the request cannot be
+        # sent somewhere the check never saw.
+        ("http://localhost:11434", "http://127.0.0.1:11434"),
+        ("http://[::1]:8080/v1", "http://[::1]:8080/v1"),
+        # All of 127/8 is this machine, not just the .1.
+        ("http://127.0.0.2:9999/v1", "http://127.0.0.2:9999/v1"),
+        ("https://127.0.0.1:8443/v1", "https://127.0.0.1:8443/v1"),
+        # Spellings of 127.0.0.1 that a checker comparing strings would miss.
+        ("http://2130706433/v1", "http://127.0.0.1/v1"),
+        ("http://127.1/v1", "http://127.0.0.1/v1"),
+        # Userinfo is dropped with the name it was attached to.
+        ("http://api.openai.com@127.0.0.1/v1", "http://127.0.0.1/v1"),
+    ],
+)
+def test_a_model_server_on_this_machine_is_accepted(url: str, pinned: str) -> None:
+    from allelio.ai.engine import pin_to_loopback
+
+    assert pin_to_loopback(url, "ALLELIO_OPENAI_BASE") == pinned
+
+
+@pytest.mark.parametrize(
+    "url,because",
+    [
+        # The whole point: a hosted endpoint in this setting reads the genome.
+        ("http://104.18.7.1/v1", "not this machine"),
+        ("http://192.168.1.50:1234/v1", "not this machine"),
+        ("http://[2001:4860:4860::8888]/v1", "not this machine"),
+        # Binds everywhere, resolves to nothing in particular. Say 127.0.0.1.
+        ("http://0.0.0.0:1234/v1", "not this machine"),
+        ("localhost:1234", "is not a URL"),
+        ("ftp://127.0.0.1/v1", "is not a URL"),
+        ("file:///etc/passwd", "is not a URL"),
+        ("http://", "is not a URL"),
+        ("", "is not a URL"),
+    ],
+)
+def test_a_model_server_anywhere_else_is_refused(url: str, because: str) -> None:
+    from allelio.ai.engine import pin_to_loopback
+
+    with pytest.raises(ValueError, match=because):
+        pin_to_loopback(url, "ALLELIO_OPENAI_BASE")
+
+
+def _resolving_to(monkeypatch, *addresses):
+    """Make every name resolve to exactly these addresses, resolver or no resolver."""
+    import socket as socket_module
+
+    from allelio.ai import engine as engine_module
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        if not addresses:
+            raise socket_module.gaierror(-2, "Name or service not known")
+        return [
+            (socket_module.AF_INET, socket_module.SOCK_STREAM, 6, "", (a, port or 0))
+            for a in addresses
+        ]
+
+    monkeypatch.setattr(engine_module.socket, "getaddrinfo", fake_getaddrinfo)
+
+
+def test_a_name_that_resolves_to_nothing_is_refused(monkeypatch) -> None:
+    """Not resolving is not resolving to 127.0.0.1.
+
+    Asserted against a stubbed resolver rather than a .invalid name, because a
+    hijacking ISP resolver answers those with an ad server.
+    """
+    from allelio.ai.engine import pin_to_loopback
+
+    _resolving_to(monkeypatch)
+
+    with pytest.raises(ValueError, match="does not resolve"):
+        pin_to_loopback("http://nowhere.invalid:1234/v1", "ALLELIO_OPENAI_BASE")
+
+
+def test_one_public_answer_out_of_four_refuses_the_whole_name(monkeypatch) -> None:
+    """A DNS-rebinding name answers 127.0.0.1 and its own address in one reply.
+
+    Accepting it because a loopback address is in there would ship the genome
+    on whichever answer the connection happened to pick.
+    """
+    from allelio.ai.engine import pin_to_loopback
+
+    _resolving_to(monkeypatch, "127.0.0.1", "127.0.0.1", "127.0.0.1", "104.18.7.1")
+
+    with pytest.raises(ValueError, match="104.18.7.1"):
+        pin_to_loopback("http://rebind.example:1234/v1", "ALLELIO_OPENAI_BASE")
+
+
+def test_ipv4_is_preferred_over_the_ipv6_answer(monkeypatch) -> None:
+    """macOS answers "localhost" with ::1 first, and Ollama does not bind ::1."""
+    from allelio.ai.engine import pin_to_loopback
+
+    import socket as socket_module
+
+    from allelio.ai import engine as engine_module
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [
+            (socket_module.AF_INET6, socket_module.SOCK_STREAM, 6, "", ("::1", port, 0, 0)),
+            (socket_module.AF_INET, socket_module.SOCK_STREAM, 6, "", ("127.0.0.1", port)),
+        ]
+
+    monkeypatch.setattr(engine_module.socket, "getaddrinfo", fake_getaddrinfo)
+
+    assert pin_to_loopback("http://localhost:11434", "host") == "http://127.0.0.1:11434"
+
+
+def test_the_ollama_client_neither_redirects_nor_proxies(monkeypatch) -> None:
+    """Two httpx defaults that each walk a prompt off the checked address.
+
+    ollama's client turns redirect-following on; httpx trusts HTTP_PROXY,
+    ALL_PROXY, .netrc, and on macOS the proxy in System Settings, which an
+    MDM-managed laptop ships with. Pinning the host counts for nothing if the
+    connection is handed to a proxy afterwards.
+    """
+    monkeypatch.setenv("ALL_PROXY", "http://corp.proxy.example:8080")
+    monkeypatch.setenv("HTTP_PROXY", "http://corp.proxy.example:8080")
+
+    engine = AIEngine()
+
+    assert engine.client._client.follow_redirects is False
+    assert _proxied(engine.client._client) is False
+    # ollama-python injects OLLAMA_API_KEY as a bearer token regardless of
+    # trust_env. There is nowhere for a key to go when the only reachable server
+    # is on this machine — it could only be handed to whatever got to :11434
+    # first. Set here rather than relying on the developer's shell not having one.
+    monkeypatch.setenv("OLLAMA_API_KEY", "sk-a-real-ollama-cloud-key")
+
+    engine = AIEngine()
+
+    assert "authorization" not in {k.lower() for k in engine.client._client.headers}
+    assert "sk-a-real-ollama-cloud-key" not in str(engine.client._client.headers)
+
+
+def test_the_ollama_environment_cannot_move_the_address(monkeypatch) -> None:
+    """host= is always passed, so OLLAMA_HOST never gets a say."""
+    monkeypatch.setenv("OLLAMA_HOST", "http://evil.example.com:11434")
+
+    engine = AIEngine()
+
+    assert engine.host == "http://127.0.0.1:11434"
+    # engine.host is what the guard decided; base_url is where the request goes.
+    assert str(engine.client._client.base_url).startswith("http://127.0.0.1:11434")
+
+
+def _proxied(client) -> bool:
+    """Whether this httpx client would hand the connection to a proxy."""
+    import httpx as real
+
+    transport = client._transport_for_url(real.URL("http://127.0.0.1:11434/x"))
+    return type(transport._pool).__name__ != "AsyncConnectionPool"
+
+
+def test_httpx_would_have_proxied_it(monkeypatch) -> None:
+    """The control for the assertion above: without trust_env=False it leaks."""
+    import httpx as real
+
+    monkeypatch.setenv("ALL_PROXY", "http://corp.proxy.example:8080")
+    monkeypatch.setenv("HTTP_PROXY", "http://corp.proxy.example:8080")
+
+    assert _proxied(real.AsyncClient()) is True
+
+
+@pytest.mark.asyncio
+async def test_the_openai_client_neither_redirects_nor_proxies(monkeypatch) -> None:
+    """Same two defaults, on the path that was added by this change."""
+    # Serving the configured model: the engine does not send a prompt to a
+    # server whose listing says it has not got it, so an empty listing here
+    # would mean the second client is never built and this would pass for the
+    # wrong reason.
+    fake = FakeHttpx(
+        lambda request: __import__("httpx").Response(
+            200, json={"data": [{"id": "llama3.1:8b"}]}
+        )
+    )
+
+    from allelio.ai import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "httpx", fake)
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    engine = AIEngine()
+    await engine.check_connection()
+    engine.available = True
+    await engine.explain(_variant())
+
+    # Both calls: the listing and the prompt.
+    assert len(fake.built) == 2
+    for kwargs in fake.built:
+        assert kwargs["follow_redirects"] is False
+        assert kwargs["trust_env"] is False
+
+
+def test_the_refusal_names_the_setting_and_the_reason() -> None:
+    """A refusal nobody can act on is a bug report waiting to be filed."""
+    from allelio.ai.engine import pin_to_loopback
+
+    with pytest.raises(ValueError) as caught:
+        pin_to_loopback("http://104.18.7.1/v1", "ALLELIO_OPENAI_BASE")
+
+    message = str(caught.value)
+    assert "ALLELIO_OPENAI_BASE" in message
+    assert "104.18.7.1" in message
+    assert "127.0.0.1" in message
+
+
+def test_a_remote_address_is_refused_by_the_engine_itself(monkeypatch) -> None:
+    """Not merely unused — construction fails, so no code path can reach it."""
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://104.18.7.1/v1")
+
+    with pytest.raises(ValueError, match="not this machine"):
+        AIEngine()
+
+
+def test_ollama_is_still_the_default(monkeypatch) -> None:
+    engine = AIEngine()
+
+    assert engine.provider == "Ollama"
+    # The name it was written with is gone: what is connected to is what was checked.
+    assert engine.host == "http://127.0.0.1:11434"
+    assert engine.model == "llama3.1:8b"
+
+
+def test_the_openai_base_switches_provider(monkeypatch) -> None:
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    engine = AIEngine()
+
+    assert engine.provider == "OpenAI-compatible"
+    assert engine.host == "http://127.0.0.1:1234/v1"
+
+
+@pytest.mark.asyncio
+async def test_an_unnamed_model_is_taken_from_a_server_holding_one(monkeypatch) -> None:
+    """A server holding one model calls it whatever it likes.
+
+    Reporting the built-in Ollama default there would name a model that is not
+    running and never was.
+    """
+    _openai_server(monkeypatch, served=["qwen2.5-14b-instruct"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    engine = AIEngine()
+    assert await engine.check_connection() is True
+
+    assert engine.model == "qwen2.5-14b-instruct"
+
+
+@pytest.mark.asyncio
+async def test_a_server_holding_several_models_is_not_guessed_at(monkeypatch) -> None:
+    """llama-swap lists a dozen. Taking whichever came first would load an 80B
+    coder model to explain a genome, and print its name as though it had been
+    chosen."""
+    _openai_server(monkeypatch, served=["Qwen3-Coder-80B", "gemma3:12b", "llama3.1:8b"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    engine = AIEngine()
+    await engine.check_connection()
+
+    assert engine.model == "llama3.1:8b"  # the default, untouched
+    # And the menu is kept, so the CLI can print it instead of "ollama pull".
+    assert engine.served_models == ["Qwen3-Coder-80B", "gemma3:12b", "llama3.1:8b"]
+
+
+@pytest.mark.asyncio
+async def test_a_named_model_survives_the_connection(monkeypatch) -> None:
+    _openai_server(monkeypatch, served=["qwen2.5-14b-instruct"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+    monkeypatch.setenv("ALLELIO_MODEL", "mistral-nemo:12b")
+
+    engine = AIEngine()
+    await engine.check_connection()
+
+    assert engine.model == "mistral-nemo:12b"
+
+
+@pytest.mark.asyncio
+async def test_ollama_keeps_the_documented_default(monkeypatch) -> None:
+    """Ollama holds many models; the first one it lists is not a choice."""
+    engine = AIEngine()
+    engine.client = StubClient()
+
+    await engine.check_connection()
+
+    assert engine.model == "llama3.1:8b"
+
+
+def test_the_environment_names_the_model_for_ollama_too(monkeypatch) -> None:
+    monkeypatch.setenv("ALLELIO_MODEL", "mistral-nemo:12b")
+
+    assert AIEngine().model == "mistral-nemo:12b"
+    # An explicit argument still outranks it.
+    assert AIEngine(model="gemma2:9b").model == "gemma2:9b"
+
+
+@pytest.mark.asyncio
+async def test_explanations_go_out_over_chat_completions(monkeypatch) -> None:
+    """The wire format, and the header that is deliberately absent from it."""
+    import json
+
+    seen = _openai_server(
+        monkeypatch,
+        served=("mistral-nemo:12b",),
+        reply="A plain-English explanation.",
+    )
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+    monkeypatch.setenv("ALLELIO_MODEL", "mistral-nemo:12b")
+
+    engine = AIEngine()
+    engine.available = True
+    explanation = (await engine.explain(_variant())).text
+
+    assert "plain-English explanation" in explanation
+    posted = [r for r in seen if r.method == "POST"]
+    assert [str(r.url) for r in posted] == ["http://127.0.0.1:1234/v1/chat/completions"]
+    body = json.loads(posted[0].content)
+    assert body["model"] == "mistral-nemo:12b"
+    assert "rs429358" in body["messages"][-1]["content"]
+    # No key is sent because there is nowhere to send one: the only servers this
+    # can reach are on this machine, and a key would mean it had left.
+    assert all("authorization" not in r.headers for r in seen)
+
+
+def _serving(*names):
+    """A stub client whose list() reports exactly these models."""
+    client = StubClient()
+
+    async def list_models():
+        return {"models": [{"model": name} for name in names]}
+
+    client.list = list_models
+    return client
+
+
+@pytest.mark.asyncio
+async def test_a_different_tag_is_not_the_model_you_asked_for() -> None:
+    """"llama3.1:8b" used to be answered yes by a box holding only the 70b.
+
+    The run then died at the first explanation instead of here, where the CLI
+    can still say which model to pull.
+    """
+    engine = AIEngine(model="llama3.1:8b")
+
+    engine.client = _serving("llama3.1:70b")
+    await engine.check_connection()
+    assert engine.check_model_available() is False
+
+    # A quantisation of the model you asked for is a different model, and this
+    # is the pair that tells a whole-name comparison from a substring one.
+    engine.client = _serving("llama3.1:8b-instruct-q8_0")
+    await engine.check_connection()
+    assert engine.check_model_available() is False
+
+    engine.client = _serving("llama3.1:8b", "llama3.1:70b")
+    await engine.check_connection()
+    assert engine.check_model_available() is True
+
+
+@pytest.mark.asyncio
+async def test_a_bare_model_name_means_latest() -> None:
+    """Ollama's own shorthand, so asking for it should not be a miss."""
+    engine = AIEngine(model="llama3.1")
+    engine.client = _serving("llama3.1:latest")
+    await engine.check_connection()
+
+    assert engine.check_model_available() is True
+
+
+@pytest.mark.asyncio
+async def test_the_model_check_costs_no_second_request() -> None:
+    """It reads the listing check_connection already fetched.
+
+    Asking twice used to mean a second call on a client bound to the first
+    call's event loop, which answered "not on that server" about a model that
+    was sitting right there.
+    """
+    calls = []
+
+    engine = AIEngine()
+    engine.client = _serving("llama3.1:8b")
+    listing = engine.client.list
+
+    async def counted():
+        calls.append(1)
+        return await listing()
+
+    engine.client.list = counted
+    await engine.check_connection()
+
+    assert engine.check_model_available() is True
+    assert engine.check_model_available() is True
+    assert len(calls) == 1
+
+
+def test_status_names_the_model_and_where_it_runs(monkeypatch) -> None:
+    _openai_server(monkeypatch, served=["qwen2.5-14b-instruct"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    body = TestClient(app, base_url="http://127.0.0.1").get("/api/status").json()
+
+    assert body["ai"] == {
+        "available": True,
+        "model_available": True,
+        "status": "serving",
+        "provider": "OpenAI-compatible",
+        "model": "qwen2.5-14b-instruct",
+        "host": "http://127.0.0.1:1234/v1",
+        "error": None,
+    }
+
+
+def test_status_does_not_call_a_missing_model_ready(monkeypatch) -> None:
+    """Reachable is not loaded, and the dot on the page follows the model."""
+    _openai_server(monkeypatch, served=["gemma3:12b", "Qwen3-Coder-80B"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    body = TestClient(app, base_url="http://127.0.0.1").get("/api/status").json()
+
+    assert body["ai"]["available"] is True
+    assert body["ai"]["model_available"] is False
+    assert body["ai"]["model"] == "llama3.1:8b"
+
+
+def test_status_says_why_rather_than_reporting_a_disconnection(monkeypatch) -> None:
+    """"Disconnected" would send them hunting for a crash that never happened."""
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://104.18.7.1/v1")
+
+    body = TestClient(app, base_url="http://127.0.0.1").get("/api/status").json()
+
+    assert body["ai"]["available"] is False
+    assert "not this machine" in body["ai"]["error"]
+    # And the rest of the page still works: the database half is unaffected.
+    assert "db_ready" in body
+
+
+def test_a_refused_address_stops_the_upload_before_the_work(monkeypatch) -> None:
+    """Half an hour of analysis is a long time to wait for a settings error."""
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://104.18.7.1/v1")
+
+    response = TestClient(app, base_url="http://127.0.0.1").post(
+        "/api/analyze",
+        files={"file": ("genome.txt", b"rs1\t1\t100\tAA\n", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert "not this machine" in response.json()["detail"]
+
+
+# --- `allelio info` and `allelio analyze`, on the model half -----------------
+
+
+def _cli_info(monkeypatch):
+    """Run `allelio info` and hand back its output, collapsed to one line.
+
+    Rich wraps to the terminal width and puts a newline wherever it likes, so
+    every assertion below is against collapsed whitespace.
+    """
+    from click.testing import CliRunner
+
+    from allelio.cli import allelio
+
+    result = CliRunner().invoke(allelio, ["info"])
+    return " ".join(result.output.split())
+
+
+def test_info_names_the_model_and_where_it_runs(monkeypatch) -> None:
+    _openai_server(monkeypatch, served=["Qwen3.6-35B-A3B"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    printed = _cli_info(monkeypatch)
+
+    assert "OpenAI-compatible answering at http://127.0.0.1:1234/v1" in printed
+    assert "Qwen3.6-35B-A3B" in printed
+
+
+def test_info_refuses_a_model_server_that_is_not_on_this_machine(monkeypatch) -> None:
+    """The refusal has to reach the person, not just the exception handler."""
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://104.18.7.1/v1")
+
+    printed = _cli_info(monkeypatch)
+
+    assert "ALLELIO_OPENAI_BASE" in printed
+    assert "not this machine" in printed
+    # And nothing was contacted, so nothing can be reported as answering.
+    assert "answering at" not in printed
+
+
+def test_info_prints_the_menu_rather_than_an_ollama_pull(monkeypatch) -> None:
+    """`ollama pull Qwen3.6-35B` cannot work against llama-swap.
+
+    A server serving a dozen models under its own names gets its menu printed;
+    only Ollama gets told to pull.
+    """
+    _openai_server(monkeypatch, served=["Qwen3.6-35B-A3B", "gemma3:12b"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    printed = _cli_info(monkeypatch)
+
+    assert "llama3.1:8b is not on that server" in printed
+    assert "That server offers: Qwen3.6-35B-A3B, gemma3:12b" in printed
+    assert "ALLELIO_MODEL" in printed
+    assert "ollama pull" not in printed
+
+
+def test_info_tells_an_ollama_user_to_pull(monkeypatch) -> None:
+    from allelio.ai import engine as engine_module
+
+    monkeypatch.setattr(
+        engine_module, "AsyncClient", lambda **kwargs: _serving("gemma2:9b")
+    )
+
+    printed = _cli_info(monkeypatch)
+
+    assert "Ollama answering at http://127.0.0.1:11434" in printed
+    assert "ollama pull llama3.1:8b" in printed
+
+
+def test_info_says_a_missing_model_server_is_optional(monkeypatch) -> None:
+    """Allelio works without one, and the README promises so."""
+    from allelio.ai import engine as engine_module
+
+    class Silent:
+        async def list(self):
+            raise ConnectionRefusedError("nothing there")
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: Silent())
+
+    printed = _cli_info(monkeypatch)
+
+    assert "No answer from Ollama at http://127.0.0.1:11434" in printed
+    assert "optional" in printed
+
+
+def _analyze(monkeypatch, tmp_path, *extra, variants=None):
+    """Run `allelio analyze` over stubbed variants with a stubbed lookup."""
+    from click.testing import CliRunner
+
+    from allelio.cli import allelio
+
+    raw = tmp_path / "genome.txt"
+    raw.write_text("# rsid\tchromosome\tposition\tgenotype\nrs429358\t19\t44908684\tCT\n")
+
+    import allelio.cli as cli_module
+
+    class FakeDB:
+        def is_initialized(self):
+            return True
+
+        def version(self):
+            return "test"
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(cli_module, "AllelioDB", lambda *a, **k: FakeDB())
+    monkeypatch.setattr(cli_module, "parse_genotype_file", lambda path: [_variant()])
+    found = variants if variants is not None else [_variant()]
+    monkeypatch.setattr(cli_module, "analyze_variants", lambda v, **kwargs: found)
+    return CliRunner().invoke(
+        allelio, ["analyze", str(raw), "--output", str(tmp_path / "r.html"), *extra]
+    )
+
+
+def test_analyze_refuses_a_model_server_that_is_not_on_this_machine(
+    monkeypatch, tmp_path
+) -> None:
+    """It aborts rather than falling back.
+
+    Half an hour of analysis that ends in a report is not the place to discover
+    the model address was rejected, and silently dropping the explanations would
+    hide that the setting was ignored.
+    """
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://104.18.7.1/v1")
+
+    result = _analyze(monkeypatch, tmp_path)
+
+    assert result.exit_code != 0
+    printed = " ".join(result.output.split())
+    assert "ALLELIO_OPENAI_BASE" in printed
+    assert "not this machine" in printed
+
+
+def test_analyze_does_not_credit_a_model_that_never_answered(
+    monkeypatch, tmp_path
+) -> None:
+    """explain answers with the variant's own data when the call fails.
+
+    That text reads like an explanation and is not one, so counting it would put
+    a model's name on a report it had no part in writing.
+    """
+    from allelio.ai import engine as engine_module
+
+    class Silent:
+        async def list(self):
+            raise ConnectionRefusedError("nothing there")
+
+        async def chat(self, **kwargs):
+            raise ConnectionRefusedError("nothing there")
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: Silent())
+
+    result = _analyze(monkeypatch, tmp_path)
+    printed = " ".join(result.output.split())
+
+    assert "Generated" not in printed
+    # Nothing answered, so no prompt was sent and "no explanations generated"
+    # would be describing the wrong thing.
+    assert "No answer from Ollama at http://127.0.0.1:11434" in printed
+    assert "Continuing without explanations" in printed
+    # And the report, which is the thing that gets kept and shown to a doctor,
+    # does not carry a model's name over pages it had no part in writing.
+    report = (tmp_path / "r.html").read_text()
+    assert "llama3.1:8b" not in report
+    assert "AI Model: none" in report
+
+
+@pytest.mark.asyncio
+async def test_a_model_server_does_not_get_to_name_itself_in_markup(monkeypatch) -> None:
+    """The adopted name is printed on the page and written into the report.
+
+    A server on 127.0.0.1 is not automatically a trusted one — anything on this
+    machine can bind a port — so a name it made up is not adopted at all.
+    """
+    _openai_server(monkeypatch, served=['<img src=x onerror=alert(1)>'])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    engine = AIEngine()
+    assert await engine.check_connection() is True
+
+    assert engine.model == "llama3.1:8b"
+
+
+@pytest.mark.asyncio
+async def test_the_names_real_servers_use_are_still_adopted(monkeypatch) -> None:
+    """The guard has to let through what llama.cpp and LM Studio actually serve."""
+    _openai_server(monkeypatch, served=["hf.co/unsloth/Qwen3-8B-GGUF:Q4_K_M"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    engine = AIEngine()
+    await engine.check_connection()
+
+    assert engine.model == "hf.co/unsloth/Qwen3-8B-GGUF:Q4_K_M"
+
+
+def test_the_report_escapes_the_model_name() -> None:
+    """The name is the server's own, and the report is a file people open.
+
+    It rides on the card now rather than arriving in the metadata, so it
+    reaches three sinks — the footer, the note, and the heading over the
+    explanation itself — and all three escape it.
+    """
+    from allelio.report import generate_html_report
+
+    hostile = '<img src=x onerror=alert(1)>'
+    html = generate_html_report(
+        [_variant()],
+        {"rs429358": Explanation("Plain English.", hostile)},
+        "",
+        {"generated_at": "now"},
+    )
+
+    assert "<img src=x onerror=alert(1)>" not in html
+    assert "&lt;img src=x onerror=alert(1)&gt;" in html
+    assert "1 of 1 variants analyzed with &lt;img" in html
+    assert "AI Analysis — &lt;img" in html
+
+
+@pytest.mark.asyncio
+async def test_the_bridge_message_names_the_provider_it_actually_used(
+    monkeypatch,
+) -> None:
+    """"Is Ollama running? (ollama serve)" is a wrong answer against llama-swap."""
+    from allelio.ai.explanations import generate_explanation
+
+    class Silent:
+        async def list(self):
+            raise ConnectionRefusedError("nothing there")
+
+    def handler(request):
+        raise ConnectionRefusedError("nothing there")
+
+    from allelio.ai import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "httpx", FakeHttpx(handler))
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    with pytest.raises(RuntimeError) as caught:
+        await generate_explanation(_variant())
+
+    message = str(caught.value)
+    assert "OpenAI-compatible at http://127.0.0.1:1234/v1" in message
+    assert "ollama" not in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_the_bridge_lists_what_the_server_does_have(monkeypatch) -> None:
+    from allelio.ai.explanations import generate_explanation
+
+    _openai_server(monkeypatch, served=["Qwen3.6-35B-A3B", "gemma3:12b"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+    monkeypatch.setenv("ALLELIO_MODEL", "llama3.1:8b")
+
+    with pytest.raises(RuntimeError, match="Qwen3.6-35B-A3B, gemma3:12b"):
+        await generate_explanation(_variant())
+
+
+def test_an_ollama_host_off_this_machine_is_refused() -> None:
+    """The guard is on the constructor, so the ollama path is held to it too."""
+    with pytest.raises(ValueError, match="not this machine"):
+        AIEngine(host="http://104.18.7.1:11434")
+
+
+def test_analyze_credits_the_model_that_did_answer(monkeypatch, tmp_path) -> None:
+    """The other half of the tally: a model that wrote the pages gets named."""
+    from allelio.ai import engine as engine_module
+
+    class Answering:
+        async def list(self):
+            return {"models": [{"model": "llama3.1:8b"}]}
+
+        async def chat(self, **kwargs):
+            return {"message": {"content": "A plain-English explanation."}}
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: Answering())
+
+    result = _analyze(monkeypatch, tmp_path)
+    printed = " ".join(result.output.split())
+
+    assert "Generated 1 AI explanations" in printed
+    report = (tmp_path / "r.html").read_text()
+    assert "llama3.1:8b (Ollama at http://127.0.0.1:11434)" in report
+
+
+def test_the_same_address_written_two_ways_gets_the_same_answer() -> None:
+    """IPv6Address.is_loopback only learned about ::ffff:127.0.0.1 in 3.13.
+
+    This package claims 3.9, so the answer is decided here rather than by
+    whichever Python is installed.
+    """
+    from allelio.ai.engine import pin_to_loopback
+
+    assert (
+        pin_to_loopback("http://[::ffff:127.0.0.1]:1234/v1", "ALLELIO_OPENAI_BASE")
+        == "http://127.0.0.1:1234/v1"
+    )
+    # And the wrapping does not launder a public address into a local one.
+    with pytest.raises(ValueError, match="not this machine"):
+        pin_to_loopback("http://[::ffff:104.18.7.1]:1234/v1", "ALLELIO_OPENAI_BASE")
+
+
+@pytest.mark.asyncio
+async def test_the_batch_counts_what_came_back_not_what_finished() -> None:
+    """A task can finish just as the clock runs out and have its answer dropped.
+
+    What puts a model's name on a card is the card, so a card that was never
+    handed back cannot carry one — and a previous run cannot lend it one
+    either. The engine keeps no count between runs to go stale; this asserts
+    there is nowhere for one to hide.
+    """
+    engine = AIEngine()
+    engine.available = True
+    engine.client = StubClient()
+
+    explanations = await engine.explain_variants_batch(
+        [_variant("rs1"), _variant("rs2")], max_concurrent=2
+    )
+
+    assert len(explanations) == 2
+    assert attribution(explanations).written == 2
+    assert not hasattr(engine, "explained")
+
+    # A second run answers for its own cards and nothing else.
+    again = await engine.explain_variants_batch([_variant("rs3")])
+    assert attribution(again) == (attribution(again).model, 1, 1)
+
+
+@pytest.mark.asyncio
+async def test_each_card_carries_its_own_reason_for_having_no_model() -> None:
+    """Three calls run at a time and the engine has one slot for the last error.
+
+    A card asking why it has no explanation used to get whichever answer landed
+    last, so a timed-out variant was reported as "model not found" because
+    another variant failed that way a moment later.
+    """
+    engine = AIEngine()
+    engine.available = True
+
+    class DifferentFailures:
+        async def chat(self, model, messages, **kwargs):
+            if "rs_missing" in messages[-1]["content"]:
+                raise RuntimeError("model 'x' not found")
+            raise asyncio.TimeoutError()
+
+    engine.client = DifferentFailures()
+
+    written = await engine.explain_variants_batch(
+        [_variant("rs_missing"), _variant("rs_slow")], max_concurrent=2
+    )
+
+    assert written["rs_missing"].error == "model 'x' not found"
+    assert written["rs_slow"].error == "Request timed out"
+    assert attribution(written).written == 0
+
+
+@pytest.mark.asyncio
+async def test_a_variant_the_prompt_cannot_be_built_from_still_gets_a_card() -> None:
+    """It used to raise straight past explain and cost the caller the row.
+
+    The batch caught it and dropped one card; the CLI caught it and wrote
+    nothing for that rsID at all, so the report simply had no line for a
+    variant the analysis had found.
+    """
+    from allelio.ai import engine as engine_module
+
+    engine = AIEngine()
+    engine.available = True
+    engine.client = StubClient()
+    monkey = engine_module.build_variant_prompt
+    engine_module.build_variant_prompt = _raise_on_prompt
+    try:
+        written = await engine.explain(_variant("rs1"))
+    finally:
+        engine_module.build_variant_prompt = monkey
+
+    assert written.model is None
+    assert "rs1" in written.text
+    assert "no prompt for this one" in written.error
+
+
+def _raise_on_prompt(result):
+    raise ValueError("no prompt for this one")
+
+
+def test_two_models_over_one_set_of_cards_are_both_named() -> None:
+    """One run has one model, so this is the case nobody meets — until a server
+    swaps the model out mid-run, or a saved payload is reopened. Naming one of
+    the two would credit it for the other's pages, which is the whole defect
+    this module exists to prevent."""
+    credit = attribution(
+        {
+            "rs1": Explanation("Written.", "qwen3:8b"),
+            "rs2": Explanation("Written.", "llama3.1:8b"),
+            "rs3": Explanation("Written.", "llama3.1:8b"),
+            "rs4": Explanation("Fallback.", None),
+        }
+    )
+
+    # Sorted, so the sentence does not reshuffle between two readings of the
+    # same payload.
+    assert credit == ("llama3.1:8b, qwen3:8b", 3, 4)
+
+
+def test_an_ollama_cloud_model_is_refused(monkeypatch) -> None:
+    """The one case where 127.0.0.1:11434 is not this machine.
+
+    Ollama forwards a `-cloud` tag to ollama.com, prompt and all, so every
+    address check in the engine passes it — the name is the only place it shows.
+    """
+    monkeypatch.setenv("ALLELIO_MODEL", "gpt-oss:120b-cloud")
+
+    with pytest.raises(ValueError, match="Ollama Cloud"):
+        AIEngine()
+
+    # And by argument, which is where the CLI's --model lands.
+    with pytest.raises(ValueError, match="Ollama Cloud"):
+        AIEngine(model="deepseek-v3.1:671b-cloud")
+
+    # A local model with cloud in the middle of its name is not one of these.
+    assert AIEngine(model="qwen-cloudy:7b").model == "qwen-cloudy:7b"
+
+
+def test_the_report_escapes_what_came_out_of_the_uploaded_file() -> None:
+    """rsID, category and chromosome are read off the user's own file.
+
+    Self-inflicted, but the report is a file they open in a browser, and the
+    rsID also lands inside an href.
+    """
+    from allelio.report import generate_html_report
+
+    hostile = _variant('rs1"><script>alert(1)</script>')
+    html = generate_html_report(
+        [hostile], {}, "", {"model_used": "none", "generated_at": "now"}
+    )
+
+    assert "<script>alert(1)</script>" not in html
+    assert "clinvar/?term=rs1%22%3E%3Cscript%3E" in html
+
+
+def test_the_note_counts_answers_not_entries() -> None:
+    """A failed call still fills a card, and that is not the model's work.
+
+    Both reports below have one card with text on it. Which of them credits a
+    model is decided by that card, and by nothing passed in beside it.
+    """
+    from allelio.report import generate_html_report
+
+    metadata = {"generated_at": "now"}
+    fallback = generate_html_report(
+        [_variant()], {"rs429358": Explanation("Plain English.", None)}, "", metadata
+    )
+    assert "variants analyzed with" not in fallback
+    assert "AI Model: none" in fallback
+
+    written = generate_html_report(
+        [_variant()], {"rs429358": Explanation("Plain English.", "llama3.1:8b")}, "", metadata
+    )
+    assert "1 of 1 variants analyzed with llama3.1:8b" in written
+
+
+def test_the_whole_run_shares_one_event_loop(monkeypatch, tmp_path) -> None:
+    """One asyncio.run() per variant closes the loop the client's pool is on.
+
+    Measured against a real Ollama: call 1 ok, call 2 "Event loop is closed",
+    call 3 ok — every second explanation silently became a fallback while the
+    report still credited the model. Asserted on the loop the calls actually ran
+    in, because a stub client has no pool to be bound to one.
+    """
+    from allelio.ai import engine as engine_module
+
+    loops = []
+
+    class Answering:
+        async def list(self):
+            loops.append(id(asyncio.get_running_loop()))
+            return {"models": [{"model": "llama3.1:8b"}]}
+
+        async def chat(self, **kwargs):
+            loops.append(id(asyncio.get_running_loop()))
+            return {"message": {"content": "A plain-English explanation."}}
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: Answering())
+    result = _analyze(
+        monkeypatch,
+        tmp_path,
+        variants=[_variant("rs1"), _variant("rs2"), _variant("rs3")],
+    )
+
+    assert "Generated 3 AI explanations" in " ".join(result.output.split())
+    # Four now: the listing joined the same run, which is the point — asking for
+    # it anywhere else would bind the client's pool to a loop that then closes.
+    assert len(loops) == 4
+    assert len(set(loops)) == 1
+
+
+def test_the_headline_stat_counts_answers_too() -> None:
+    """The note was fixed and the stat card above it was not.
+
+    It is the largest number on the page, and it was crediting a model the
+    footer on the same page said had written nothing.
+    """
+    from allelio.report import generate_html_report
+
+    html = generate_html_report(
+        [_variant()],
+        {"rs429358": Explanation("Fallback text, not an explanation.", None)},
+        "",
+        {"generated_at": "now"},
+    )
+
+    stat = html.split('<div class="stat-value">')[-1].split("<")[0]
+    assert stat == "0"
+    assert "AI Explanations" in html
+
+
+def test_the_downloaded_report_names_the_model(client: TestClient, monkeypatch) -> None:
+    """The web export is the copy that leaves the browser and gets shown around.
+
+    Read off the rows it prints, so the line and the rows underneath it cannot
+    describe different runs.
+    """
+    from allelio.web import routes as routes_module
+
+    named = "Qwen3.6-35B-A3B (OpenAI-compatible at http://127.0.0.1:1234/v1)"
+    html = routes_module._generate_html_report(
+        {
+            "summary": "s",
+            "results": [
+                {"rsid": "rs1", "explanation": "Written.", "explained_by": named},
+            ],
+            "total_variants": 1,
+            "analyzed_at": "now",
+            "model_used": named,
+        }
+    )
+
+    assert "AI Model:" in html
+    assert f"{named} (1 of 1 explanations)" in html
+
+    # And a run where nothing answered says so rather than naming a model.
+    silent = routes_module._generate_html_report(
+        {
+            "summary": "s",
+            "results": [{"rsid": "rs1", "explanation": "Fallback.", "explained_by": None}],
+            "total_variants": 1,
+            "analyzed_at": "now",
+        }
+    )
+    assert "AI Model:</strong> none" in silent
+
+    # A saved analysis from before the cards carried their credit has one name
+    # for the whole run and says so; one from before even that says nothing was
+    # written down, which is not the same as "no model".
+    older = routes_module._generate_html_report(
+        {"summary": "s", "results": [{"rsid": "rs1", "explanation": "x"}],
+         "total_variants": 1, "analyzed_at": "now", "model_used": named}
+    )
+    assert f"{named} (whole run)" in older
+    oldest = routes_module._generate_html_report(
+        {"summary": "s", "results": [{"rsid": "rs1", "explanation": "x"}],
+         "total_variants": 1, "analyzed_at": "now"}
+    )
+    assert "AI Model:</strong> not recorded" in oldest
+
+
+def test_the_downloaded_report_counts_the_rows_it_prints() -> None:
+    """The table stops at a hundred rows and the line above it did not.
+
+    A genome with more significant variants than that read "150 of 150
+    explanations" over a table holding a hundred, which is a count of a set the
+    reader was never shown.
+    """
+    from allelio.web import routes as routes_module
+
+    html = routes_module._generate_html_report(
+        {
+            "summary": "s",
+            "results": [
+                {"rsid": f"rs{i}", "explanation": "Written.", "explained_by": "llama3.1:8b"}
+                for i in range(150)
+            ],
+            "total_variants": 150,
+            "analyzed_at": "now",
+        }
+    )
+
+    assert "llama3.1:8b (100 of 100 explanations)" in html
+    assert html.count("<tr>") == 101  # the header row and the hundred it kept
+
+
+def test_the_downloaded_report_escapes_the_model_name() -> None:
+    from allelio.web import routes as routes_module
+
+    html = routes_module._generate_html_report(
+        {"summary": "s", "results": [], "total_variants": 0, "analyzed_at": "now",
+         "model_used": '<img src=x onerror=alert(1)>'}
+    )
+
+    assert "<img src=x onerror=alert(1)>" not in html
+    assert "&lt;img src=x onerror=alert(1)&gt;" in html
+
+
+def test_the_report_escapes_the_chromosome_off_the_uploaded_file() -> None:
+    """The 23andMe parser checks the rsID prefix and the position, not this."""
+    from allelio.report import generate_html_report
+
+    hostile = _variant()
+    hostile.chromosome = '19"><script>alert(1)</script>'
+    html = generate_html_report(
+        [hostile], {}, "", {"model_used": "none", "generated_at": "now"}
+    )
+
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_a_port_of_zero_is_refused() -> None:
+    """Dropping it would send the prompt to port 80 rather than fail."""
+    from allelio.ai.engine import pin_to_loopback
+
+    with pytest.raises(ValueError, match="port 0 is not a port"):
+        pin_to_loopback("http://127.0.0.1:0/v1", "ALLELIO_OPENAI_BASE")
+
+
+@pytest.mark.asyncio
+async def test_a_cloud_model_is_refused_however_it_is_spelled(monkeypatch) -> None:
+    """Ollama resolves model names case-insensitively; so must the refusal."""
+    for spelling in ("gpt-oss:120b-CLOUD", "gpt-oss:120b-Cloud", "GPT-OSS:120B-CLOUD"):
+        monkeypatch.setenv("ALLELIO_MODEL", spelling)
+        with pytest.raises(ValueError, match="Ollama Cloud"):
+            AIEngine()
+
+
+@pytest.mark.asyncio
+async def test_a_cloud_model_is_refused_when_the_server_names_it(monkeypatch) -> None:
+    """__init__ never sees an adopted name.
+
+    A signed-in Ollama user with one cloud model pulled serves exactly one, which
+    is precisely the case the adoption path was written for.
+    """
+    _openai_server(monkeypatch, served=["gpt-oss:120b-cloud"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:11434/v1")
+
+    engine = AIEngine()
+
+    # The refusal cannot abort construction here — the server had not been asked
+    # yet — so it stops the connection, and the model is never adopted.
+    assert await engine.check_connection() is False
+    assert engine.model == "llama3.1:8b"
+    # And it says why. "No answer" would send them restarting a daemon that
+    # answered perfectly well.
+    assert "Ollama Cloud" in engine.refusal
+
+
+def test_the_upload_does_not_name_a_model_that_never_answered(monkeypatch) -> None:
+    """The web path has its own copy of the attribution rule.
+
+    Nothing is listening in this test, so every card is the variant's own data
+    wrapped in a disclaimer — which is exactly the text a reader would take for
+    an explanation if the payload put a model's name on it.
+    """
+    from allelio.ai import engine as engine_module
+
+    class Silent:
+        async def list(self):
+            raise ConnectionRefusedError("nothing there")
+
+        async def chat(self, **kwargs):
+            raise ConnectionRefusedError("nothing there")
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: Silent())
+
+    from allelio.web import routes as routes_module
+
+    class FakeDB:
+        def is_initialized(self):
+            return True
+
+        def close(self):
+            pass
+
+    # Otherwise this needs the built 905 MB database and passes only on a
+    # machine that has already run `allelio setup-db`.
+    monkeypatch.setattr(routes_module, "AllelioDB", lambda *a, **k: FakeDB())
+    monkeypatch.setattr(routes_module, "parse_genotype_file", lambda path: [_variant()])
+    monkeypatch.setattr(
+        routes_module, "analyze_variants", lambda genotypes, db: [_variant()]
+    )
+
+    response = TestClient(app, base_url="http://127.0.0.1").post(
+        "/api/analyze",
+        files={"file": ("genome.txt", b"rs429358\t19\t44908684\tCT\n", "text/plain")},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["model_used"] == "none"
+
+
+def test_the_suite_does_not_inherit_an_ollama_key() -> None:
+    """A developer signed in to Ollama Cloud must get the same answers as CI.
+
+    The fixture that clears it is the only thing standing between the two, and
+    nothing else would notice if it stopped.
+    """
+    assert "OLLAMA_API_KEY" not in os.environ
+    assert "OLLAMA_HOST" not in os.environ
+    assert "ALLELIO_OPENAI_BASE" not in os.environ
+    assert "ALLELIO_MODEL" not in os.environ
+
+
+@pytest.mark.asyncio
+async def test_a_name_the_server_made_up_is_not_adopted(monkeypatch) -> None:
+    """An adopted name is printed on the page and written into the report.
+
+    Whatever a server answers with ends up in front of the reader, so only
+    something shaped like a model name is taken. The connection still stands —
+    there is nothing wrong with the server, only with what it called itself.
+    """
+    _openai_server(monkeypatch, served=["<script>alert(1)</script>"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    engine = AIEngine()
+
+    assert await engine.check_connection() is True
+    assert engine.model == "llama3.1:8b"
+
+
+def test_info_says_a_model_was_refused_rather_than_unreachable(monkeypatch) -> None:
+    """The two are fixed by opposite actions, so they cannot share a message."""
+    _openai_server(monkeypatch, served=["gpt-oss:120b-cloud"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:11434/v1")
+
+    printed = _cli_info(monkeypatch)
+
+    assert "Ollama Cloud" in printed
+    assert "No answer from" not in printed
+
+
+def test_analyze_stops_rather_than_relay_the_genome(monkeypatch, tmp_path) -> None:
+    """A server whose only model is a cloud tag is a relay, and it is refused.
+
+    This is the one abort left in `analyze`, and it happens before the genotype
+    file is read: the refusal is only discoverable on the OpenAI-compatible
+    path, where a single served model gets adopted, and asking costs one request
+    to loopback.
+    """
+    seen = _openai_server(monkeypatch, served=["gpt-oss:120b-cloud"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:11434/v1")
+
+    result = _analyze(monkeypatch, tmp_path)
+
+    assert result.exit_code != 0
+    assert "Ollama Cloud" in " ".join(result.output.split())
+    assert not (tmp_path / "r.html").exists()
+    # The name of this test is the assertion: the relay was asked what it
+    # serves, and nothing else.
+    assert [r.url.path for r in seen] == ["/v1/models"]
+
+
+def test_the_upload_refuses_a_server_that_only_serves_a_cloud_model(
+    monkeypatch, tmp_path
+) -> None:
+    """Same refusal as a remote address, and the same 400 with the reason."""
+    _openai_server(monkeypatch, served=["gpt-oss:120b-cloud"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:11434/v1")
+
+    raw = tmp_path / "genome.txt"
+    raw.write_text("# rsid\tchromosome\tposition\tgenotype\nrs429358\t19\t44908684\tCT\n")
+
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        with open(raw, "rb") as fh:
+            response = client.post("/api/analyze", files={"file": ("genome.txt", fh)})
+
+    assert response.status_code == 400
+    assert "Ollama Cloud" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_the_status_endpoint_carries_the_reason(monkeypatch) -> None:
+    """The page has one line for this, and it should hold the actionable half."""
+    _openai_server(monkeypatch, served=["gpt-oss:120b-cloud"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:11434/v1")
+
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        ai = client.get("/api/status").json()["ai"]
+
+    assert ai["available"] is False
+    assert "Ollama Cloud" in ai["error"]
+
+
+# --- Round 5 findings -------------------------------------------------------
+
+
+def _llama_swap(monkeypatch, models):
+    """A stub llama-swap: canonical ids, each with the aliases it also routes on.
+
+    Shape copied from the real server on 127.0.0.1:1234, which answers
+    /v1/models with meta.llamaswap.aliases beside every id.
+    """
+    import httpx as real
+
+    from allelio.ai import engine as engine_module
+
+    def handler(request: "real.Request") -> "real.Response":
+        if request.url.path.endswith("/models"):
+            return real.Response(200, json={"data": [
+                {
+                    "id": name,
+                    "object": "model",
+                    "meta": {"llamaswap": {"aliases": list(aliases), "type": "model"}},
+                }
+                for name, aliases in models.items()
+            ]})
+        if request.url.path.endswith("/chat/completions"):
+            return real.Response(
+                200, json={"choices": [{"message": {"content": "Plain English."}}]}
+            )
+        return real.Response(404)
+
+    monkeypatch.setattr(engine_module, "httpx", FakeHttpx(handler))
+
+
+@pytest.mark.asyncio
+async def test_an_alias_is_the_model(monkeypatch) -> None:
+    """llama-swap routes on the aliases in its config, and they are not ids.
+
+    `ALLELIO_MODEL=qwen36` is a working setup against the real server; called
+    not-serving, it turns the status dot grey, makes `info` recommend a menu the
+    name is already on, and makes generate_explanation refuse outright.
+    """
+    _llama_swap(monkeypatch, {"Qwen3.6-35B-A3B": ["qwen36"]})
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+    monkeypatch.setenv("ALLELIO_MODEL", "qwen36")
+
+    engine = AIEngine()
+    assert await engine.check_connection() is True
+    assert engine.check_model_available() is True
+    # Shown as the server spells it, though: an alias is for matching.
+    assert engine.served_models == ["Qwen3.6-35B-A3B"]
+
+
+@pytest.mark.asyncio
+async def test_an_alias_does_not_make_a_server_look_like_it_serves_several(
+    monkeypatch,
+) -> None:
+    """One model with two aliases is still one model, and still adoptable."""
+    _llama_swap(monkeypatch, {"Qwen3.6-35B-A3B": ["qwen36", "qwen"]})
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    engine = AIEngine()
+    assert await engine.check_connection() is True
+    assert engine.model == "Qwen3.6-35B-A3B"
+
+
+def test_analyze_skips_the_explanations_when_the_listing_says_the_model_is_not_there(
+    monkeypatch, tmp_path
+) -> None:
+    """The contradiction is already in hand before the first prompt goes out.
+
+    A server that answers a completion for a model it does not serve — and not
+    all of them check — hands back another model's text, which then goes into
+    the report under the name that was asked for. So no prompt is sent.
+
+    The analysis needed no model at all, though. Refusing to write the report
+    because an optional feature is misconfigured is the CLI disagreeing with its
+    own web path, which degrades and returns the findings.
+    """
+    seen = _openai_server(monkeypatch, served=["qwen2.5-14b-instruct"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+    monkeypatch.setenv("ALLELIO_MODEL", "llama3.1:8b")
+
+    result = _analyze(monkeypatch, tmp_path)
+
+    assert result.exit_code == 0
+    printed = " ".join(result.output.split())
+    assert "is not serving" in printed
+    assert "qwen2.5-14b-instruct" in printed
+    # The report is written, and it credits nobody.
+    report = (tmp_path / "r.html").read_text()
+    assert "AI Model: none" in report
+    assert "llama3.1:8b" not in report
+    # Nothing was asked of the server past the listing.
+    assert [r.url.path for r in seen] == ["/v1/models"]
+
+
+def test_the_upload_does_not_credit_a_model_the_listing_does_not_have(
+    monkeypatch, tmp_path
+) -> None:
+    """Same contradiction, the other path. The analysis is still worth having;
+    the attribution on it is not."""
+    from allelio.web import routes as routes_module
+
+    _openai_server(monkeypatch, served=["qwen2.5-14b-instruct"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+    monkeypatch.setenv("ALLELIO_MODEL", "llama3.1:8b")
+
+    class FakeDB:
+        def is_initialized(self):
+            return True
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(routes_module, "AllelioDB", lambda *a, **k: FakeDB())
+    monkeypatch.setattr(routes_module, "parse_genotype_file", lambda path: [_variant()])
+    monkeypatch.setattr(routes_module, "analyze_variants", lambda *a, **k: [_variant()])
+
+    raw = tmp_path / "genome.txt"
+    raw.write_text("# rsid\tchromosome\tposition\tgenotype\nrs429358\t19\t44908684\tCT\n")
+
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        with open(raw, "rb") as fh:
+            payload = client.post(
+                "/api/analyze", files={"file": ("genome.txt", fh)}
+            ).json()
+
+    assert payload["model_used"] == "none"
+    assert "llama3.1:8b" not in str(payload)
+
+
+def test_a_refused_address_arrives_before_the_genome_is_read(
+    monkeypatch, tmp_path
+) -> None:
+    """The README promises this happens before any analysis starts.
+
+    Parsing a 16 MB file and matching 630,774 variants against ClinVar takes
+    minutes; discovering the refusal afterwards is discovering it at the end.
+    """
+    import allelio.cli as cli_module
+
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://104.18.7.1/v1")
+
+    ran = []
+
+    class FakeDB:
+        def is_initialized(self):
+            return True
+
+        def version(self):
+            return "test"
+
+        def close(self):
+            pass
+
+    def parsed(path):
+        ran.append("parse")
+        return [_variant()]
+
+    def analyzed(v, **kwargs):
+        ran.append("analyze")
+        return [_variant()]
+
+    monkeypatch.setattr(cli_module, "AllelioDB", lambda *a, **k: FakeDB())
+    monkeypatch.setattr(cli_module, "parse_genotype_file", parsed)
+    monkeypatch.setattr(cli_module, "analyze_variants", analyzed)
+
+    from click.testing import CliRunner
+
+    raw = tmp_path / "genome.txt"
+    raw.write_text("# rsid\tchromosome\tposition\tgenotype\nrs429358\t19\t44908684\tCT\n")
+    result = CliRunner().invoke(
+        cli_module.allelio,
+        ["analyze", str(raw), "--output", str(tmp_path / "r.html")],
+    )
+
+    assert result.exit_code != 0
+    assert ran == []
+
+
+@pytest.mark.asyncio
+async def test_the_batch_counts_only_answers_it_read() -> None:
+    """A task can finish after the clock runs out and never be read.
+
+    Counting those credits the model for pages nobody was given, and the
+    per-task failure branch inflates `done`, so clamping to it is not enough.
+    """
+    engine = AIEngine()
+    engine.available = True
+
+    async def one_of_each(result):
+        if result.rsid == "rs_slow":
+            await asyncio.sleep(30)
+            return Explanation("late", NAMED)
+        if result.rsid == "rs_failed":
+            return Explanation("fallback text", None)
+        return Explanation("written by the model", NAMED)
+
+    engine.explain = one_of_each
+
+    explanations = await engine.explain_variants_batch(
+        [VariantResult(rsid="rs_ok"), VariantResult(rsid="rs_failed"),
+         VariantResult(rsid="rs_slow")],
+        deadline=0.5,
+    )
+
+    assert explanations["rs_ok"].text == "written by the model"
+    assert explanations["rs_ok"].model == NAMED
+    # The one that came back late is on the page as its own data, uncredited —
+    # the seed, not the answer nobody read.
+    assert explanations["rs_slow"].model is None
+    assert explanations["rs_failed"].model is None
+    assert attribution(explanations).written == 1
+
+
+@pytest.mark.asyncio
+async def test_a_variant_that_fails_outside_the_guard_costs_one_variant() -> None:
+    """It used to cost the whole upload, minutes after the analysis was done."""
+    engine = AIEngine()
+    engine.available = True
+
+    async def boom(result):
+        if result.rsid == "rs_bad":
+            raise RuntimeError("something the guard never saw")
+        return Explanation("fine", NAMED)
+
+    engine.explain = boom
+
+    explanations = await engine.explain_variants_batch(
+        [VariantResult(rsid="rs_ok"), VariantResult(rsid="rs_bad")]
+    )
+
+    assert explanations["rs_ok"].text == "fine"
+    # Seeded with its own data rather than dropped, and not credited to the
+    # model that never saw it.
+    assert "rs_bad" in explanations["rs_bad"].text
+    assert explanations["rs_bad"].model is None
+    assert attribution(explanations).written == 1
+
+
+@pytest.mark.asyncio
+async def test_the_listing_reads_the_objects_the_real_ollama_returns() -> None:
+    """Every stub in this file answers with dicts; the library does not.
+
+    ollama-python returns a ListResponse of Model objects, so the attribute
+    branch of _model_names is the one every Ollama user takes. If it broke,
+    `info` would tell all of them their model is missing and the suite would
+    stay green.
+    """
+    from allelio.ai.engine import _model_names
+
+    class Model:
+        def __init__(self, name):
+            self.model = name
+
+    class ListResponse:
+        models = [Model("llama3.1:8b"), Model("qwen2.5:14b")]
+
+    assert _model_names(ListResponse()) == ["llama3.1:8b", "qwen2.5:14b"]
+
+
+@pytest.mark.parametrize("url", [
+    "http://127.0.0.1:99999/v1",
+    "http://127.0.0.1:abc/v1",
+])
+def test_a_port_that_is_not_a_port_is_refused(url) -> None:
+    """urlsplit raises on both of these, and an unread exception here would
+    escape as a traceback rather than the sentence explaining the setting."""
+    from allelio.ai.engine import pin_to_loopback
+
+    with pytest.raises(ValueError, match="ALLELIO_OPENAI_BASE"):
+        pin_to_loopback(url, "ALLELIO_OPENAI_BASE")
+
+
+@pytest.mark.asyncio
+async def test_an_absurdly_long_name_is_not_adopted(monkeypatch) -> None:
+    """The name goes on the page and into the report; there is a limit to it."""
+    _openai_server(monkeypatch, served=["m" * 200])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+
+    engine = AIEngine()
+
+    assert await engine.check_connection() is True
+    assert engine.model == "llama3.1:8b"
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_does_not_outlive_the_server_that_caused_it(
+    monkeypatch,
+) -> None:
+    """Restart the server with a local model and the old reason has to go.
+
+    It is printed by `info` and returned by /api/status, both of which can ask
+    twice in one process.
+    """
+    _openai_server(monkeypatch, served=["gpt-oss:120b-cloud"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:11434/v1")
+
+    engine = AIEngine()
+    assert await engine.check_connection() is False
+    assert engine.refusal
+
+    _openai_server(monkeypatch, served=["llama3.1:8b"])
+    assert await engine.check_connection() is True
+    assert engine.refusal is None
+
+
+def test_a_missing_ollama_package_is_not_a_server_that_is_down(monkeypatch) -> None:
+    """engine.py swallows the ImportError so the rest of the tool still runs,
+    which left `info` telling people to start a daemon they cannot install."""
+    from allelio.ai import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "AsyncClient", None)
+
+    printed = _cli_info(monkeypatch)
+
+    assert "pip install ollama" in printed
+    assert "No answer from" not in printed
+
+
+def test_a_query_string_cannot_swallow_the_endpoint() -> None:
+    """The base has "/models" glued to it, so anything after the path has to go."""
+    from allelio.ai.engine import pin_to_loopback
+
+    assert pin_to_loopback("http://127.0.0.1:1234/v1?a=b#c", "ALLELIO_OPENAI_BASE") == (
+        "http://127.0.0.1:1234/v1"
+    )
+
+
+def _run_attribution_block(results):
+    """Run the page's own attribution branch over a payload, under node.
+
+    One branch, in isolation: the caller decides what set it describes. That the
+    page hands it the cards it is actually showing is _run_the_card_render's
+    job, and that either is reached at all is §9's browser gate. node is
+    required rather than skipped: this repo has no CI, so a skip is a check that
+    quietly stops existing.
+    """
+    template = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "allelio/web/templates/index.html"
+    ).read_text()
+    block = template.split("// attribution-block start")[1].split(
+        "// attribution-block end"
+    )[0]
+
+    node = shutil.which("node")
+    if node is None:
+        if os.environ.get("ALLELIO_NO_JS"):
+            pytest.skip("ALLELIO_NO_JS is set")
+        pytest.fail("node is needed to run the page's attribution branch")
+
+    script = (
+        "const el = {style: {}, textContent: null};\n"
+        "const document = {getElementById: () => el};\n"
+        + block
+        + "\nrenderAttribution(" + json.dumps(results) + ");\n"
+        "console.log(JSON.stringify(el));\n"
+    )
+    done = subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        capture_output=True,
+        text=True,
+    )
+    assert done.returncode == 0, done.stderr
+    return json.loads(done.stdout)
+
+
+def _run_the_card_render(results, category):
+    """Run the page's own card render, filter and all, under node.
+
+    Wider than _run_attribution_block on purpose: it proves the line above the
+    cards is recomputed from the cards actually rendered. Nothing is
+    reimplemented here — every fenced region is the page's own source.
+    """
+    template = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "allelio/web/templates/index.html"
+    ).read_text()
+
+    def fenced(name):
+        return template.split(f"// {name} start")[1].split(f"// {name} end")[0]
+
+    node = shutil.which("node")
+    if node is None:
+        if os.environ.get("ALLELIO_NO_JS"):
+            pytest.skip("ALLELIO_NO_JS is set")
+        pytest.fail("node is needed to run the page's card render")
+
+    script = (
+        "const modelUsed = {style: {}, textContent: null};\n"
+        "const container = {innerHTML: '', appendChild: () => {}};\n"
+        "const document = {getElementById: id =>"
+        " id === 'modelUsed' ? modelUsed : container};\n"
+        "const createResultCard = () => ({});\n"
+        "const analysisResults = " + json.dumps({"results": results}) + ";\n"
+        "let currentCategory = " + json.dumps(category) + ";\n"
+        + fenced("attribution-block")
+        + fenced("slugify")
+        + fenced("render-cards")
+        + "\nrenderResultCards();\n"
+        "console.log(JSON.stringify(modelUsed));\n"
+    )
+    done = subprocess.run(
+        [node, "--input-type=module", "-e", script], capture_output=True, text=True
+    )
+    assert done.returncode == 0, done.stderr
+    return json.loads(done.stdout)
+
+
+def test_the_page_counts_the_cards_the_tab_is_showing():
+    """A tab filters the cards; the line above them used to keep the whole
+    run's count, so three carrier cards none of which a model wrote sat under
+    "12 of 50 explanations written by llama3.1:8b"."""
+    results = [
+        _card(category="Health Conditions", explained_by="llama3.1:8b"),
+        _card(category="Health Conditions", explained_by="llama3.1:8b"),
+        _card(category="Carrier Status", explained_by=None),
+    ]
+
+    everything = _run_the_card_render(results, "all")
+    assert everything["textContent"] == (
+        "2 of 3 explanations written by llama3.1:8b. The rest come straight "
+        "from ClinVar and the GWAS Catalog."
+    )
+
+    carriers = _run_the_card_render(results, "carrier_status")
+    assert carriers["textContent"] == (
+        "No model wrote the explanations below. They come straight from "
+        "ClinVar and the GWAS Catalog."
+    )
+
+    conditions = _run_the_card_render(results, "health_conditions")
+    assert conditions["textContent"] == "Explanations written by llama3.1:8b."
+
+
+def test_the_page_claims_nothing_when_there_are_no_results_to_claim():
+    """The container is emptied on this path, and the line above it was left
+    describing the analysis before it."""
+    assert _run_the_card_render(None, "all")["style"]["display"] == "none"
+
+
+def _run_credit_line(result):
+    """Run the page's per-card credit line over one card, under node.
+
+    Same reach and same limits as _run_attribution_block.
+    """
+    template = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "allelio/web/templates/index.html"
+    ).read_text()
+    block = template.split("// credit-line start")[1].split("// credit-line end")[0]
+
+    node = shutil.which("node")
+    if node is None:
+        if os.environ.get("ALLELIO_NO_JS"):
+            pytest.skip("ALLELIO_NO_JS is set")
+        pytest.fail("node is needed to run the page's credit line")
+
+    script = (
+        "const esc = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;');\n"
+        + block
+        + "\nconsole.log(JSON.stringify(creditLine("
+        + json.dumps(result)
+        + ")));\n"
+    )
+    done = subprocess.run(
+        [node, "--input-type=module", "-e", script], capture_output=True, text=True
+    )
+    assert done.returncode == 0, done.stderr
+    return json.loads(done.stdout)
+
+
+def test_a_card_says_which_model_wrote_it():
+    assert _run_credit_line(_card(explained_by="llama3.1:8b")) == (
+        '<div class="result-credit">Written by llama3.1:8b.</div>'
+    )
+
+
+def test_a_card_the_model_did_not_write_says_where_it_came_from():
+    assert _run_credit_line(_card(explained_by=None)) == (
+        '<div class="result-credit">No model wrote this. Data from ClinVar '
+        "and the GWAS Catalog.</div>"
+    )
+
+
+def test_a_card_from_before_the_credit_existed_claims_nothing():
+    """The wrong way round is the expensive one: telling a reader that a model's
+    own prose came from ClinVar dresses an 8B guess as a curated record."""
+    assert _run_credit_line(_card()) == ""
+
+
+def test_a_card_with_no_explanation_carries_no_credit_line():
+    assert _run_credit_line(_card(explanation=None, explained_by=None)) == ""
+
+
+def test_the_card_credit_escapes_the_model_name():
+    """The name comes off the server and lands in the page's innerHTML."""
+    assert "<img" not in _run_credit_line(_card(explained_by="<img src=x>"))
+
+
+def _card(explanation="Plain English.", **extra):
+    return dict({"rsid": "rs1", "explanation": explanation}, **extra)
+
+
+def test_the_page_says_who_wrote_the_cards_when_they_all_came_from_the_model():
+    el = _run_attribution_block([_card(explained_by="llama3.1:8b"), _card(explained_by="llama3.1:8b")])
+
+    assert el["textContent"] == "Explanations written by llama3.1:8b."
+    assert el["style"]["display"] == "block"
+
+
+def test_the_page_says_how_many_when_only_some_came_from_the_model():
+    el = _run_attribution_block(
+        [_card(explained_by="llama3.1:8b"), _card(explained_by=None), _card(explained_by=None)]
+    )
+
+    assert el["textContent"].startswith("1 of 3 explanations written by llama3.1:8b.")
+
+
+def test_the_page_names_no_model_when_none_wrote_a_card():
+    el = _run_attribution_block([_card(explained_by=None), _card(explained_by=None)])
+
+    assert el["textContent"] == (
+        "No model wrote the explanations below. They come straight from ClinVar "
+        "and the GWAS Catalog."
+    )
+
+
+def test_the_page_stays_quiet_about_a_payload_saved_before_the_cards_carried_credit():
+    el = _run_attribution_block([_card(), _card()])
+
+    assert el["textContent"] is None
+    assert el["style"]["display"] == "none"
+
+
+def test_a_card_with_no_explanation_does_not_dilute_the_count():
+    """Below the top 50 there is no explanation to credit or not credit."""
+    el = _run_attribution_block(
+        [_card(explained_by="llama3.1:8b"), _card(explanation=None, explained_by=None)]
+    )
+
+    assert el["textContent"] == "Explanations written by llama3.1:8b."
+
+
+def test_the_page_names_the_model_that_wrote_the_cards() -> None:
+    """The status pill is fetched once at page load and can be stale by the time
+    a half-hour run finishes; the payload's own attribution is not.
+
+    A grep, and only a grep: nothing here runs the script, so this catches the
+    element and the read being deleted but not the branch being made
+    unreachable. That the line actually renders is asserted in the browser run.
+    """
+    template = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "allelio/web/templates/index.html"
+    ).read_text()
+
+    assert 'id="modelUsed"' in template
+    # Counted off the cards, and off nothing else: no read of model_used is
+    # left on the page for a partial run to contradict.
+    assert "r.explained_by" in template
+    assert "analysisResults.model_used" not in template
+    assert "of ${explained.length} explanations written by" in template
+    assert "Explanations written by ${names.join(', ')}." in template
+    # Three states, not two: a payload saved before this key existed hides the
+    # line rather than claiming nothing wrote cards a model did write.
+    assert "No model wrote the explanations below." in template
+    assert "!cards.some(r => 'explained_by' in r)" in template
+    # And each card says for itself who wrote it.
+    assert "No model wrote this. Data from ClinVar and the GWAS Catalog." in template
+    # And the pill switches on the one word the engine answers with.
+    assert "ai.status === 'serving'" in template
+    assert "ai.status === 'unlisted'" in template
+    assert "ai.status === 'refuted'" in template
+
+
+# --- What the server said about itself ---------------------------------------
+#
+# The listing used to be a veto: a name that was not in it aborted the run, and
+# a listing that never came back was read as no server at all. Both were wrong
+# in the same way — they treated "the server did not say" as "the server said
+# no" — and the model server this feature is about, a bare llama.cpp, has no
+# /v1/models endpoint to say anything with. These pin the five answers apart.
+
+
+@pytest.mark.asyncio
+async def test_the_status_is_one_word_and_covers_every_case(monkeypatch) -> None:
+    """The truth table three call sites used to work out for themselves."""
+    from allelio.ai.engine import SERVING, REFUTED, UNLISTED, UNREACHABLE, REFUSED
+
+    async def status_for(**kw):
+        _openai_server(monkeypatch, **kw)
+        monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+        engine = AIEngine()
+        await engine.check_connection()
+        return engine
+
+    monkeypatch.setenv("ALLELIO_MODEL", "llama3.1:8b")
+    assert (await status_for(served=["llama3.1:8b"])).status == SERVING
+    # Case is not a difference: Ollama resolves names case-insensitively, and
+    # comparing them exactly refused a name the server was serving.
+    assert (await status_for(served=["LLAMA3.1:8B"])).status == SERVING
+    assert (await status_for(served=["qwen2.5-14b-instruct"])).status == REFUTED
+    # An empty listing is an answer — "I serve nothing" — not a silence. A
+    # fresh Ollama with nothing pulled is the commonest misconfiguration there
+    # is, and it has to keep its `ollama pull` line.
+    assert (await status_for(served=[])).status == REFUTED
+    # No /v1/models at all: a bare llama.cpp. It has said nothing about its
+    # models, which is not the same as saying it has not got this one.
+    assert (await status_for(lists=False)).status == UNLISTED
+
+    monkeypatch.delenv("ALLELIO_MODEL")
+    refused = await status_for(served=["gpt-oss:120b-cloud"])
+    assert refused.status == REFUSED
+    # A refused model is not a refuted one. The listing came back and `listed`
+    # is True, so a predicate that only asked "did it list, and is my model in
+    # it" said the model was missing when the thing to print is the relay.
+    assert refused.model_refuted() is False
+
+    class Dead:
+        async def list(self):
+            raise ConnectionRefusedError("nothing there")
+
+    engine = AIEngine()
+    engine.client = Dead()
+    await engine.check_connection()
+    assert engine.status == UNREACHABLE
+    assert engine.model_refuted() is False
+    assert engine.will_explain() is False
+
+
+@pytest.mark.asyncio
+async def test_a_listing_that_never_came_back_is_not_a_server_that_is_down(
+    monkeypatch,
+) -> None:
+    """A slow listing used to cost the whole run its explanations.
+
+    A warming Ollama daemon takes its time over /api/tags while answering chat
+    perfectly well, and a dead port answers ConnectError in milliseconds — so a
+    clock that ran out is evidence of something being there, not of nothing.
+    """
+    from allelio.ai import engine as engine_module
+
+    class Slow:
+        async def list(self):
+            await asyncio.sleep(30)
+
+        async def chat(self, **kwargs):
+            return {"message": {"content": "A plain-English explanation."}}
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: Slow())
+    engine = AIEngine()
+    assert await engine.check_connection() is True
+    assert engine.status == "unlisted"
+    assert engine.will_explain() is True
+
+
+def test_analyze_explains_through_a_server_that_will_not_list_its_models(
+    monkeypatch, tmp_path
+) -> None:
+    """The flagship configuration: a bare llama.cpp with no /v1/models."""
+    _openai_server(monkeypatch, lists=False, served=["anything"], answers_anything=True)
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:8080/v1")
+    monkeypatch.setenv("ALLELIO_MODEL", "Qwen3-8B-Q4_K_M.gguf")
+
+    result = _analyze(monkeypatch, tmp_path)
+    printed = " ".join(result.output.split())
+
+    assert result.exit_code == 0
+    assert "Generated 1 AI explanations" in printed
+    assert "Qwen3-8B-Q4_K_M.gguf" in (tmp_path / "r.html").read_text()
+
+
+def test_analyze_prints_the_servers_own_reason_when_the_chat_fails(
+    monkeypatch, tmp_path
+) -> None:
+    """`model 'x' not found` is the whole diagnostic, and it is in the body.
+
+    raise_for_status() throws the body away and reports the status line and a
+    link to MDN, so the one sentence that says what to change never reached the
+    person on the path this feature is about.
+    """
+    _openai_server(monkeypatch, lists=False, served=["something-else"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:8080/v1")
+
+    result = _analyze(monkeypatch, tmp_path)
+    printed = " ".join(result.output.split())
+
+    assert result.exit_code == 0
+    assert "No explanations generated" in printed
+    assert "model 'llama3.1:8b' not found" in printed
+    # And the per-variant line agrees: a fallback card is not a tick.
+    assert "[1/1] rs429358 \u2717" in printed
+    assert "[1/1] rs429358 \u2713" not in printed
+    report = (tmp_path / "r.html").read_text()
+    assert "AI Model: none" in report
+
+
+def test_analyze_sends_nothing_when_nothing_is_answering(monkeypatch, tmp_path) -> None:
+    """No listing, no prompt, and a report either way."""
+    from allelio.ai import engine as engine_module
+
+    asked = []
+
+    class Silent:
+        async def list(self):
+            asked.append("list")
+            raise ConnectionRefusedError("nothing there")
+
+        async def chat(self, **kwargs):
+            asked.append("chat")
+            raise ConnectionRefusedError("nothing there")
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: Silent())
+
+    result = _analyze(monkeypatch, tmp_path)
+    printed = " ".join(result.output.split())
+
+    assert result.exit_code == 0
+    assert "No answer from Ollama" in printed
+    assert asked == ["list"]
+    assert "AI Model: none" in (tmp_path / "r.html").read_text()
+
+
+def test_analyze_tells_an_ollama_user_with_nothing_pulled_to_pull(
+    monkeypatch, tmp_path
+) -> None:
+    """A fresh install lists {"models": []}, which is an answer and a menu."""
+    from allelio.ai import engine as engine_module
+
+    class Empty:
+        async def list(self):
+            return {"models": []}
+
+        async def chat(self, **kwargs):
+            raise AssertionError("no prompt should be sent")
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: Empty())
+
+    result = _analyze(monkeypatch, tmp_path)
+    printed = " ".join(result.output.split())
+
+    assert result.exit_code == 0
+    assert "is not serving" in printed
+    assert "ollama pull llama3.1:8b" in printed
+    assert "AI Model: none" in (tmp_path / "r.html").read_text()
+
+
+def test_analyze_runs_a_model_named_in_the_wrong_case(monkeypatch, tmp_path) -> None:
+    """Ollama resolves names case-insensitively; this used to refuse them.
+
+    Measured against the real daemon: POST /api/chat with "LLAMA3.1:8B" answers
+    200 and echoes that spelling back.
+    """
+    from allelio.ai import engine as engine_module
+
+    class Answering:
+        async def list(self):
+            return {"models": [{"model": "llama3.1:8b"}]}
+
+        async def chat(self, **kwargs):
+            return {"message": {"content": "A plain-English explanation."}}
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: Answering())
+    monkeypatch.setenv("ALLELIO_MODEL", "LLAMA3.1:8B")
+
+    result = _analyze(monkeypatch, tmp_path)
+
+    assert "Generated 1 AI explanations" in " ".join(result.output.split())
+    # Credited in the spelling that was configured, which is the only honest
+    # string available: Ollama echoes back whatever it was sent.
+    assert "LLAMA3.1:8B" in (tmp_path / "r.html").read_text()
+
+
+def test_the_upload_names_a_model_the_listing_only_answers_to_by_alias(
+    monkeypatch,
+) -> None:
+    """llama-swap routes on names that are nowhere in its list of ids.
+
+    ALLELIO_MODEL=qwen36 is a working configuration whose name appears only
+    under meta.llamaswap.aliases — measured against the real server on :1234 —
+    and the listing gate used to refuse it.
+    """
+    from allelio.web import routes as routes_module
+
+    _llama_swap(monkeypatch, {"Qwen3.6-35B-A3B": ["qwen36", "qwen"]})
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+    monkeypatch.setenv("ALLELIO_MODEL", "qwen36")
+
+    class FakeDB:
+        def is_initialized(self):
+            return True
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(routes_module, "AllelioDB", lambda *a, **k: FakeDB())
+    monkeypatch.setattr(routes_module, "parse_genotype_file", lambda path: [_variant()])
+    monkeypatch.setattr(routes_module, "analyze_variants", lambda *a, **k: [_variant()])
+
+    payload = (
+        TestClient(app, base_url="http://127.0.0.1")
+        .post(
+            "/api/analyze",
+            files={"file": ("genome.txt", b"rs429358\t19\t44908684\tCT\n", "text/plain")},
+        )
+        .json()
+    )
+
+    assert payload["model_used"].startswith("qwen36 (OpenAI-compatible")
+
+
+def test_the_upload_does_not_credit_the_summary_to_the_cards(monkeypatch) -> None:
+    """The summary is a separate call and can be the only one that answers.
+
+    Counting it would put "Explanations written by X" over fifty cards X never
+    wrote, which is the sentence the page renders from this key.
+    """
+    from allelio.web import routes as routes_module
+
+    class OnlyTheSummary:
+        async def list(self):
+            return {"models": [{"model": "llama3.1:8b"}]}
+
+        async def chat(self, model, messages, **kwargs):
+            # The batch asks one variant at a time; the summary asks for a
+            # summary. Only the second one is answered here.
+            if "Summar" not in messages[-1]["content"]:
+                raise RuntimeError("model is busy")
+            return {"message": {"content": "Two findings worth a second look."}}
+
+    from allelio.ai import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: OnlyTheSummary())
+
+    class FakeDB:
+        def is_initialized(self):
+            return True
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(routes_module, "AllelioDB", lambda *a, **k: FakeDB())
+    monkeypatch.setattr(routes_module, "parse_genotype_file", lambda path: [_variant()])
+    monkeypatch.setattr(routes_module, "analyze_variants", lambda *a, **k: [_variant()])
+
+    payload = (
+        TestClient(app, base_url="http://127.0.0.1")
+        .post(
+            "/api/analyze",
+            files={"file": ("genome.txt", b"rs429358\t19\t44908684\tCT\n", "text/plain")},
+        )
+        .json()
+    )
+
+    assert payload["model_used"] == "none"
+    # And the summary the model did write is still shown.
+    assert "second look" in payload["summary"]
+
+
+def test_the_upload_credits_the_cards_one_by_one(monkeypatch) -> None:
+    """The run that no single name can describe: some answered, some did not.
+
+    Fifty variants, a model that starts failing at variant twelve, and one
+    string on the payload saying who wrote "the explanations" — that string is
+    wrong for thirty-eight cards whichever way it is written. The credit is on
+    each card instead, and there is no longer a run-level string for the page
+    to read.
+    """
+    from allelio.web import routes as routes_module
+
+    class AnswersOnce:
+        async def list(self):
+            return {"models": [{"model": "llama3.1:8b"}]}
+
+        async def chat(self, model, messages, **kwargs):
+            asked = messages[-1]["content"]
+            if "Summar" in asked:
+                return {"message": {"content": "Two findings worth a second look."}}
+            if "rs1" in asked:
+                return {"message": {"content": "A plain-English explanation."}}
+            raise RuntimeError("model is busy")
+
+    from allelio.ai import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: AnswersOnce())
+
+    class FakeDB:
+        def is_initialized(self):
+            return True
+
+        def close(self):
+            pass
+
+    found = [_variant("rs1"), _variant("rs2"), _variant("rs3")]
+    monkeypatch.setattr(routes_module, "AllelioDB", lambda *a, **k: FakeDB())
+    monkeypatch.setattr(routes_module, "parse_genotype_file", lambda path: found)
+    monkeypatch.setattr(routes_module, "analyze_variants", lambda *a, **k: found)
+
+    payload = (
+        TestClient(app, base_url="http://127.0.0.1")
+        .post(
+            "/api/analyze",
+            files={"file": ("genome.txt", b"rs1\t19\t44908684\tCT\n", "text/plain")},
+        )
+        .json()
+    )
+
+    cards = {r["rsid"]: r for r in payload["results"]}
+    assert cards["rs1"]["explained_by"].startswith("llama3.1:8b (Ollama at ")
+    # The two the model never wrote carry no name, on a run where it wrote one.
+    assert cards["rs2"]["explained_by"] is None
+    assert cards["rs3"]["explained_by"] is None
+    # Their text is still there — the variant's own data — which is exactly why
+    # the card has to say who wrote it.
+    assert cards["rs2"]["explanation"]
+    # And the payload's own count agrees with the cards, because it is read
+    # off them.
+    written = [r for r in payload["results"] if r["explained_by"]]
+    assert len(written) == 1
+    assert payload["model_used"] == cards["rs1"]["explained_by"]
+
+
+def test_the_report_credits_the_cards_one_by_one() -> None:
+    """The same partial run, in the file people keep and show around."""
+    from allelio.report import generate_html_report
+
+    html = generate_html_report(
+        [_variant("rs1"), _variant("rs2")],
+        {
+            "rs1": Explanation("A plain-English explanation.", "llama3.1:8b"),
+            "rs2": Explanation("Explanation: model is busy", None),
+        },
+        "",
+        {"generated_at": "now"},
+    )
+
+    assert "1 of 2 variants analyzed with llama3.1:8b" in html
+    assert "AI Analysis — llama3.1:8b" in html
+    assert "No model wrote this" in html
+    # One heading each, and the fallback card does not get the model's.
+    assert html.count("AI Analysis — llama3.1:8b") == 1
+    assert html.count("No model wrote this") == 1
+
+
+def test_the_cli_credits_the_cards_one_by_one(monkeypatch, tmp_path) -> None:
+    """Same run again, on the console and in the report it writes.
+
+    The tick, the tally and the report all read the same records, so a run that
+    wrote one of two cards cannot print two ticks, or say two, or head both
+    cards with the model's name.
+    """
+    from allelio.ai import engine as engine_module
+
+    class AnswersOnce:
+        async def list(self):
+            return {"models": [{"model": "llama3.1:8b"}]}
+
+        async def chat(self, model, messages, **kwargs):
+            if "rs1" in messages[-1]["content"]:
+                return {"message": {"content": "A plain-English explanation."}}
+            raise RuntimeError("model is busy")
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: AnswersOnce())
+
+    result = _analyze(
+        monkeypatch, tmp_path, variants=[_variant("rs1"), _variant("rs2")]
+    )
+    printed = " ".join(result.output.split())
+
+    assert "[1/2] rs1 \u2713" in printed
+    assert "[2/2] rs2 \u2717" in printed
+    assert "Generated 1 AI explanations" in printed
+
+    report = (tmp_path / "r.html").read_text()
+    assert "1 of 2 variants analyzed with llama3.1:8b" in report
+    assert report.count("AI Analysis \u2014 llama3.1:8b") == 1
+    assert report.count("No model wrote this") == 1
+
+
+def test_info_and_analyze_agree_about_a_server_that_will_not_list(
+    monkeypatch, tmp_path
+) -> None:
+    """They used to disagree: `info` said the model was missing, `analyze` ran."""
+    _openai_server(monkeypatch, lists=False, served=["x"], answers_anything=True)
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:8080/v1")
+
+    printed_info = _cli_info(monkeypatch)
+    printed_analyze = " ".join(_analyze(monkeypatch, tmp_path).output.split())
+
+    assert "is not on that server" not in printed_info
+    assert "is not serving" not in printed_analyze
+    assert "answering at" in printed_info
+
+
+def test_the_status_payload_carries_the_word_the_page_switches_on(
+    monkeypatch,
+) -> None:
+    """A server that answers without listing is connected, not disconnected."""
+    _openai_server(monkeypatch, lists=False)
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:8080/v1")
+
+    body = TestClient(app, base_url="http://127.0.0.1").get("/api/status").json()
+
+    assert body["ai"]["status"] == "unlisted"
+    assert body["ai"]["available"] is True
+    assert body["ai"]["model_available"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_served_entry_this_shape_does_not_read_as_a_dead_server(
+    monkeypatch,
+) -> None:
+    """Another process's JSON, parsed without trusting its shape.
+
+    A TypeError in here lands in check_connection's blanket except, where a
+    server that answered is reported as not being there at all.
+    """
+    from allelio.ai.engine import _aliases_of
+
+    assert _aliases_of({"meta": {"llamaswap": {"aliases": "qwen36"}}}) == []
+    assert _aliases_of({"meta": {"llamaswap": {"aliases": 7}}}) == []
+    assert _aliases_of({"meta": {"llamaswap": {"aliases": ["qwen36"]}}}) == ["qwen36"]
+
+    import httpx as real
+
+    from allelio.ai import engine as engine_module
+
+    def handler(request):
+        return real.Response(200, json={"data": None})
+
+    monkeypatch.setattr(engine_module, "httpx", FakeHttpx(handler))
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:1234/v1")
+    engine = AIEngine()
+    assert await engine.check_connection() is True
+    assert engine.served_models == []
+    # It answered and listed nothing, so it is refuted, not unreachable.
+    assert engine.status == "refuted"
+
+
+@pytest.mark.asyncio
+async def test_the_bridge_raises_rather_than_hand_back_a_fallback(monkeypatch) -> None:
+    """"or raises if no model answers" is the documented contract.
+
+    A failed call returns the variant's own data wrapped in a disclaimer, and
+    handing that to a caller that was promised an exception is handing it text
+    it will present as an explanation.
+    """
+    from allelio.ai.explanations import generate_explanation
+
+    _openai_server(monkeypatch, lists=False, served=["something-else"])
+    monkeypatch.setenv("ALLELIO_OPENAI_BASE", "http://127.0.0.1:8080/v1")
+
+    with pytest.raises(RuntimeError, match="not found"):
+        await generate_explanation(_variant())
+
+
+def test_analyze_says_the_package_is_missing_rather_than_the_server(
+    monkeypatch, tmp_path
+) -> None:
+    """Only `allelio info` said this. engine.py swallows the ImportError."""
+    from allelio.ai import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "AsyncClient", None)
+
+    printed = " ".join(_analyze(monkeypatch, tmp_path).output.split())
+
+    assert "pip install ollama" in printed
+    assert "No answer from" not in printed
+
+
+@pytest.mark.asyncio
+async def test_a_reason_does_not_outlive_the_call_that_gave_it(monkeypatch) -> None:
+    """last_error is printed after the run, so a stale one is a wrong sentence.
+
+    One variant failing and the next one answering used to leave the first
+    one's message on the engine, where the end-of-run line reads it.
+    """
+    from allelio.ai import engine as engine_module
+
+    replies = [RuntimeError("model 'x' not found"), {"message": {"content": "Plain."}}]
+
+    class Flaky:
+        async def list(self):
+            return {"models": [{"model": "llama3.1:8b"}]}
+
+        async def chat(self, **kwargs):
+            reply = replies.pop(0)
+            if isinstance(reply, Exception):
+                raise reply
+            return reply
+
+    monkeypatch.setattr(engine_module, "AsyncClient", lambda **kwargs: Flaky())
+    engine = AIEngine()
+    await engine.check_connection()
+
+    await engine.explain(_variant())
+    assert "not found" in engine.last_error
+    await engine.explain(_variant())
+    assert engine.last_error is None

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -125,9 +125,10 @@ def test_result_cards_get_a_gene_and_a_significance() -> None:
     assert _gene_of(benign) is None
 
 
-def test_conflicting_interpretations_are_not_pathogenic() -> None:
-    """ClinVar's commonest ambiguous term contains the word "pathogenic"; a
-    substring match painted those variants with the red badge."""
+def test_conflicting_classifications_get_their_own_badge() -> None:
+    """ClinVar's commonest ambiguous term contains the word "pathogenic", so a
+    substring match painted 130k variants with the red badge — and calling them
+    a trait instead painted them green. They are neither."""
     from allelio.web.routes import _significance_of
 
     conflicting = VariantResult(
@@ -135,11 +136,25 @@ def test_conflicting_interpretations_are_not_pathogenic() -> None:
         clinvar_entries=[
             ClinVarEntry(
                 rsid="rs1",
-                clinical_significance="Conflicting interpretations of pathogenicity",
+                # The term the shipped ClinVar dump actually uses.
+                clinical_significance="Conflicting classifications of pathogenicity",
             )
         ],
     )
-    assert _significance_of(conflicting) != "pathogenic"
+    assert _significance_of(conflicting) == "conflicting"
+
+
+def test_clinvar_benign_survives_a_gwas_hit() -> None:
+    """Any GWAS row used to be checked before ClinVar's benign call, so a
+    variant ClinVar calls benign came out orange."""
+    from allelio.web.routes import _significance_of
+
+    variant = VariantResult(
+        rsid="rs1",
+        clinvar_entries=[ClinVarEntry(rsid="rs1", clinical_significance="Benign")],
+        gwas_entries=[GWASEntry(rsid="rs1", trait="Height", p_value=1e-9)],
+    )
+    assert _significance_of(variant) == "benign"
 
 
 @pytest.mark.asyncio
@@ -212,3 +227,37 @@ def test_strong_gwas_reads_the_smallest_p_values() -> None:
     prompt = engine.client.prompts[0]
 
     assert prompt.index("rs3") < prompt.index("rs4")
+
+
+def test_exported_report_carries_the_counselling_warnings() -> None:
+    """The safety layer computes a warning for BRCA1/2, TP53, Lynch and APOE.
+    Every consumer dropped it on the floor."""
+    from allelio.web.routes import _generate_html_report
+
+    html = _generate_html_report(
+        {
+            "results": [
+                {
+                    "rsid": "rs1",
+                    "warnings": ["Talk to a genetic counselor."],
+                }
+            ]
+        }
+    )
+    assert "Talk to a genetic counselor." in html
+
+
+def test_export_does_not_leave_the_report_in_the_temp_directory() -> None:
+    """The report holds the user's genotypes, and the system temp directory is
+    world-readable."""
+    import tempfile
+    from pathlib import Path
+
+    temp_dir = Path(tempfile.gettempdir())
+    before = set(temp_dir.glob("allelio_report_*"))
+
+    client = TestClient(app)
+    response = client.post("/api/export", json={"results": [{"rsid": "rs1"}]})
+
+    assert response.status_code == 200
+    assert set(temp_dir.glob("allelio_report_*")) == before


### PR DESCRIPTION
Stacked on #1 and #2 — the commits from both appear below until they merge. The commit to review here is the last one.

## What this changes

**Any local server, not just Ollama.** `ALLELIO_OPENAI_BASE` points the engine at anything speaking the OpenAI API — llama.cpp, llama-swap, LM Studio, vLLM — and `ALLELIO_MODEL` names the model on it. Aliases resolve, so a llama-swap name that exists only under `meta.llamaswap.aliases` works. A server holding exactly one model gets to name it, and that adopted name is the one shown. Ollama remains the default and needs no configuration.

**The name shown is the model that answered**, not the one configured. Every explanation now carries the name of whoever wrote it, and a single function derives the credit for every place it is displayed: the line above the results, the line under each card, the downloaded report, the CLI report and the API payload. A failed call still fills a card — the variant's own ClinVar and GWAS data, wrapped in the disclaimer — and that card says so instead of being credited to the model.

Each of those lines describes the cards actually in front of the reader: the page recomputes when a category tab filters the list, and the downloaded report counts the same hundred rows its table prints. An analysis saved before any of this existed claims nothing rather than telling the reader that ClinVar wrote a model's prose.

**The privacy boundary is explicit.** The host is resolved, every answer checked against loopback, and the connection made to the address that was checked. `trust_env` is off, so no proxy variable can redirect a prompt; redirects are not followed; the `authorization` header is dropped. An Ollama `-cloud` tag is refused by name — the one case where `127.0.0.1:11434` is not this machine, because the daemon forwards it. The interface shows one word for the state of the model server — unreachable, refused, refuted, unlisted or serving — and the same word decides whether a prompt is sent at all.

## Tests

257 pass. Beyond the Python, the page's own JavaScript is sliced out of the template and executed under `node` with a DOM stub, so the branches that print the credit are run rather than grepped. `node` is required rather than skipped, since there is no CI here; `ALLELIO_NO_JS=1` opts out.

## Tried against real servers

- Ollama with `llama3.1:8b` — web upload of 14 variants against the full ClinVar/GWAS database, all 14 credited by name on the page, under each card, and in both reports.
- llama-swap with `Qwen3.6-35B-A3B`, addressed by its alias `qwen36` — `info` and a CLI run, credited as `qwen36 (OpenAI-compatible at http://127.0.0.1:1234/v1)`.
- A partial run: the cards a model did not write say so, and the counts above them follow the filter.

Genotype data used for those runs was synthetic — real rsIDs, invented genotypes.
