### PR TITLE
Preserve VCF source evidence and haploid copy counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ PUBLICATION_PLAN.md
 paper_outline.md
 paper.md
 paper.bib
+
+# Internal publication strategy, working protocols, and development reports
+PUBLICATION_STRATEGY.md
+docs/research/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- Preserve haploid VCF genotypes as one allele rather than duplicating them,
+  so haploid SNVs reach zygosity interpretation with the correct copy count.
+- Skip malformed VCF headers without crashing on unset column indices.
+
+### Added
+
+- Optional VCF source evidence on parsed variants: ordered alleles/indices,
+  phase and ploidy, raw reference declaration, and quality fields. Existing
+  consumer-format constructors remain compatible. See `docs/vcf-evidence.md`
+  for interpretation limits and reproducible development checks.
+
 ## [0.3.0] - 2026-09-09 — Revival
 
 **Unblocking population frequencies, and hardening the rolling downloads.** The gnomAD frequency feature shipped in 0.2.1 was inert because its data file was never published (the download 404'd). This makes it real and shores up the other data sources against upstream drift.

--- a/allelio/parsers/base.py
+++ b/allelio/parsers/base.py
@@ -12,6 +12,31 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 
+@dataclass(frozen=True)
+class VCFEvidence:
+    """Original VCF evidence; reference declaration is not a verified build.
+
+    Alleles and indices retain GT order. Phase applies within this record;
+    phase_set is retained without inferring relationships between records.
+    Quality values remain source strings; None means unavailable, not zero.
+    """
+    reference: str
+    alternates: Tuple[str, ...]
+    allele_indices: Tuple[int, ...]
+    alleles: Tuple[str, ...]
+    phased: Optional[bool]
+    reference_declaration: Optional[str] = None
+    phase_set: Optional[str] = None
+    quality: Optional[str] = None
+    filter_status: Optional[str] = None
+    genotype_quality: Optional[str] = None
+    depth: Optional[str] = None
+
+    @property
+    def ploidy(self) -> int:
+        return len(self.allele_indices)
+
+
 @dataclass
 class Variant:
     """Represents a genetic variant with genotype information.
@@ -26,6 +51,7 @@ class Variant:
     chromosome: str
     position: int
     genotype: str
+    vcf_evidence: Optional[VCFEvidence] = None
 
 
 def detect_format(filepath: str) -> str:

--- a/allelio/parsers/vcf_parser.py
+++ b/allelio/parsers/vcf_parser.py
@@ -15,7 +15,7 @@ Format specification:
 import gzip
 from typing import List, Generator, Optional, Tuple
 
-from .base import Variant
+from .base import Variant, VCFEvidence
 
 
 def _parse_gt_field(gt_str: str, ref: str, alt: str) -> Optional[str]:
@@ -63,7 +63,9 @@ def _parse_gt_field(gt_str: str, ref: str, alt: str) -> Optional[str]:
     if len(genotype_alleles) == 2:
         return ''.join(sorted(genotype_alleles))
     elif len(genotype_alleles) == 1:
-        return genotype_alleles[0] * 2  # Haploid to diploid
+        # The legacy display cannot distinguish a two-base haploid allele
+        # from two SNP copies. Keep it uncalled there; evidence retains it.
+        return genotype_alleles[0] if len(genotype_alleles[0]) == 1 else "--"
     else:
         return None
 
@@ -85,6 +87,7 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
         format_index = None
         sample_column_index = None
         gt_index = None
+        reference_declaration = None
         
         for line in f:
             line = line.rstrip('\n')
@@ -95,11 +98,13 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
             
             # Skip meta-info lines
             if line.startswith('##'):
+                if line.startswith('##reference='):
+                    reference_declaration = line.partition('=')[2] or None
                 continue
             
             # Parse header line
             if line.startswith('#CHROM'):
-                header_line = line
+                header_line = None
                 parts = line[1:].split('\t')  # Remove leading #
                 
                 try:
@@ -113,6 +118,7 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
                     
                     # Sample column is the first column after FORMAT
                     sample_column_index = format_index + 1
+                    header_line = line
                 except ValueError:
                     continue
                 
@@ -163,12 +169,30 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
                 if genotype is None:
                     continue
                 
+                fields = dict(zip(format_parts, sample_parts))
+                def available(value):
+                    return value if value not in (None, "", ".") else None
+
+                indices = tuple(int(i) for i in gt_str.replace('|', '/').split('/'))
+                alternatives = tuple(alt.split(',')) if alt != '.' else ()
+                options = (ref,) + alternatives
+                evidence = VCFEvidence(
+                    reference=ref, alternates=alternatives,
+                    allele_indices=indices, alleles=tuple(options[i] for i in indices),
+                    phased=('|' in gt_str) if len(indices) > 1 else None,
+                    reference_declaration=reference_declaration,
+                    phase_set=available(fields.get('PS')),
+                    quality=available(parts[5]), filter_status=available(parts[6]),
+                    genotype_quality=available(fields.get('GQ')),
+                    depth=available(fields.get('DP')),
+                )
                 # Yield valid variant
                 yield Variant(
                     rsid=rsid,
                     chromosome=chromosome,
                     position=position,
-                    genotype=genotype
+                    genotype=genotype,
+                    vcf_evidence=evidence,
                 )
             
             except (ValueError, IndexError):

--- a/docs/vcf-evidence.md
+++ b/docs/vcf-evidence.md
@@ -1,0 +1,42 @@
+# VCF parsing evidence
+
+VCF records returned by `parse_vcf()` carry an optional `Variant.vcf_evidence`
+object. Existing four-argument `Variant` construction remains supported and
+consumer-array records leave this object unset.
+
+The evidence retains REF, ordered ALT entries, GT allele indices and ordered
+allele sequences, ploidy, within-record phase, PS, QUAL, FILTER, GQ, DP, and the
+raw `##reference` declaration. Missing fields are `None`; numerical zero remains
+a source value. Quality fields are preserved as strings, not interpreted as a
+validation score. No reference URL is fetched or used to infer a verified build.
+
+The legacy genotype display sorts diploid alleles. Use evidence allele order
+when inspecting phase. Haploid SNVs retain a single allele, allowing the existing
+zygosity calculation to distinguish one copy from two. A phase delimiter alone
+does not establish phase relationships between different records.
+
+## Current limits
+
+The parser selects the first sample. Missing/partial GT calls, unsupported
+ploidy, and records without identifiers are still skipped. Evidence preservation
+does not add coordinate lookup, reference normalization, cross-build matching,
+quality filtering, or general indel/structural-variant interpretation. The legacy
+analysis still uses its genotype string; do not use it to infer multibase allele
+boundaries. Haploid multibase alleles use `--` in the legacy display to avoid being read as
+two SNP alleles. Full source alleles remain available in the evidence object.
+
+## Reproducible development checks
+
+Run `python3 -m pytest tests/test_vcf_evidence.py tests/test_vcf_ploidy.py -q`.
+The tests generate synthetic records, including ordered multiallelic indels,
+phased/unphased calls, haploid SNVs, missing fields, and gzip input.
+
+`python3 scripts/publication_baseline.py --output /tmp/allelio-baseline.json`
+combines the shipped example checks, lexical-filter fixture counts, and four
+VCF ploidy challenges. It needs a source checkout with the development dependencies.
+It uses shipped fixtures and temporary storage, not personal genomic inputs or
+live reference downloads. Its results are development evidence, not independent
+validation or a clinical accuracy estimate. Review generated artifacts before
+sharing: source hashes and checkout revision are included for reproducibility.
+
+Source format: [VCF specification](https://samtools.github.io/hts-specs/VCFv4.3.pdf).

--- a/scripts/publication_baseline.py
+++ b/scripts/publication_baseline.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Reproduce internal development checks; never an independent accuracy benchmark."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from allelio.analysis.example_check import build_fixture_db, compare
+from allelio.ai.safety import find_unsafe_language
+from allelio.parsers.vcf_parser import parse_vcf
+from allelio.analysis.zygosity import call_zygosity
+
+
+def run():
+    cases = []
+    with tempfile.TemporaryDirectory() as directory:
+        db = build_fixture_db(str(Path(directory) / 'fixture.db'))
+        example = [dict(check=n, passed=p, detail=d) for n, p, d in compare(db)]
+        for name, gt, expected in [('haploid_alt', '1', 1),
+                                   ('haploid_ref', '0', 0),
+                                   ('diploid_het', '0/1', 1),
+                                   ('diploid_alt', '1/1', 2)]:
+            path = Path(directory) / 'case.vcf'
+            path.write_text('##fileformat=VCFv4.2\n'
+                            '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n'
+                            f'X\t100\trs900000001\tA\tG\t.\tPASS\t.\tGT\t{gt}\n')
+            variants = parse_vcf(str(path))
+            actual = call_zygosity(variants[0].genotype, 'A', 'G') if variants else None
+            expected_ploidy = 1 if '/' not in gt else 2
+            passed = (actual is not None and actual.alt_copies == expected
+                      and len(variants[0].genotype) == expected_ploidy)
+            cases.append(dict(case=name, expected_copies=expected,
+                              actual_copies=actual.alt_copies if actual else None,
+                              expected_ploidy=expected_ploidy,
+                              genotype=variants[0].genotype if variants else None,
+                              passed=passed))
+    labelled = json.loads((ROOT / 'tests/fixtures/safety_sentences.json').read_text())
+    caught = sum(bool(find_unsafe_language(x['text'])) for x in labelled['unsafe'])
+    false_positive = sum(bool(find_unsafe_language(x)) for x in labelled['safe'])
+    paths = sorted(p for folder in ('allelio', 'tests/fixtures', 'examples')
+                   for p in (ROOT / folder).rglob('*')
+                   if p.is_file() and '__pycache__' not in p.parts
+                   and p.suffix in ('.py', '.json', '.tsv', '.csv', '.gz', '.txt'))
+    paths.append(Path(__file__).resolve())
+    hashes = {str(p.relative_to(ROOT)): hashlib.sha256(p.read_bytes()).hexdigest() for p in paths}
+    revision = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=ROOT, text=True).strip()
+    dirty = bool(subprocess.check_output(['git', 'status', '--porcelain'], cwd=ROOT, text=True).strip())
+    passed = all(x['passed'] for x in example + cases) and caught == len(labelled['unsafe']) and false_positive == 0
+    return dict(schema_version=1, evidence_type='internal_development_only',
+                independent_validation=False, revision=revision, working_tree_dirty=dirty,
+                file_sha256=hashes, example_checks=example, vcf_challenges=cases,
+                safety=dict(unsafe_total=len(labelled['unsafe']), caught=caught,
+                            safe_total=len(labelled['safe']), false_positives=false_positive),
+                passed=passed)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    result = run()
+    args.output.write_text(json.dumps(result, indent=2) + '\n')
+    print(f"Internal development checks: {'PASS' if result['passed'] else 'FAIL'}; {args.output}")
+    return 0 if result['passed'] else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_vcf_evidence.py
+++ b/tests/test_vcf_evidence.py
@@ -1,0 +1,65 @@
+"""Preserve source evidence independently of the legacy genotype display."""
+import gzip
+import pytest
+from allelio.parsers.base import Variant
+from allelio.parsers.vcf_parser import parse_vcf
+
+
+def write_vcf(tmp_path, row, meta='', compressed=False):
+    text = ('##fileformat=VCFv4.3\n' + meta +
+            '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n' + row + '\n')
+    path = tmp_path / ('case.vcf.gz' if compressed else 'case.vcf')
+    if compressed:
+        with gzip.open(path, 'wt') as stream:
+            stream.write(text)
+    else:
+        path.write_text(text)
+    return str(path)
+
+
+@pytest.mark.parametrize('compressed', [False, True])
+def test_multiallelic_phase_and_quality_preserved(tmp_path, compressed):
+    path = write_vcf(tmp_path,
+        '1\t100\trs1\tA\tG,AT\t42.5\tq10\t.\tGT:PS:GQ:DP\t2|1:100:0:12',
+        '##reference=file:///reference/GRCh38.fa\n', compressed)
+    variant, = parse_vcf(path)
+    e = variant.vcf_evidence
+    assert e.alleles == ('AT', 'G')
+    assert e.allele_indices == (2, 1)
+    assert e.reference == 'A' and e.alternates == ('G', 'AT')
+    assert e.phased is True and e.ploidy == 2 and e.phase_set == '100'
+    assert e.reference_declaration == 'file:///reference/GRCh38.fa'
+    assert (e.quality, e.filter_status, e.genotype_quality, e.depth) == ('42.5', 'q10', '0', '12')
+
+
+@pytest.mark.parametrize('gt,phased,ploidy', [('1', None, 1), ('0/1', False, 2)])
+def test_missing_metadata_is_unknown(tmp_path, gt, phased, ploidy):
+    v, = parse_vcf(write_vcf(tmp_path, f'X\t100\trs1\tA\tG\t.\t.\t.\tGT:GQ:DP\t{gt}:.:.'))
+    e = v.vcf_evidence
+    assert e.phased is phased and e.ploidy == ploidy
+    assert e.reference_declaration is None
+    assert e.quality is None and e.filter_status is None
+    assert e.genotype_quality is None and e.depth is None and e.phase_set is None
+
+
+def test_old_constructor_remains_compatible():
+    assert Variant('rs1', '1', 100, 'AG').vcf_evidence is None
+
+
+def test_invalid_header_does_not_crash(tmp_path):
+    p = tmp_path / 'bad.vcf'
+    p.write_text('##fileformat=VCFv4.3\n#CHROM\tPOS\n1\t100\n')
+    assert parse_vcf(str(p)) == []
+
+
+@pytest.mark.parametrize('gt', ['.', './.', '0/.', '3/0', '-1/0', '0/1/1', '0|1/0'])
+def test_unsupported_or_missing_calls_stay_excluded(tmp_path, gt):
+    assert parse_vcf(write_vcf(tmp_path, f'1\t100\trs1\tA\tG\t.\tPASS\t.\tGT\t{gt}')) == []
+
+
+def test_haploid_multibase_allele_is_not_two_snp_copies(tmp_path):
+    from allelio.analysis.zygosity import call_zygosity
+    v, = parse_vcf(write_vcf(tmp_path, 'X\t100\trs1\tA\tAG\t.\tPASS\t.\tGT\t1'))
+    assert v.vcf_evidence.alleles == ('AG',)
+    assert v.vcf_evidence.ploidy == 1
+    assert call_zygosity(v.genotype, 'A', 'G').alt_copies is None

--- a/tests/test_vcf_ploidy.py
+++ b/tests/test_vcf_ploidy.py
@@ -1,0 +1,23 @@
+"""VCF-to-interpretation regression: do not manufacture a second allele."""
+import pytest
+from allelio.parsers.vcf_parser import parse_vcf
+from allelio.analysis.zygosity import call_zygosity, Zygosity
+
+
+@pytest.mark.parametrize("gt,genotype,copies,zygosity", [
+    ("1", "G", 1, Zygosity.HEMIZYGOUS_ALTERNATE),
+    ("0", "A", 0, Zygosity.HEMIZYGOUS_REFERENCE),
+    ("0/1", "AG", 1, Zygosity.HETEROZYGOUS),
+    ("1|1", "GG", 2, Zygosity.HOMOZYGOUS_ALTERNATE),
+])
+def test_vcf_reported_ploidy_reaches_interpretation(tmp_path, gt, genotype, copies, zygosity):
+    path = tmp_path / "sample.vcf"
+    path.write_text("##fileformat=VCFv4.2\n"
+                    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n"
+                    f"X\t100\trs900000001\tA\tG\t.\tPASS\t.\tGT\t{gt}\n")
+    variants = parse_vcf(str(path))
+    assert len(variants) == 1
+    assert variants[0].genotype == genotype
+    call = call_zygosity(variants[0].genotype, "A", "G")
+    assert call.alt_copies == copies
+    assert call.zygosity == zygosity


### PR DESCRIPTION
VCF haploid calls were duplicated into diploid-looking genotypes, changing the copy count passed to interpretation. Preserve haploid SNVs and retain optional source evidence on parsed variants: ordered alleles and GT indices, phase/ploidy, reference declaration, and quality fields.

A haploid multibase allele remains unavailable to legacy SNP interpretation instead of being mistaken for two SNP alleles; its original sequence is preserved in the evidence object. Malformed headers are skipped safely. Existing consumer-format constructors remain compatible.

Adds generated synthetic regression cases, a reproducible fixture-based development-check runner, and documentation of supported behavior and limitations. This does not add verified-build matching, coordinate recovery, or general indel interpretation.

Validation: final full suite passed (576 tests); all 18 focused parser evidence/ploidy checks passed; fixture-based development baseline passed. CI covers Python 3.9–3.12. No personal genotype data or internal planning documents are included.
