### PR TITLE
Use explicit VCF evidence for conservative ClinVar SNP matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Use structured VCF evidence for ClinVar SNP copy counts, including two
+  different alternate alleles at a multiallelic site. VCF reference mismatches
+  no longer trigger consumer-array strand inference. Non-SNP VCF records
+  remain unknown pending build-aware normalization and cannot enter legacy
+  GWAS/PGx matching as flattened SNP genotypes.
+
 - Preserve haploid VCF genotypes as one allele rather than duplicating them,
   so haploid SNVs reach zygosity interpretation with the correct copy count.
 - Skip malformed VCF headers without crashing on unset column indices.

--- a/allelio/analysis/lookup.py
+++ b/allelio/analysis/lookup.py
@@ -6,7 +6,8 @@ from enum import Enum
 
 from allelio.database.store import AllelioDB
 from allelio.database.clinpgx import level_rank as pgx_level_rank
-from allelio.analysis.zygosity import Zygosity, ZygosityCall, call_zygosity, genotype_alleles
+from allelio.analysis.zygosity import Zygosity, ZygosityCall, call_zygosity, genotype_alleles, call_vcf_zygosity
+from allelio.parsers.base import VCFEvidence
 
 
 # ClinVar review status to star rating mapping (0-4 stars)
@@ -450,7 +451,8 @@ def _rank_clinvar(entry: ClinVarEntry) -> float:
 
 
 def _select_clinvar_rows(
-    genotype: Optional[str], rows: List[Dict[str, Any]]
+    genotype: Optional[str], rows: List[Dict[str, Any]],
+    vcf_evidence: Optional[VCFEvidence] = None,
 ) -> Tuple[List[ClinVarEntry], Optional[ZygosityCall], bool]:
     """Pick the ClinVar rows that apply to this genotype.
 
@@ -476,7 +478,9 @@ def _select_clinvar_rows(
     if any(e.ref_allele and e.alt_allele and e.ref_allele != e.alt_allele for e in entries):
         entries = [e for e in entries if not (e.ref_allele and e.ref_allele == e.alt_allele)]
     for entry in entries:
-        call = call_zygosity(genotype, entry.ref_allele, entry.alt_allele)
+        call = (call_vcf_zygosity(vcf_evidence, entry.ref_allele, entry.alt_allele)
+                if vcf_evidence is not None
+                else call_zygosity(genotype, entry.ref_allele, entry.alt_allele))
         if call.alt_copies is None:
             unknown.append((entry, call))
         elif call.alt_copies > 0:
@@ -740,8 +744,19 @@ def analyze_variants_with_stats(
         position = getattr(original_variant, 'position', None)
         genotype = getattr(original_variant, 'genotype', None)
 
+        vcf_evidence = getattr(original_variant, 'vcf_evidence', None)
+        # Do not let non-SNP sequences reach legacy SNP/GWAS/PGx matching as
+        # concatenated bases. Their complete alleles remain in source evidence.
+        if vcf_evidence is not None and any(
+            a not in {"A", "C", "G", "T"}
+            for a in (vcf_evidence.reference,) + vcf_evidence.alternates
+        ):
+            genotype = "--"
+
         # ClinVar rows that apply to this genotype (allele-aware)
-        clinvar_entries, call, is_reference = _select_clinvar_rows(genotype, data["clinvar"])
+        clinvar_entries, call, is_reference = _select_clinvar_rows(
+            genotype, data["clinvar"], vcf_evidence
+        )
         clinvar_entry = clinvar_entries[0] if clinvar_entries else None
 
         # Create GWAS entries

--- a/allelio/analysis/zygosity.py
+++ b/allelio/analysis/zygosity.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Sequence
 
+from allelio.parsers.base import VCFEvidence
+
 
 class Zygosity(str, Enum):
     """How many copies of the annotated (alternate / risk) allele are present."""
@@ -192,3 +194,34 @@ def call_zygosity(genotype: Optional[str], ref: Optional[str], alt: Optional[str
         Zygosity.UNKNOWN, None, allele=alt,
         note=f"genotype {''.join(alleles)} does not match annotated alleles {ref or '?'}/{alt}",
     )
+
+
+def call_vcf_zygosity(evidence: VCFEvidence, ref: Optional[str], alt: Optional[str]) -> ZygosityCall:
+    """Count an explicitly declared SNP allele without strand inference.
+
+    This checks allele compatibility, not verified coordinate/build identity.
+    Non-SNP records require normalization and build-aware source matching first.
+    A different declared alternate can coexist with the target at a multiallelic
+    site; unlike a biallelic genotype string, it need not make the count unknown.
+    """
+    ref = (ref or "").upper()
+    alt = (alt or "").upper()
+    def unknown(reason):
+        return ZygosityCall(Zygosity.UNKNOWN, None, allele=alt or None, note=reason)
+
+    options = (evidence.reference,) + evidence.alternates
+    if not options or any(a not in _COMPLEMENT for a in options):
+        return unknown("VCF non-SNP record requires build-aware normalization")
+    if evidence.ploidy not in (1, 2) or len(evidence.alleles) != evidence.ploidy:
+        return unknown("unsupported or inconsistent VCF ploidy")
+    if any(i < 0 or i >= len(options) for i in evidence.allele_indices):
+        return unknown("invalid VCF allele index")
+    if tuple(options[i] for i in evidence.allele_indices) != evidence.alleles:
+        return unknown("VCF alleles disagree with genotype indices")
+    if ref not in _COMPLEMENT or alt not in _COMPLEMENT or ref == alt:
+        return unknown("annotation is not SNP allele-specific")
+    if ref != evidence.reference:
+        return unknown("VCF reference allele does not match annotation")
+    if alt not in evidence.alternates:
+        return unknown("annotated alternate is not declared in VCF")
+    return _count(evidence.alleles, alt)

--- a/docs/vcf-evidence.md
+++ b/docs/vcf-evidence.md
@@ -20,9 +20,16 @@ does not establish phase relationships between different records.
 The parser selects the first sample. Missing/partial GT calls, unsupported
 ploidy, and records without identifiers are still skipped. Evidence preservation
 does not add coordinate lookup, reference normalization, cross-build matching,
-quality filtering, or general indel/structural-variant interpretation. The legacy
-analysis still uses its genotype string; do not use it to infer multibase allele
-boundaries. Haploid multibase alleles use `--` in the legacy display to avoid being read as
+quality filtering, or general indel/structural-variant interpretation. ClinVar SNP matching uses explicit VCF alleles and indices, requires the same
+reference allele and a declared target alternate, and never complements a VCF
+call to force a match. Multiallelic SNPs can carry two different alternates;
+each annotated alternate is counted independently. Non-SNP records and
+reference mismatches have unknown ClinVar zygosity. This is allele compatibility,
+not verification that the source and input coordinates/builds match.
+
+GWAS and pharmacogenomic matching still use the legacy SNP path. Non-SNP VCF
+records are withheld from that path so flattened sequences cannot look like SNP
+genotypes; no new GWAS/PGx interpretation is claimed here. Haploid multibase alleles use `--` in the legacy display to avoid being read as
 two SNP alleles. Full source alleles remain available in the evidence object.
 
 ## Reproducible development checks

--- a/tests/test_vcf_interpretation.py
+++ b/tests/test_vcf_interpretation.py
@@ -1,0 +1,47 @@
+"""Integration tests for explicit VCF evidence in ClinVar row selection."""
+import pytest
+from allelio.analysis.lookup import analyze_variants_with_stats
+from allelio.database.store import AllelioDB
+from allelio.parsers.vcf_parser import parse_vcf
+
+
+@pytest.mark.parametrize('ref,alt,gt,cv_ref,cv_alt,copies', [
+    ('A', 'G', '1', 'A', 'G', 1),
+    ('A', 'G', '0/0', 'A', 'G', 0),
+    ('A', 'G,T', '1/2', 'A', 'G', 1),
+    ('A', 'G,T', '2/2', 'A', 'G', 0),
+    ('A', 'G,T', '2|1', 'A', 'T', 1),
+    ('T', 'C', '1/1', 'A', 'G', None),  # No automatic complement.
+    ('A', 'T', '1/1', 'A', 'G', None),  # Undeclared alternate.
+    ('A', 'AG', '1', 'A', 'G', None),   # Not two SNP bases.
+    ('AT', 'A', '0/1', 'AT', 'A', None),  # Normalization not yet supported.
+    ('A', '<DEL>', '1/1', 'A', 'G', None),
+])
+def test_parser_evidence_reaches_clinvar(tmp_path, ref, alt, gt, cv_ref, cv_alt, copies):
+    path = tmp_path / 'input.vcf'
+    path.write_text('##fileformat=VCFv4.3\n'
+                    '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n'
+                    f'1\t100\trs1\t{ref}\t{alt}\t.\tPASS\t.\tGT\t{gt}\n')
+    db = AllelioDB(str(tmp_path / 'a.db'))
+    db.initialize()
+    db.insert_clinvar_batch([dict(rsid='rs1', ref_allele=cv_ref, alt_allele=cv_alt,
+        gene='EXAMPLE', clinical_significance='Pathogenic', conditions='Example',
+        review_status='reviewed by expert panel', last_evaluated='')])
+    results, stats = analyze_variants_with_stats(parse_vcf(str(path)), db)
+    if copies == 0:
+        assert results == [] and stats.reference_genotype_sites == 1
+    else:
+        result, = results
+        assert result.alt_copies == copies
+        assert not result.strand_flipped
+        if copies is None:
+            assert result.zygosity == 'unknown'
+            assert stats.zygosity_unknown_sites == 1
+
+
+@pytest.mark.parametrize('indices,alleles', [((2,), ('G',)), ((1,), ('A',)), ((0, 1, 1), ('A', 'G', 'G'))])
+def test_inconsistent_structured_evidence_abstains(indices, alleles):
+    from allelio.parsers.base import VCFEvidence
+    from allelio.analysis.zygosity import call_vcf_zygosity
+    evidence = VCFEvidence('A', ('G',), indices, alleles, False)
+    assert call_vcf_zygosity(evidence, 'A', 'G').alt_copies is None


### PR DESCRIPTION
ClinVar matching previously flattened VCF genotypes and applied consumer-array strand inference. This lost multiallelic context and could turn a VCF reference mismatch into an asserted match.

Use the preserved VCF alleles and GT indices to count declared SNP alternates, including genotypes carrying two different alternates. Require reference agreement, validate indices and ploidy, and leave undeclared alternates, reference mismatches, and non-SNP records unknown. Non-SNP records cannot feed flattened sequences to legacy GWAS/PGx matching.

This checks allele compatibility, not verified build/coordinate identity. Indel normalization and build-aware matching remain unsupported and documented. Consumer-array interpretation is unchanged.

Validation: CI passed on Python 3.9–3.12 for the final revision (589 tests). Local full suite passed before three extra defensive cases (586 tests), the final focused suite passed all 13 cases, and the fixture-based development baseline passed.
