### PR TITLE
Preserve ClinVar source identity metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- ClinVar assembly, chromosome, VCF position, and source identifiers survive
+  parsing, storage, and lookup. Existing allele-aware databases migrate without
+  losing rows; missing legacy metadata stays unknown until refresh.
+
 - Optional VCF source evidence on parsed variants: ordered alleles/indices,
   phase and ploidy, raw reference declaration, and quality fields. Existing
   consumer-format constructors remain compatible. See `docs/vcf-evidence.md`

--- a/allelio/analysis/lookup.py
+++ b/allelio/analysis/lookup.py
@@ -168,6 +168,12 @@ class ClinVarEntry:
     review_stars: int = 0
     ref_allele: Optional[str] = None
     alt_allele: Optional[str] = None
+    assembly: Optional[str] = None
+    chromosome: Optional[str] = None
+    position_vcf: Optional[int] = None
+    allele_id: Optional[str] = None
+    variation_id: Optional[str] = None
+    hgnc_id: Optional[str] = None
 
 
 @dataclass
@@ -437,6 +443,9 @@ def _clinvar_entry(cv_data: Dict[str, Any]) -> ClinVarEntry:
         review_stars=_get_review_stars(review_status),
         ref_allele=cv_data.get("ref_allele") or None,
         alt_allele=cv_data.get("alt_allele") or None,
+        **{key: cv_data.get(key) for key in (
+            "assembly", "chromosome", "position_vcf", "allele_id", "variation_id", "hgnc_id"
+        )},
     )
 
 

--- a/allelio/database/clinvar.py
+++ b/allelio/database/clinvar.py
@@ -52,6 +52,20 @@ def _allele(fields, index: int) -> str:
     return "" if value in ("", "NA", "-", ".") else value
 
 
+def _source_value(fields, column):
+    index = CLINVAR_COLUMNS[column]
+    value = fields[index].strip() if index < len(fields) else ""
+    return None if value in ("", "na", "NA", "-", ".", "-1") else value
+
+
+def _position(fields):
+    try:
+        value = int(_source_value(fields, "PositionVCF"))
+        return value if 0 < value < 2**63 else None
+    except (TypeError, ValueError):
+        return None
+
+
 def _bit(bitmap: bytearray, allele_id: str) -> bool:
     try:
         n = int(allele_id)
@@ -152,6 +166,12 @@ def parse_clinvar(filepath: str) -> Generator[Dict[str, Any], None, None]:
                 # Create record
                 record = {
                     "rsid": rsid,
+                    "assembly": assembly,
+                    "chromosome": _source_value(fields, "Chromosome"),
+                    "position_vcf": _position(fields),
+                    "allele_id": _source_value(fields, "#AlleleID"),
+                    "variation_id": _source_value(fields, "VariationID"),
+                    "hgnc_id": _source_value(fields, "HGNC_ID"),
                     "ref_allele": ref_allele,
                     "alt_allele": alt_allele,
                     "gene": gene_symbol if gene_symbol else None,

--- a/allelio/database/store.py
+++ b/allelio/database/store.py
@@ -80,6 +80,15 @@ class AllelioDB:
             )
         """)
         
+        # Add source identity without discarding existing allele-aware rows.
+        # Legacy records stay NULL until refreshed from their reference source.
+        columns = self._columns("clinvar")
+        for name, sql_type in (("assembly", "TEXT"), ("chromosome", "TEXT"),
+                               ("position_vcf", "INTEGER"), ("allele_id", "TEXT"),
+                               ("variation_id", "TEXT"), ("hgnc_id", "TEXT")):
+            if name not in columns:
+                self.cursor.execute(f"ALTER TABLE clinvar ADD COLUMN {name} {sql_type}")
+
         # Create GWAS table
         self.cursor.execute("""
             CREATE TABLE IF NOT EXISTS gwas (
@@ -200,14 +209,16 @@ class AllelioDB:
                 "ref_allele": (r.get("ref_allele") or ""),
                 "alt_allele": (r.get("alt_allele") or ""),
                 **{k: r.get(k) for k in ("rsid", "gene", "clinical_significance",
-                                         "conditions", "review_status", "last_evaluated")},
+                                         "conditions", "review_status", "last_evaluated",
+                                         "assembly", "chromosome", "position_vcf", "allele_id",
+                                         "variation_id", "hgnc_id")},
             }
             for r in records
         ]
         self.cursor.executemany(
             """INSERT OR REPLACE INTO clinvar
-               (rsid, ref_allele, alt_allele, gene, clinical_significance, conditions, review_status, last_evaluated)
-               VALUES (:rsid, :ref_allele, :alt_allele, :gene, :clinical_significance, :conditions, :review_status, :last_evaluated)
+               (rsid, ref_allele, alt_allele, gene, clinical_significance, conditions, review_status, last_evaluated, assembly, chromosome, position_vcf, allele_id, variation_id, hgnc_id)
+               VALUES (:rsid, :ref_allele, :alt_allele, :gene, :clinical_significance, :conditions, :review_status, :last_evaluated, :assembly, :chromosome, :position_vcf, :allele_id, :variation_id, :hgnc_id)
             """,
             rows
         )

--- a/docs/vcf-evidence.md
+++ b/docs/vcf-evidence.md
@@ -47,3 +47,12 @@ validation or a clinical accuracy estimate. Review generated artifacts before
 sharing: source hashes and checkout revision are included for reproducibility.
 
 Source format: [VCF specification](https://samtools.github.io/hts-specs/VCFv4.3.pdf).
+
+## ClinVar source identity
+
+Reference refreshes now preserve the selected ClinVar row's assembly, chromosome,
+VCF position, AlleleID, VariationID, and HGNC identifier in SQLite and analysis
+entries. Existing allele-aware databases migrate without losing rows; old rows
+have unavailable identity fields until `allelio update` refreshes them. The
+existing GRCh38-preferred row selection remains in place, with GRCh37-only rows
+retained. This metadata addition does not perform liftover or normalization.

--- a/tests/test_clinvar_identity.py
+++ b/tests/test_clinvar_identity.py
@@ -1,0 +1,48 @@
+"""Reference provenance survives parsing and non-destructive schema migration."""
+import sqlite3
+import pytest
+from allelio.database.clinvar import parse_clinvar
+from allelio.database.store import AllelioDB
+from allelio.analysis.lookup import _clinvar_entry
+
+
+def source(tmp_path, position='101'):
+    row = [''] * 34
+    for i, value in {0:'123', 4:'GENE', 5:'HGNC:1', 6:'Pathogenic', 9:'1',
+                     16:'GRCh38', 18:'X', 24:'reviewed by expert panel',
+                     30:'456', 31:position, 32:'A', 33:'G'}.items():
+        row[i] = value
+    path = tmp_path / 'source.tsv'
+    path.write_text('\t'.join(row) + '\n')
+    return next(parse_clinvar(str(path)))
+
+
+def test_round_trip(tmp_path):
+    record = source(tmp_path)
+    db = AllelioDB(str(tmp_path / 'a.db'))
+    db.initialize()
+    db.insert_clinvar_batch([record])
+    single = db.lookup_rsid('rs1')['clinvar'][0]
+    batch = db.lookup_rsids_batch(['rs1'])['rs1']['clinvar'][0]
+    assert single == batch
+    entry = _clinvar_entry(single)
+    assert (entry.assembly, entry.chromosome, entry.position_vcf) == ('GRCh38', 'X', 101)
+    assert (entry.allele_id, entry.variation_id, entry.hgnc_id) == ('123', '456', 'HGNC:1')
+
+
+@pytest.mark.parametrize('value', ['', 'na', '-1', '0', 'junk', str(2**63)])
+def test_missing_or_invalid_position(tmp_path, value):
+    assert source(tmp_path, value)['position_vcf'] is None
+
+
+def test_legacy_migration_preserves_rows(tmp_path):
+    path = tmp_path / 'legacy.db'
+    with sqlite3.connect(path) as con:
+        con.execute('CREATE TABLE clinvar (rsid TEXT, ref_allele TEXT, alt_allele TEXT, gene TEXT, clinical_significance TEXT, conditions TEXT, review_status TEXT, last_evaluated TEXT, PRIMARY KEY(rsid, ref_allele, alt_allele))')
+        con.execute("INSERT INTO clinvar VALUES ('rs1','A','G','GENE','Pathogenic','','','')")
+    db = AllelioDB(str(path))
+    db.initialize()
+    db.initialize()  # Idempotent.
+    row, = db.lookup_rsid('rs1')['clinvar']
+    assert row['gene'] == 'GENE' and row['alt_allele'] == 'G'
+    assert all(row[key] is None for key in ('assembly', 'chromosome', 'position_vcf', 'allele_id', 'variation_id', 'hgnc_id'))


### PR DESCRIPTION
ClinVar parsing discarded reference identity needed to check VCF annotation matches. Preserve assembly, chromosome, PositionVCF, AlleleID, VariationID, and HGNC identifier through parsing, SQLite, and analysis entries.

Existing allele-aware databases migrate without losing rows; identity remains NULL until source refresh. Preferred-build selection is unchanged. No liftover or coordinate lookup is added.

Validation: 597 tests pass locally, including round-trip, idempotent legacy migration, and malformed-position tests. CI must pass before merge.

Closes #8.
