### PR TITLE
Check VCF reference identity before ClinVar SNP matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Require declared VCF build, chromosome and position agreement with ClinVar
+  before counting SNP alleles. Unknown/mismatched identities abstain with a
+  reason; no build inference, liftover, or mitochondrial matching is attempted.
+
 - Use structured VCF evidence for ClinVar SNP copy counts, including two
   different alternate alleles at a multiallelic site. VCF reference mismatches
   no longer trigger consumer-array strand inference. Non-SNP VCF records

--- a/allelio/analysis/identity.py
+++ b/allelio/analysis/identity.py
@@ -1,0 +1,45 @@
+"""Conservative checks of declared reference identity; no liftover or guessing."""
+from typing import Optional
+
+
+_BUILD_NAMES = {'GRCh37': 'GRCh37', 'hg19': 'GRCh37',
+                'GRCh38': 'GRCh38', 'hg38': 'GRCh38'}
+
+
+def declared_build(value: Optional[str]) -> Optional[str]:
+    """Recognize explicit names only, not filenames, URLs, or substrings."""
+    return _BUILD_NAMES.get(value)
+
+
+def chromosome_name(value: Optional[str]) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    name = value[3:] if value.startswith('chr') else value
+    if name == 'M':
+        name = 'MT'
+    return name if name in {str(i) for i in range(1, 23)} | {'X', 'Y', 'MT'} else None
+
+
+def vcf_identity_reason(evidence, chromosome, position, entry) -> Optional[str]:
+    """None if declarations agree; otherwise a reason to abstain.
+
+    Agreement does not authenticate a file or validate its reference sequence.
+    GRCh37/hg19 mitochondrial references differ, so aliases never authorize MT.
+    """
+    build = declared_build(evidence.reference_declaration)
+    if build is None:
+        return 'VCF reference build is unknown or unsupported'
+    if not entry.assembly or not entry.chromosome or entry.position_vcf is None:
+        return 'ClinVar reference identity unavailable; refresh reference data'
+    if build != entry.assembly:
+        return 'VCF and ClinVar reference builds differ'
+    source_chr, input_chr = chromosome_name(entry.chromosome), chromosome_name(chromosome)
+    if input_chr is None or source_chr is None:
+        return 'unsupported chromosome identity'
+    if input_chr == 'MT' or source_chr == 'MT':
+        return 'mitochondrial reference identity requires sequence-specific matching'
+    if input_chr != source_chr:
+        return 'VCF and ClinVar chromosomes differ'
+    if not isinstance(position, int) or position <= 0 or position != entry.position_vcf:
+        return 'VCF and ClinVar positions differ'
+    return None

--- a/allelio/analysis/lookup.py
+++ b/allelio/analysis/lookup.py
@@ -8,6 +8,7 @@ from allelio.database.store import AllelioDB
 from allelio.database.clinpgx import level_rank as pgx_level_rank
 from allelio.analysis.zygosity import Zygosity, ZygosityCall, call_zygosity, genotype_alleles, call_vcf_zygosity
 from allelio.parsers.base import VCFEvidence
+from allelio.analysis.identity import vcf_identity_reason
 
 
 # ClinVar review status to star rating mapping (0-4 stars)
@@ -462,6 +463,7 @@ def _rank_clinvar(entry: ClinVarEntry) -> float:
 def _select_clinvar_rows(
     genotype: Optional[str], rows: List[Dict[str, Any]],
     vcf_evidence: Optional[VCFEvidence] = None,
+    chromosome: Optional[str] = None, position: Optional[int] = None,
 ) -> Tuple[List[ClinVarEntry], Optional[ZygosityCall], bool]:
     """Pick the ClinVar rows that apply to this genotype.
 
@@ -487,9 +489,12 @@ def _select_clinvar_rows(
     if any(e.ref_allele and e.alt_allele and e.ref_allele != e.alt_allele for e in entries):
         entries = [e for e in entries if not (e.ref_allele and e.ref_allele == e.alt_allele)]
     for entry in entries:
-        call = (call_vcf_zygosity(vcf_evidence, entry.ref_allele, entry.alt_allele)
-                if vcf_evidence is not None
-                else call_zygosity(genotype, entry.ref_allele, entry.alt_allele))
+        if vcf_evidence is not None:
+            reason = vcf_identity_reason(vcf_evidence, chromosome, position, entry)
+            call = (ZygosityCall(Zygosity.UNKNOWN, None, allele=entry.alt_allele, note=reason)
+                    if reason else call_vcf_zygosity(vcf_evidence, entry.ref_allele, entry.alt_allele))
+        else:
+            call = call_zygosity(genotype, entry.ref_allele, entry.alt_allele)
         if call.alt_copies is None:
             unknown.append((entry, call))
         elif call.alt_copies > 0:
@@ -764,7 +769,7 @@ def analyze_variants_with_stats(
 
         # ClinVar rows that apply to this genotype (allele-aware)
         clinvar_entries, call, is_reference = _select_clinvar_rows(
-            genotype, data["clinvar"], vcf_evidence
+            genotype, data["clinvar"], vcf_evidence, chromosome, position
         )
         clinvar_entry = clinvar_entries[0] if clinvar_entries else None
 

--- a/docs/vcf-evidence.md
+++ b/docs/vcf-evidence.md
@@ -24,8 +24,14 @@ quality filtering, or general indel/structural-variant interpretation. ClinVar S
 reference allele and a declared target alternate, and never complements a VCF
 call to force a match. Multiallelic SNPs can carry two different alternates;
 each annotated alternate is counted independently. Non-SNP records and
-reference mismatches have unknown ClinVar zygosity. This is allele compatibility,
-not verification that the source and input coordinates/builds match.
+reference mismatches have unknown ClinVar zygosity. ClinVar matching also requires agreement between the declared VCF build,
+chromosome and position and the source row. Only bare `GRCh37`, `GRCh38`, `hg19`,
+and `hg38` declarations are recognized. Paths, URLs and unknown declarations
+remain unknown rather than being guessed. Canonical autosomes and X/Y accept
+an optional `chr` prefix. Mitochondrial and noncanonical contigs abstain until
+sequence-specific identity is supported. Declaration agreement does not verify
+the actual reference sequence or authenticate the input file. Missing metadata
+in a legacy database requires `allelio update` before VCF matches can be counted.
 
 GWAS and pharmacogenomic matching still use the legacy SNP path. Non-SNP VCF
 records are withheld from that path so flattened sequences cannot look like SNP

--- a/tests/test_vcf_identity_matching.py
+++ b/tests/test_vcf_identity_matching.py
@@ -1,0 +1,41 @@
+"""Missing/mismatched reference identity must not turn into a copy count."""
+from dataclasses import replace
+import pytest
+from allelio.analysis.lookup import _select_clinvar_rows
+from allelio.parsers.base import VCFEvidence
+
+EVIDENCE = VCFEvidence('A', ('G',), (0, 1), ('A', 'G'), False,
+                       reference_declaration='GRCh38')
+ROW = dict(rsid='rs1', ref_allele='A', alt_allele='G', assembly='GRCh38',
+           chromosome='1', position_vcf=100, clinical_significance='Pathogenic')
+
+
+@pytest.mark.parametrize('declaration,chrom,position,changes,expected', [
+    ('GRCh38', '1', 100, {}, 1),
+    ('hg38', 'chr1', 100, {}, 1),
+    ('GRCh37', '1', 100, {'assembly':'GRCh37'}, 1),
+    ('hg19', '1', 100, {'assembly':'GRCh37'}, 1),
+    ('GRCh37', '1', 100, {}, None),
+    (None, '1', 100, {}, None),
+    ('file:///GRCh38.fa', '1', 100, {}, None),
+    ('unknown_GRCh38', '1', 100, {}, None),
+    ('GRCh38', '2', 100, {}, None),
+    ('GRCh38', '1', 101, {}, None),
+    ('GRCh38', '1', 100, {'assembly':None}, None),
+    ('GRCh38', '1', 100, {'position_vcf':None}, None),
+    ('GRCh38', 'chrM', 100, {'chromosome':'MT'}, None),
+    ('GRCh38', 'NC_000001.11', 100, {}, None),
+])
+def test_identity_gate(declaration, chrom, position, changes, expected):
+    entries, call, is_reference = _select_clinvar_rows(
+        'AG', [{**ROW, **changes}], replace(EVIDENCE, reference_declaration=declaration),
+        chrom, position)
+    assert entries and not is_reference
+    assert call.alt_copies == expected
+    if expected is None:
+        assert call.zygosity == 'unknown' and call.note
+
+
+def test_legacy_consumer_input_does_not_require_vcf_metadata():
+    _, call, _ = _select_clinvar_rows('AG', [{**ROW, 'assembly':None}])
+    assert call.alt_copies == 1

--- a/tests/test_vcf_interpretation.py
+++ b/tests/test_vcf_interpretation.py
@@ -19,12 +19,13 @@ from allelio.parsers.vcf_parser import parse_vcf
 ])
 def test_parser_evidence_reaches_clinvar(tmp_path, ref, alt, gt, cv_ref, cv_alt, copies):
     path = tmp_path / 'input.vcf'
-    path.write_text('##fileformat=VCFv4.3\n'
+    path.write_text('##fileformat=VCFv4.3\n##reference=GRCh38\n'
                     '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n'
                     f'1\t100\trs1\t{ref}\t{alt}\t.\tPASS\t.\tGT\t{gt}\n')
     db = AllelioDB(str(tmp_path / 'a.db'))
     db.initialize()
     db.insert_clinvar_batch([dict(rsid='rs1', ref_allele=cv_ref, alt_allele=cv_alt,
+        assembly='GRCh38', chromosome='1', position_vcf=100,
         gene='EXAMPLE', clinical_significance='Pathogenic', conditions='Example',
         review_status='reviewed by expert panel', last_evaluated='')])
     results, stats = analyze_variants_with_stats(parse_vcf(str(path)), db)


### PR DESCRIPTION
Matching VCF and ClinVar allele letters is insufficient when reference builds or positions differ. Require agreement on a recognized declared build, canonical chromosome, and VCF position before the ClinVar SNP copy-count path runs.

Unknown declarations, unavailable legacy metadata, mismatches, mitochondrial records and unsupported contigs abstain with a reason. Recognize only explicit GRCh37/GRCh38/hg19/hg38 names; no filename inference, liftover, or reference-sequence authentication. Consumer-array handling and GWAS/PGx interpretation are unchanged.

Validation: 612 tests pass locally, including 15 new identity-gate cases plus existing parser-to-analysis integration tests. Source refresh requirements and limitations are documented.

Closes #9.
