### PR TITLE
Group findings by gene and unify HTML report presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Gene groups in CLI, web, and HTML reports, with distinct-finding counts,
+  source-backed function descriptions where available, and individual details.
+  Shared gene associations and unassigned findings remain visible. HTML exports
+  no longer truncate at 100 findings, so every gene-summary link is reachable.
+
 - ClinVar assembly, chromosome, VCF position, and source identifiers survive
   parsing, storage, and lookup. Existing allele-aware databases migrate without
   losing rows; missing legacy metadata stays unknown until refresh.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,14 @@ pick for your RAM, and what a good setup feels like.
 
 ---
 
+## Findings by gene
+
+Results now include gene groups in the CLI, web interface, and HTML reports.
+Expand a group to inspect its findings, their categories, and any available
+sourced function summary. Shared findings can appear under several genes; having
+multiple findings alone does not establish higher risk. See
+[gene grouping](docs/gene-grouping.md) for counting rules and coverage limits.
+
 ## How it works under the hood
 
 Allelio's pipeline is straightforward:

--- a/allelio/analysis/genes.py
+++ b/allelio/analysis/genes.py
@@ -1,0 +1,124 @@
+"""Deterministic gene grouping over existing findings, without risk aggregation."""
+import re
+from html import escape
+
+# Short original paraphrases of MedlinePlus Genetics normal-function sections.
+# The catalogue is deliberately limited; do not generate missing functions.
+FUNCTION_VERSION = '2026-09-12'
+FUNCTIONS = {
+    'BRCA1': 'Helps repair damaged DNA and maintain the stability of genetic information.',
+    'BRCA2': 'Helps repair breaks in DNA and maintain the stability of genetic information.',
+    'CFTR': 'Forms a chloride channel that helps regulate water movement and mucus consistency.',
+    'APOE': 'Helps package and transport cholesterol and other fats in the bloodstream.',
+    'HFE': 'Helps regulate iron absorption and storage through iron sensing and hepcidin regulation.',
+}
+MULTIPLE_NOTE = ('Multiple findings in a gene do not by themselves establish greater risk, '
+                 'a haplotype, or compound heterozygosity. Review each finding separately.')
+MISSING_FUNCTION = 'A sourced function summary is not available in this release.'
+
+
+def value(item, name, default=None):
+    return item.get(name, default) if isinstance(item, dict) else getattr(item, name, default)
+
+
+def _symbols(text):
+    if not isinstance(text, str):
+        return []
+    return sorted({s for raw in re.split(r';|,|\s+-\s+', text) if
+                   (s := raw.strip()) and re.fullmatch(r'[A-Za-z0-9][A-Za-z0-9_.-]*', s)
+                   and s.lower() not in {'unknown', 'unassigned', 'intergenic', 'nr', 'na'}})
+
+
+def gene_assignments(result):
+    """All source gene associations; stable IDs only when mapping is unambiguous."""
+    assignments = set()
+    if isinstance(result, dict):
+        for entry in result.get('gene_assignments') or []:
+            if not isinstance(entry, dict):
+                continue
+            names = _symbols(entry.get('symbol'))
+            identifier = entry.get('hgnc_id')
+            identifier = identifier if isinstance(identifier, str) and re.fullmatch(r'HGNC:\d+', identifier) else None
+            assignments.update((name, identifier if len(names) == 1 else None) for name in names)
+        if not assignments:
+            assignments.update((name, None) for name in _symbols(result.get('gene')))
+    else:
+        for source, field in (('clinvar_entries', 'gene'), ('gwas_entries', 'mapped_gene'), ('pgx_entries', 'gene')):
+            for entry in value(result, source, []) or []:
+                names = _symbols(value(entry, field))
+                identifier = value(entry, 'hgnc_id')
+                identifier = identifier if isinstance(identifier, str) and re.fullmatch(r'HGNC:\d+', identifier) else None
+                assignments.update((name, identifier if len(names) == 1 else None) for name in names)
+    return [dict(symbol=s, hgnc_id=i) for s, i in sorted(assignments, key=lambda a: (a[0], a[1] or ''))]
+
+
+def gene_label(result):
+    """Display all recorded gene associations, including PGx-only findings."""
+    return '; '.join(sorted({a['symbol'] for a in gene_assignments(result)})) or None
+
+
+def group_findings(results):
+    """Return JSON-compatible groups referencing input indices, before UI limits.
+
+    Shared findings appear in each associated gene. Identical finding identities
+    count once per group. Conflicting genotypes/categories remain separate.
+    Symbols merge through HGNC only when the source supplies an unambiguous ID.
+    """
+    assignments = [gene_assignments(r) for r in results]
+    symbol_ids = {}
+    for row in assignments:
+        for a in row:
+            if a['hgnc_id']:
+                symbol_ids.setdefault(a['symbol'], set()).add(a['hgnc_id'])
+    groups = {}
+    for index, (result, row) in enumerate(zip(results, assignments)):
+        identity = tuple(str(value(result, k, '') or '') for k in
+                         ('rsid', 'chromosome', 'position', 'genotype', 'matched_allele', 'category'))
+        if not identity[0]:
+            identity += (str(index),)
+        for a in row or [dict(symbol='Unassigned', hgnc_id=None)]:
+            symbol = a['symbol']
+            candidates = symbol_ids.get(symbol, set())
+            identifier = a['hgnc_id'] or (next(iter(candidates)) if len(candidates) == 1 else None)
+            key = identifier or 'symbol:' + symbol
+            group = groups.setdefault(key, dict(key=key, hgnc_id=identifier, symbols=set(),
+                                                indices=[], seen=set()))
+            group['symbols'].add(symbol)
+            if identity not in group['seen']:
+                group['seen'].add(identity)
+                group['indices'].append(index)
+    output = []
+    for group in groups.values():
+        symbols = sorted(group['symbols'])
+        # Do not ascribe a catalogue function to a group of unresolved aliases.
+        symbol = symbols[0] if len(symbols) == 1 else None
+        function = FUNCTIONS.get(symbol)
+        output.append(dict(key=group['key'], hgnc_id=group['hgnc_id'],
+            gene=' / '.join(symbols), symbols=symbols, indices=group['indices'],
+            count=len(group['indices']), function=function or MISSING_FUNCTION,
+            function_source=(f'https://medlineplus.gov/genetics/gene/{symbol.lower()}/' if function else None),
+            function_version=FUNCTION_VERSION if function else None,
+            note=MULTIPLE_NOTE if len(group['indices']) > 1 else 'Interpret this finding using its own evidence.'))
+    return sorted(output, key=lambda g: (g['gene'] == 'Unassigned', g['gene']))
+
+
+def gene_overview_html(results):
+    """Escaped, expandable overview linked to canonical finding details."""
+    if not results:
+        return ''
+    out = ['<section class="gene-overview"><h2>Findings by gene</h2>',
+           '<p>Counts cover the findings in this report, not all variants in the gene. '
+           'A finding associated with several genes appears in each group.</p>']
+    for group in group_findings(results):
+        out.append(f'<details class="gene-group"><summary>{escape(group["gene"])} — '
+                   f'{group["count"]} {"finding" if group["count"] == 1 else "findings"}</summary><p>{escape(group["function"])}</p>')
+        if group['function_source']:
+            out.append(f'<p><a href="{group["function_source"]}">MedlinePlus Genetics</a> '
+                       f'(summary version {FUNCTION_VERSION})</p>')
+        out.append(f'<p>{escape(group["note"])}</p><ul>')
+        for index in group['indices']:
+            result = results[index]
+            out.append(f'<li><a href="#finding-{index}">{escape(str(value(result, "rsid", "Unknown")))}</a>'
+                       f' — {escape(str(value(result, "category", "Unknown")))}</li>')
+        out.append('</ul></details>')
+    return ''.join(out) + '</section>'

--- a/allelio/cli.py
+++ b/allelio/cli.py
@@ -17,6 +17,7 @@ from allelio.analysis.lookup import analyze_variants, AnalysisStats
 from allelio.database import AllelioDB, setup_database, staleness_warning, sources_summary, provenance_of
 from allelio.parsers import parse_genotype_file_with_stats
 from allelio.report import generate_html_report
+from allelio.analysis.genes import group_findings, gene_label
 
 # See README "Known gaps: 23andMe internal IDs" and PUB-11-lite in
 # PUBLICATION_PLAN.md — printed wherever a parsed 23andMe file skipped i-ID
@@ -372,12 +373,7 @@ def analyze(
     table.add_column("Zygosity", width=22)
     
     for result in sorted(results, key=lambda x: x.significance_rank)[:top]:
-        # Extract gene name from clinvar or gwas entries
-        gene = "-"
-        if result.clinvar_entries:
-            gene = result.clinvar_entries[0].gene or "-"
-        elif result.gwas_entries:
-            gene = result.gwas_entries[0].mapped_gene or "-"
+        gene = gene_label(result) or "-"
 
         # Color code by significance
         if result.category == "Health Conditions":
@@ -400,6 +396,20 @@ def analyze(
         )
     
     console.print(table)
+    console.print("\n[bold]Findings by gene[/bold]")
+    console.print("Counts cover all returned findings; the table above shows the requested top results.")
+    console.print("A finding associated with several genes appears in each group.")
+    groups_table = Table(show_header=True, header_style="bold cyan")
+    groups_table.add_column("Gene")
+    groups_table.add_column("Findings")
+    groups_table.add_column("rsIDs")
+    groups_table.add_column("Function and interpretation")
+    for group in group_findings(results):
+        source = (" Source: " + group["function_source"] + " (" + group["function_version"] + ")") if group["function_source"] else ""
+        groups_table.add_row(escape(group["gene"]), str(group["count"]),
+                             escape(", ".join(results[i].rsid for i in group["indices"])),
+                             escape(group["function"] + source + " " + group["note"]))
+    console.print(groups_table)
     
     # Generate HTML report
     try:

--- a/allelio/report.py
+++ b/allelio/report.py
@@ -5,17 +5,15 @@ from typing import Any, Dict, List, Optional
 import html as html_escape
 from urllib.parse import quote
 
+from allelio.report_style import REPORT_CSS
 from allelio.ai.attribution import Explanation, attribution
 from allelio.analysis.lookup import _get_review_stars
+from allelio.analysis.genes import gene_overview_html, gene_label
 
 
 def _get_gene(variant) -> str:
     """Extract gene name from a VariantResult's sub-entries."""
-    if variant.clinvar_entries:
-        return getattr(variant.clinvar_entries[0], 'gene', None) or "Unknown"
-    elif variant.gwas_entries:
-        return getattr(variant.gwas_entries[0], 'mapped_gene', None) or "Unknown"
-    return "Unknown"
+    return gene_label(variant) or "Unknown"
 
 
 def _get_conditions(variant) -> str:
@@ -237,6 +235,9 @@ def generate_html_report(
         Complete HTML report as a string
     """
 
+    # Repeated references to the same result object need only one detail card.
+    results = list({id(result): result for result in results}.values())
+
     # Prepare data
     generated_at = metadata.get("generated_at", datetime.now().isoformat())
     db_version = metadata.get("db_version", "Unknown")
@@ -261,6 +262,9 @@ def generate_html_report(
     # these lines nothing in the report explains why.
     sources_html = _sources_html(provenance)
 
+    gene_overview = gene_overview_html(results)
+    finding_indices = {id(result): index for index, result in enumerate(results)}
+
     # Categorize results using actual VariantCategory values
     health_conditions = [r for r in results if r.category == "Health Conditions"]
     risk_factors = [r for r in results if r.category == "Risk Factors"]
@@ -268,7 +272,7 @@ def generate_html_report(
     traits = [r for r in results if r.category == "Traits"]
     carrier = [r for r in results if r.category == "Carrier Status"]
     benign = [r for r in results if r.category == "Benign"]
-    other = [r for r in results if r.category in ("Unknown",)]
+    other = [r for r in results if r.category not in {"Health Conditions", "Risk Factors", "Pharmacogenomics", "Traits", "Carrier Status", "Benign"}]
 
     def generate_variant_card(variant, explanation=None):
         """Generate HTML for a single variant card.
@@ -385,7 +389,7 @@ def generate_html_report(
             </div>
         </div>
 '''
-        return card_html
+        return f'<div id="finding-{finding_indices[id(variant)]}">{card_html}</div>'
 
     # Build category sections
     categories_html = ""
@@ -398,6 +402,8 @@ def generate_html_report(
         (carrier, "Carrier Status", "#0d9488", "carrier-status", "One copy of a pathogenic allele in a gene ClinGen curates only for recessive conditions: not the affected genotype, but relevant to family planning."),
         (benign, "Benign", "#16a34a", "benign", "Variants ClinVar classifies as benign or likely benign (shown with --include-benign)."),
     ]
+
+    sections.append((other, "Other Findings", "#64748b", "other-findings", "Findings without a supported category."))
 
     # Build tab navigation — only for sections that have results
     active_sections = [(vl, t, c, sid, d) for vl, t, c, sid, d in sections if vl]
@@ -412,8 +418,8 @@ def generate_html_report(
     for variant_list, title, color, section_id, description in sections:
         if not variant_list:
             continue
-        # Show up to 100 per category
-        display_list = sorted(variant_list, key=lambda x: x.significance_rank)[:100]
+        # All findings remain reachable from the gene overview.
+        display_list = sorted(variant_list, key=lambda x: x.significance_rank)
         categories_html += f'<section class="category-section" id="{section_id}">\n'
         categories_html += f'<h2 class="category-title" style="color: {color}; border-color: {color};">{title} ({len(variant_list)})</h2>\n'
         categories_html += f'<p class="category-desc">{description}</p>\n'
@@ -429,7 +435,7 @@ def generate_html_report(
         categories_html = '<section class="category-section">\n'
         categories_html += '<h2 class="category-title">All Findings</h2>\n'
         categories_html += '<div class="variants-grid">\n'
-        for variant in sorted(results, key=lambda x: x.significance_rank)[:100]:
+        for variant in sorted(results, key=lambda x: x.significance_rank):
             explanation = explanations.get(variant.rsid)
             categories_html += generate_variant_card(variant, explanation)
         categories_html += '</div>\n</section>\n'
@@ -523,6 +529,9 @@ def generate_html_report(
             margin-bottom: 10px;
         }}
 
+        [id^="finding-"] {{ scroll-margin-top: 100px; }}
+        .gene-group {{ padding: 12px; margin: 8px 0; border: 1px solid #cbd5e1; border-radius: 8px; }}
+        .gene-group summary {{ cursor: pointer; font-weight: 600; }}
         .generated-date {{
             opacity: 0.9;
             font-size: 14px;
@@ -855,6 +864,7 @@ def generate_html_report(
             .variant-card {{ break-inside: avoid; page-break-inside: avoid; }}
             a {{ text-decoration: underline; }}
         }}
+        {REPORT_CSS}
     </style>
 </head>
 <body>
@@ -895,6 +905,8 @@ def generate_html_report(
         {gap_note}
 
         {ai_note}
+
+        {gene_overview}
 
         {tab_nav_html}
 

--- a/allelio/report_style.py
+++ b/allelio/report_style.py
@@ -1,0 +1,65 @@
+"""Shared, offline branding for both standalone HTML report formats."""
+
+REPORT_CSS = """
+:root {
+    --report-page: #f9f8fb;
+    --report-panel: #eae7ef;
+    --report-border: #d9d5df;
+    --report-ink: #29272e;
+    --report-muted: #625d6b;
+    --report-mint: #d8f3e9;
+    --report-cyan: #d6f0f7;
+}
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+                 'Helvetica Neue', Arial, sans-serif;
+    color: var(--report-ink);
+    background: var(--report-page);
+    line-height: 1.6;
+}
+h1, h2, h3 { color: var(--report-ink); font-weight: 600; }
+a { color: #176579; text-underline-offset: 3px; }
+a:focus-visible, summary:focus-visible {
+    outline: 3px solid #176579; outline-offset: 3px;
+}
+header {
+    background: var(--report-panel); color: var(--report-ink);
+    border: 1px solid var(--report-border); border-top: 4px solid #66c8aa;
+    border-radius: 12px; box-shadow: none;
+}
+.stat-card, .summary-section, .variant-card, .summary, .gene-group {
+    background: var(--report-page); border: 1px solid var(--report-border);
+    border-radius: 12px; box-shadow: 0 1px 2px #29272e0d;
+}
+.stat-value { color: var(--report-ink); font-size: 38px; font-weight: 500; }
+.stat-label { color: var(--report-muted); text-transform: none; letter-spacing: 0; }
+.gene-group { padding: 16px 20px; margin: 10px 0; }
+.gene-group summary { cursor: pointer; font-weight: 600; }
+.gene-group[open] summary {
+    border-bottom: 1px solid var(--report-border); padding-bottom: 12px; margin-bottom: 12px;
+}
+.gene-group ul { padding-left: 24px; }
+.gene-group p { margin: 8px 0; }
+.tab-nav { background: var(--report-page); border-color: var(--report-border); }
+.tab-link, .tab-count { background: var(--report-panel); color: var(--report-ink); }
+.link-btn { color: #176579; border-color: var(--report-border); }
+.link-btn:hover { background: var(--report-cyan); color: #174e5e; border-color: #176579; }
+.ai-note { background: var(--report-cyan); border-color: #27869c; color: #174e5e; }
+.gap-note { background: var(--report-panel); color: var(--report-ink); }
+footer { background: var(--report-panel); color: var(--report-muted); border: 1px solid var(--report-border); }
+.footer-section strong { color: var(--report-ink); }
+.footer-meta { color: var(--report-muted); border-color: var(--report-border); }
+.variant-card:hover { transform: none; box-shadow: 0 2px 6px #29272e14; }
+@media (max-width: 600px) {
+    .container { padding: 12px; }
+    .variants-grid { grid-template-columns: minmax(0, 1fr); }
+    .summary-section { padding: 18px; }
+    .gene-group { padding: 12px; }
+}
+@media print {
+    body, header, .stat-card, .summary-section, .variant-card, .gene-group, footer {
+        background: white; color: #222; box-shadow: none;
+    }
+    .gene-group { break-inside: avoid; }
+}
+"""

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -13,11 +13,13 @@ from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
 from starlette.background import BackgroundTask
 
+from allelio.report_style import REPORT_CSS
 from allelio import __version__
 from allelio.parsers import parse_genotype_file
 from allelio.database.store import AllelioDB
 from allelio.database.downloader import sources_summary, provenance_of
 from allelio.analysis.lookup import analyze_variants, AnalysisStats
+from allelio.analysis.genes import gene_assignments, group_findings, gene_overview_html, gene_label
 from allelio.ai.attribution import Explanation, attribution
 from allelio.ai.engine import AIEngine, REFUSED, UNREACHABLE
 from allelio.ai.safety import get_variant_warnings
@@ -140,14 +142,8 @@ def _model_of(explanation) -> Optional[str]:
 
 
 def _gene_of(variant) -> Optional[str]:
-    """Gene symbol for a result, from ClinVar first and GWAS as a fallback."""
-    for entry in (variant.clinvar_entries or []):
-        if entry.gene:
-            return entry.gene
-    for entry in (variant.gwas_entries or []):
-        if entry.mapped_gene:
-            return entry.mapped_gene
-    return None
+    """Display all recorded ClinVar, GWAS and ClinPGx gene associations."""
+    return gene_label(variant)
 
 
 def _significance_of(variant) -> str:
@@ -327,6 +323,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
                 # did not write it, because the credit is on the card.
                 "explained_by": _model_of(explanations.get(variant.rsid)),
                 "gene": _gene_of(variant),
+                "gene_assignments": gene_assignments(variant),
                 "significance": _significance_of(variant),
                 "pubmed_id": next(
                     (e.pubmed_id for e in (variant.gwas_entries or []) if e.pubmed_id),
@@ -339,6 +336,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         payload = {
             "summary": summary,
             "results": formatted_results,
+            "gene_groups": group_findings(formatted_results),
             "total_variants": len(analysis_results),
             "reference_genotype_sites": analysis_stats.reference_genotype_sites,
             "zygosity_unknown_sites": analysis_stats.zygosity_unknown_sites,
@@ -576,8 +574,9 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
             "you carry only the reference allele (not findings).</p>"
         )
 
-    # The table below stops at a hundred rows.
-    rows = results[:100]
+    # Every finding referenced by the gene overview must remain reachable.
+    rows = [r for r in results if isinstance(r, dict)]
+    gene_overview = gene_overview_html(rows)
 
     cards = [r for r in rows if isinstance(r, dict)]
     # Count the credit over the cards that actually carry an explanation, the
@@ -609,7 +608,7 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
 
     # Build results table HTML
     results_html = ""
-    for result in rows:
+    for index, result in enumerate(rows):
         # These come from the uploaded file and the model, and the report is
         # opened in a browser — none of it is trusted markup.
         def field(name):
@@ -636,7 +635,7 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         )
 
         results_html += f"""
-        <tr>
+        <tr id="finding-{index}">
             <td>{rsid}</td>
             <td>{chrom}</td>
             <td>{pos}</td>
@@ -652,6 +651,7 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     <html>
     <head>
         <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Allelio Analysis Report</title>
         <style>
             td {{
@@ -701,6 +701,17 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
                 color: #666;
                 margin: 10px 0;
             }}
+            {REPORT_CSS}
+            body {{ max-width: 1200px; margin: 0 auto; padding: 24px; }}
+            h1 {{ padding: 24px; background: var(--report-panel); border-radius: 12px;
+                  border: 1px solid var(--report-border); border-top: 4px solid #66c8aa; }}
+            .metadata {{ color: var(--report-muted); }}
+            .summary {{ padding: 20px; }}
+            .table-scroll {{ overflow-x: auto; }}
+            th {{ background: var(--report-panel); color: var(--report-ink); font-weight: 600; }}
+            td {{ border-color: var(--report-border); }}
+            tr:hover {{ background: var(--report-mint); }}
+            @media print {{ .table-scroll {{ overflow: visible; }} }}
         </style>
     </head>
     <body>
@@ -718,7 +729,10 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
             {summary}
         </div>
         
+        {gene_overview}
+
         <h2>Detailed Results</h2>
+        <div class="table-scroll" tabindex="0" role="region" aria-label="Detailed results">
         <table>
             <thead>
                 <tr>
@@ -735,6 +749,7 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
                 {results_html}
             </tbody>
         </table>
+        </div>
         
         <p><em>Report generated by Allelio - Privacy-first local genomics analysis</em></p>
     </body>

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -506,6 +506,13 @@
             color: var(--primary);
         }
 
+        .gene-group {
+            margin: 1rem 0; padding: 1rem; border: 1px solid var(--gray-300);
+            border-radius: 12px; background: var(--white);
+        }
+        .gene-group > summary { cursor: pointer; font-weight: 700; font-size: 1.1rem; }
+        .gene-group > p { margin: 0.75rem 0; }
+        body.dark-mode .gene-group { background: var(--gray-800); border-color: var(--gray-600); }
         .result-gene {
             font-size: 0.95rem;
             color: var(--gray-600);
@@ -1497,10 +1504,50 @@
                 return;
             }
 
-            results.forEach((result, idx) => {
-                const card = createResultCard(result);
-                container.appendChild(card);
-            });
+            if (Array.isArray(analysisResults.gene_groups) && analysisResults.gene_groups.length) {
+                const note = document.createElement('p');
+                note.textContent = 'Counts cover returned findings, not all variants in a gene. Shared findings appear in each associated gene.';
+                container.appendChild(note);
+                const visible = new Set(results);
+                const rendered = new Set();
+                analysisResults.gene_groups.forEach(group => {
+                    if (!group || typeof group !== 'object') return;
+                    const indices = Array.isArray(group.indices) ? group.indices : [];
+                    const members = [...new Set(indices.filter(Number.isInteger))]
+                        .map(i => analysisResults.results[i]).filter(r => r && visible.has(r));
+                    if (!members.length) return;
+                    const details = document.createElement('details');
+                    details.className = 'gene-group';
+                    const title = document.createElement('summary');
+                    const countLabel = members.length === group.count
+                        ? `${members.length} ${members.length === 1 ? 'finding' : 'findings'}`
+                        : `${members.length} of ${group.count} findings in this view`;
+                    title.textContent = `${group.gene} — ${countLabel}`;
+                    details.appendChild(title);
+                    const description = document.createElement('p');
+                    description.textContent = group.function || 'A sourced function summary is not available in this release.';
+                    details.appendChild(description);
+                    if (/^https:\/\/medlineplus\.gov\/genetics\/gene\/[a-z0-9-]+\/$/.test(group.function_source || '')) {
+                        const source = document.createElement('a');
+                        source.href = group.function_source;
+                        source.textContent = `MedlinePlus Genetics (summary version ${group.function_version || 'not recorded'})`;
+                        source.target = '_blank'; source.rel = 'noopener noreferrer';
+                        details.appendChild(source);
+                    }
+                    const interpretation = document.createElement('p');
+                    interpretation.textContent = group.note || '';
+                    details.appendChild(interpretation);
+                    members.forEach(result => {
+                        details.appendChild(createResultCard(result)); rendered.add(result);
+                    });
+                    container.appendChild(details);
+                });
+                // Corrupt or older saved grouping metadata must not hide findings.
+                results.filter(r => !rendered.has(r)).forEach(r => container.appendChild(createResultCard(r)));
+            } else {
+                // Saved analyses from earlier releases retain their flat view.
+                results.forEach(result => container.appendChild(createResultCard(result)));
+            }
         }
         // render-cards end
 

--- a/docs/gene-grouping.md
+++ b/docs/gene-grouping.md
@@ -1,0 +1,68 @@
+# Findings by gene
+
+Allelio now organizes returned findings by gene in the CLI, web page, and both
+HTML exports. Expand a gene to inspect the findings it contains. The individual
+annotations and ranking are unchanged; grouping adds no combined risk score.
+
+Counts refer to returned findings, not every variant in the gene or every site
+on the uploaded array. They are computed before display limits and category
+filters. The CLI top-results table keeps its requested limit, followed by a
+summary of every returned gene group. Web category filters show visible versus
+total group counts. HTML exports retain all findings so every summary link has
+a detail target. Large analyses therefore produce larger exports than earlier
+releases that truncated the result list. No gene grouping implies that a gene was comprehensively tested.
+
+## Gene identity and shared findings
+
+Associations are gathered from ClinVar, GWAS, and ClinPGx. Semicolon/comma lists
+and spaced intergenic separators are split, while hyphenated symbols such as
+HLA-DQA1 stay intact. The source's HGNC identifier is used only when its mapping
+to a symbol is unambiguous. Known source aliases sharing an ID can be grouped;
+no broad symbol-alias inference is performed. Missing IDs use symbol groups.
+Conflicting source IDs are not forced together. Unassigned findings remain
+visible in an explicit group.
+
+Within a group, matching rsID, chromosome, position, genotype, matched allele,
+and category identify duplicate results. Conflicting genotypes/categories remain
+separate. Findings associated with several genes appear in each relevant group;
+group counts therefore must not be summed into a genome-wide count. Grouping
+expresses source associations, not a new causal gene assignment.
+
+## Function descriptions
+
+A small offline catalogue provides original, short paraphrases of the Normal
+Function sections of MedlinePlus Genetics for BRCA1, BRCA2, CFTR, APOE and HFE.
+Each description links its source and records catalogue version 2026-09-12:
+
+- https://medlineplus.gov/genetics/gene/brca1/
+- https://medlineplus.gov/genetics/gene/brca2/
+- https://medlineplus.gov/genetics/gene/cftr/
+- https://medlineplus.gov/genetics/gene/apoe/
+- https://medlineplus.gov/genetics/gene/hfe/
+
+Other genes explicitly state that a sourced function summary is unavailable.
+No network request or AI call fills missing descriptions. Future catalogue
+updates should cite sources and change the version deliberately.
+
+The combined note explains that several findings alone do not establish higher
+risk, a haplotype, or compound heterozygosity. Determining those relationships
+requires evidence outside this presentation feature.
+
+## Saved results and reproducibility
+
+New web payloads preserve gene assignments and groups with indices into their
+canonical results array. Older saves without grouping metadata keep their flat
+web view; exporting them can still group their recorded gene symbols. Exports
+recompute summaries from their findings rather than trusting submitted counts
+or source URLs. Corrupt grouping metadata cannot hide unlisted web findings.
+
+Tests cover counts, overlapping genes, ambiguous identifiers, missing genes,
+source links, HTML escaping, findings beyond old export limits, CLI top limits,
+and the actual browser rendering code with category filters.
+
+## HTML presentation
+
+Both standalone exports share an offline system-font stack, lavender-gray
+surfaces, thin rounded panel borders, and restrained mint/cyan accents. Clinical
+status labels keep their existing meanings and warning colors. No remote fonts
+or branding assets are fetched. Tables can scroll on small screens.

--- a/tests/test_gene_grouping.py
+++ b/tests/test_gene_grouping.py
@@ -1,0 +1,145 @@
+"""Gene grouping conserves findings and does not combine their clinical meaning."""
+from types import SimpleNamespace
+import re
+from allelio.analysis.genes import group_findings, gene_assignments, gene_overview_html, MULTIPLE_NOTE
+from allelio.analysis.lookup import VariantResult, ClinVarEntry, PGxEntry, GWASEntry
+from allelio.report import generate_html_report
+from allelio.web.app import app  # Initialize routes through the app.
+from allelio.web.routes import _generate_html_report
+
+
+def finding(rsid='rs1', gene='BRCA2', category='Health Conditions'):
+    return VariantResult(rsid=rsid, genotype='AG', chromosome='1', position=100,
+        category=category, significance_rank=1,
+        clinvar_entries=[ClinVarEntry(rsid=rsid, gene=gene, clinical_significance='Pathogenic')])
+
+
+def test_distinct_counts_and_multiple_gene_membership():
+    first = finding(gene='BRCA2;CFTR')
+    results = [first, first, finding('rs2'), finding('rs3', None)]
+    groups = {g['gene']:g for g in group_findings(results)}
+    assert groups['BRCA2']['indices'] == [0, 2]
+    assert groups['BRCA2']['count'] == 2
+    assert groups['CFTR']['indices'] == [0]
+    assert groups['Unassigned']['indices'] == [3]
+    assert groups['BRCA2']['note'] == MULTIPLE_NOTE
+    assert sorted({i for g in groups.values() for i in g['indices']}) == [0, 2, 3]
+
+
+def test_all_sources_and_hyphenated_symbols():
+    result = finding(gene='HLA-DQA1')
+    result.gwas_entries = [GWASEntry(rsid='rs1', mapped_gene='HLA-DQB1 - HLA-DQA1')]
+    result.pgx_entries = [PGxEntry(rsid='rs1', annotation_id='1', gene='CYP2D6')]
+    assert {a['symbol'] for a in gene_assignments(result)} == {'HLA-DQA1','HLA-DQB1','CYP2D6'}
+
+
+def test_shared_stable_id_merges_source_aliases():
+    a, b = finding(gene='OLD'), finding('rs2', 'NEW')
+    a.clinvar_entries[0].hgnc_id = b.clinvar_entries[0].hgnc_id = 'HGNC:1'
+    group, = group_findings([a,b])
+    assert group['hgnc_id'] == 'HGNC:1' and group['count'] == 2
+    assert group['symbols'] == ['NEW','OLD']
+    assert group['function_source'] is None
+
+
+def test_conflicting_ids_do_not_force_merge():
+    a, b, c = finding(), finding('rs2'), finding('rs3')
+    a.clinvar_entries[0].hgnc_id = 'HGNC:1'
+    b.clinvar_entries[0].hgnc_id = 'HGNC:2'
+    assert len(group_findings([a,b,c])) == 3
+
+
+def test_json_projection_preserves_groups():
+    results = [finding(), finding('rs2', 'CFTR')]
+    projected = [dict(rsid=r.rsid, chromosome=r.chromosome, position=r.position,
+                      genotype=r.genotype, category=r.category, gene_assignments=gene_assignments(r)) for r in results]
+    assert group_findings(projected) == group_findings(results)
+
+
+def test_unassigned_and_untrusted_text_are_not_lost_or_executed():
+    rows = [dict(rsid='<script>alert(1)</script>', gene='<img src=x>', category='<b>unsafe</b>')]
+    html = gene_overview_html(rows)
+    assert 'Unassigned' in html and '&lt;script&gt;' in html
+    assert '<script>' not in html and '<img' not in html
+
+
+def test_report_links_reach_all_findings_including_past_previous_limit():
+    results = [finding(f'rs{i}') for i in range(102)] + [finding('rs999', None, 'Unknown')]
+    html = generate_html_report(results, {}, '', {})
+    links = re.findall(r'href="#(finding-\d+)"', html)
+    assert len(links) == 103
+    assert all(f'id="{target}"' in html for target in links)
+    assert 'MedlinePlus Genetics' in html and 'compound heterozygosity' in html
+
+
+def test_web_export_group_links_and_uncategorized_rows():
+    results = [dict(rsid=f'rs{i}', gene='BRCA2', category='Unknown', genotype='AG') for i in range(102)]
+    html = _generate_html_report(dict(results=results))
+    assert '102 findings' in html
+    assert 'id="finding-101"' in html
+    assert '<script>' not in html
+
+
+def test_cli_gene_summary_includes_findings_beyond_top(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+    from allelio import cli
+    from allelio.database.store import AllelioDB
+    db = AllelioDB(str(tmp_path / 'a.db'))
+    db.initialize()
+    db.insert_clinvar_batch([dict(rsid=f'rs{i}', gene='BRCA2', clinical_significance='Pathogenic',
+        ref_allele='A', alt_allele='G', review_status='', conditions='', last_evaluated='') for i in (1,2)])
+    monkeypatch.setattr(cli, 'AllelioDB', lambda: db)
+    path = tmp_path / 'input.txt'
+    path.write_text('# synthetic\nrs1\t1\t100\tAG\nrs2\t1\t101\tAG\n')
+    result = CliRunner().invoke(cli.analyze, [str(path), '--no-ai', '--top', '1', '-o', str(tmp_path / 'report.html')])
+    assert result.exit_code == 0, result.output
+    assert 'Findings by gene' in result.output
+    # rs2 is not in the top-one variant table but is in the gene summary.
+    assert 'rs2' in result.output
+    assert 'BRCA2' in result.output
+
+
+def test_actual_web_group_renderer_filters_and_keeps_unlisted_rows():
+    import json
+    import shutil
+    import subprocess
+    from pathlib import Path
+    node = shutil.which('node')
+    assert node, 'Node is needed for the web grouping test'
+    results = [dict(rsid='rs1', category='Traits', gene='BRCA2'),
+               dict(rsid='rs2', category='Health Conditions', gene='BRCA2'),
+               dict(rsid='rs3', category='Traits', gene=None)]
+    groups = group_findings(results)
+    # Deliberately omit Unassigned to exercise stale/incomplete saved metadata.
+    payload = dict(results=results, gene_groups=[g for g in groups if g['gene'] != 'Unassigned'])
+    template = (Path(__file__).resolve().parents[1] / 'allelio/web/templates/index.html').read_text()
+    def fenced(name):
+        return template.split(f'// {name} start')[1].split(f'// {name} end')[0]
+    script = '''
+const element = tag => ({tag, children: [], appendChild(child) {this.children.push(child);}});
+const container = element('container');
+const document = {getElementById: () => container, createElement: element};
+const createResultCard = result => ({tag:'card', rsid:result.rsid});
+const renderAttribution = () => {};
+let currentCategory = 'traits';
+''' + 'const analysisResults = ' + json.dumps(payload) + ';\n' + fenced('slugify') + fenced('render-cards') + '''
+renderResultCards();
+console.log(JSON.stringify(container));
+'''
+    completed = subprocess.run([node, '-e', script], capture_output=True, text=True)
+    assert completed.returncode == 0, completed.stderr
+    tree = json.loads(completed.stdout)
+    serialized = json.dumps(tree)
+    assert '1 of 2 findings' in serialized
+    assert 'rs1' in serialized and 'rs3' in serialized and 'rs2' not in serialized
+
+
+def test_pgx_only_gene_label_matches_its_group():
+    from allelio.analysis.genes import gene_label
+    from allelio.report import _get_gene
+    from allelio.web.routes import _gene_of
+    result = finding(gene=None)
+    result.clinvar_entries = []
+    result.pgx_entries = [PGxEntry(rsid='rs1', annotation_id='1', gene='CYP2D6')]
+    assert gene_label(result) == _get_gene(result) == _gene_of(result) == 'CYP2D6'
+    assert group_findings([result])[0]['gene'] == 'CYP2D6'

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1790,12 +1790,7 @@ def test_the_downloaded_report_names_the_model(client: TestClient, monkeypatch) 
 
 
 def test_the_downloaded_report_counts_the_rows_it_prints() -> None:
-    """The table stops at a hundred rows and the line above it did not.
-
-    A genome with more significant variants than that read "150 of 150
-    explanations" over a table holding a hundred, which is a count of a set the
-    reader was never shown.
-    """
+    """Every finding is reachable from gene groups, so count all rendered rows."""
     from allelio.web import routes as routes_module
 
     html = routes_module._generate_html_report(
@@ -1810,8 +1805,9 @@ def test_the_downloaded_report_counts_the_rows_it_prints() -> None:
         }
     )
 
-    assert "llama3.1:8b (100 of 100 explanations)" in html
-    assert html.count("<tr>") == 101  # the header row and the hundred it kept
+    assert "llama3.1:8b (150 of 150 explanations)" in html
+    assert 'id="finding-149"' in html
+    assert html.count("<tr") == 151  # the header and every displayed finding
 
 
 def test_the_report_counts_explanations_not_unexplained_rows() -> None:


### PR DESCRIPTION
## Changes

Findings were presented as flat lists, making it difficult to inspect several results associated with the same gene. Add deterministic gene groups to the CLI, web results and both HTML exports, with distinct finding counts, links to individual results, and conservative use of source HGNC identifiers. Shared findings remain visible under every associated gene; missing assignments have an explicit group.

Include a small versioned, sourced offline function catalogue for five genes, with an explicit fallback elsewhere. Multiple findings do not imply combined risk, phase or compound heterozygosity. Original annotations and ranking remain unchanged. Remove the HTML 100-finding truncation so every group link has a detail target, retain uncategorized findings, and correct gene labels for pharmacogenomics-only results.

Both HTML exports now share lavender-gray panels, system typography, thin rounded borders and restrained mint/cyan accents. Fonts and assets remain offline. Clinical warnings retain their meanings; wide tables scroll on smaller screens.

## Validation

- 623 tests passed, including grouping, identifier ambiguity, escaping, complete export links, CLI limits, pharmacogenomics labels and JavaScript category-filter behavior.
- Synthetic browser checks covered expandable groups, category filtering, finding links and both styled HTML export formats.
- Local fixture baseline passed before the presentation-only styling update.

Closes #5
