### PR TITLE
Correct frequency guidance and preserve ranking direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Separate frequency display heuristics from clinical evidence, ignore invalid
+  frequency values, and prevent rank caps from increasing benign-row priority.
+
 - Require declared VCF build, chromosome and position agreement with ClinVar
   before counting SNP alleles. Unknown/mismatched identities abstain with a
   reason; no build inference, liftover, or mitochondrial matching is attempted.

--- a/README.md
+++ b/README.md
@@ -410,12 +410,12 @@ then association, and so on down to benign), then two adjustments are applied:
    stars) nudges the rank within its own tier — a 4-star pathogenic call
    ranks slightly above a 0-star one — capped so it can never cross into a
    different significance tier.
-2. **Population frequency.** A variant common in gnomAD is less likely to be
-   truly pathogenic, so common variants (allele frequency above roughly 5%
-   and 1%, echoing the [ACMG/AMP BA1 and BS1 population-frequency
-   thresholds](https://doi.org/10.1038/gim.2015.30), Richards et al. 2015) are
-   downgraded toward "less significant," capped so they never fully cross the
-   benign boundary.
+2. **Population frequency.** Optional display penalties use frequency tiers
+   above 5%, 1%, and 0.1%. These thresholds and penalty sizes are Allelio
+   heuristics, not ACMG/AMP classification rules. They only lower display
+   priority; source classifications remain unchanged. Missing or invalid
+   frequencies do not adjust ranking. Rarity alone does not establish
+   pathogenicity, and commonness alone does not establish benignity.
 
 To see exactly what the frequency adjustment does, run
 `python3 scripts/ablation_frequency.py`: it ranks the example file with the
@@ -424,10 +424,9 @@ to use your full local database). On the example, the adjustment leaves the
 rare pathogenic alleles where they are and pushes two common
 "conflicting" variants (APOE ε4, HFE H63D) below the default cutoff.
 
-The frequency *thresholds* are cited to ACMG/AMP; the specific *penalty
-sizes* are not — ACMG/AMP's BA1/BS1 are qualitative evidence codes, not point
-values, so Allelio's amounts are an author choice, documented as such at each
-constant in `allelio/analysis/lookup.py`.
+[ClinGen defines BS1 relative to the expected frequency for a disorder](https://dataexchange.clinicalgenome.org/interpretation/entities/VariantPathogenicityInterpretationCriterion.html),
+not a universal 1% cutoff. Allelio does not apply BS1 or BA1 evidence codes.
+The optional ranking heuristic is not a validated clinical classifier.
 
 ---
 

--- a/allelio/ai/prompts.py
+++ b/allelio/ai/prompts.py
@@ -7,6 +7,7 @@ human-readable text suitable for inclusion in prompts.
 """
 
 from typing import List, Optional
+from allelio.analysis.frequency import valid_frequency
 
 
 SYSTEM_PROMPT = """You are a genetics education assistant for Allelio, an open-source genomics tool. Your role is to explain genetic variant findings in clear, accessible language. You MUST: 1) Use plain English that a non-scientist can understand. 2) Explain what the variant means in practical terms. 3) Provide relevant lifestyle or dietary context from published research when applicable. 4) Always note limitations and uncertainties. 5) Never make definitive medical diagnoses. 6) Cite the source databases (ClinVar, GWAS Catalog) and relevant studies. 7) Recommend consulting a genetic counselor for clinically significant findings. Keep explanations concise (2-4 paragraphs). Be warm, informative, and reassuring without minimizing genuine risks."""
@@ -154,7 +155,7 @@ def format_gnomad_summary(gnomad_entry) -> str:
         return "No population frequency data available for this variant."
 
     af = getattr(gnomad_entry, 'allele_frequency', None)
-    if af is None:
+    if not valid_frequency(af):
         return "No population frequency data available for this variant."
 
     af_percent = af * 100
@@ -171,21 +172,26 @@ def format_gnomad_summary(gnomad_entry) -> str:
         lines.append(f"- Global Allele Frequency: {af_percent:.4f}%")
 
     # Popmax
-    if af_popmax is not None and af_popmax > af:
+    if valid_frequency(af_popmax) and af_popmax > af:
         lines.append(f"- Highest in any population: {af_popmax * 100:.4f}%")
 
     # Interpretation hint for the LLM
-    if af > 0.05:
-        lines.append("- Context: Common variant (>5% frequency) — typically benign or population-specific")
+    if af == 0:
+        lines.append("- Context: Not observed in the recorded source sample; absence is not evidence of pathogenicity")
+    elif af > 0.05:
+        lines.append("- Context: Common variant (>5% frequency)")
     elif af > 0.01:
-        lines.append("- Context: Moderately common variant (1-5% frequency)")
+        lines.append("- Context: Moderately common variant (>1% to 5% frequency)")
     elif af > 0.001:
-        lines.append("- Context: Uncommon variant (0.1-1% frequency)")
+        lines.append("- Context: Uncommon variant (>0.1% to 1% frequency)")
     elif af > 0.00001:
-        lines.append("- Context: Rare variant (<0.1% frequency) — more likely to be clinically significant")
+        lines.append("- Context: Rare variant (>0.001% to 0.1% frequency)")
     else:
-        lines.append("- Context: Very rare variant (<0.001% frequency) — warrants careful interpretation")
+        lines.append("- Context: Very rare variant (>0% to 0.001% frequency)")
 
+    lines.append("- Frequency alone does not establish benignity or pathogenicity. "
+                 "Clinical interpretation requires disease-specific evidence; "
+                 "do not apply a universal BS1 threshold.")
     return "\n".join(lines)
 
 

--- a/allelio/analysis/frequency.py
+++ b/allelio/analysis/frequency.py
@@ -1,0 +1,8 @@
+"""Validation shared by frequency display and ranking."""
+import math
+
+
+def valid_frequency(value) -> bool:
+    """Accept finite numeric proportions, never booleans or coerced strings."""
+    return (isinstance(value, (int, float)) and not isinstance(value, bool)
+            and math.isfinite(value) and 0 <= value <= 1)

--- a/allelio/analysis/lookup.py
+++ b/allelio/analysis/lookup.py
@@ -9,6 +9,7 @@ from allelio.database.clinpgx import level_rank as pgx_level_rank
 from allelio.analysis.zygosity import Zygosity, ZygosityCall, call_zygosity, genotype_alleles, call_vcf_zygosity
 from allelio.parsers.base import VCFEvidence
 from allelio.analysis.identity import vcf_identity_reason
+from allelio.analysis.frequency import valid_frequency
 
 
 # ClinVar review status to star rating mapping (0-4 stars)
@@ -75,28 +76,15 @@ SIGNIFICANCE_RANKS = {
 }
 
 # --- Allele-frequency tiers used to adjust the rank ------------------------
-# ACMG/AMP (Richards et al. 2015, https://doi.org/10.1038/gim.2015.30) treats
-# population allele frequency as evidence against pathogenicity: BA1
-# (stand-alone) at roughly 5%, BS1 (strong) at roughly 1%, for a fully
-# penetrant dominant disorder. Those are the two cited cutoffs below. BA1/BS1
-# are categorical evidence codes, not numeric rank penalties, so the tier
-# boundaries are cited but the third, tighter tier and every penalty size
-# below are Allelio's own choices, not a re-derivation of ACMG/AMP.
-COMMON_AF_THRESHOLD = 0.05  # cf. ACMG/AMP BA1 (~5%), Richards et al. 2015
-MODERATELY_COMMON_AF_THRESHOLD = 0.01  # cf. ACMG/AMP BS1 (~1%), Richards et al. 2015
-UNCOMMON_AF_THRESHOLD = 0.001  # author choice, no ACMG/AMP precedent at this cutoff
-
-# Common variants are less likely to be truly pathogenic, so their rank is
-# pushed toward "less significant" — more at the common tier, less at the
-# uncommon one. ACMG/AMP's BA1/BS1 are evidence codes, not point values, so
-# none of these three sizes has an external citation: they are author
-# choices, sized only so a common variant is downgraded more than a
-# moderately common one, which is downgraded more than an uncommon one, and
-# so that no single downgrade crosses a full significance tier on its own
-# (see MAX_ADJUSTED_RANK).
-COMMON_AF_PENALTY = 3.0  # author choice, no external precedent
-MODERATELY_COMMON_AF_PENALTY = 1.5  # author choice, no external precedent
-UNCOMMON_AF_PENALTY = 0.5  # author choice, no external precedent
+# These are display-priority heuristics, not ACMG/AMP classification rules.
+# BS1 depends on the disorder; 1% is not a universal BS1 cutoff. Frequency
+# alone establishes neither benignity nor pathogenicity.
+COMMON_AF_THRESHOLD = 0.05
+MODERATELY_COMMON_AF_THRESHOLD = 0.01
+UNCOMMON_AF_THRESHOLD = 0.001
+COMMON_AF_PENALTY = 3.0
+MODERATELY_COMMON_AF_PENALTY = 1.5
+UNCOMMON_AF_PENALTY = 0.5
 
 # Keeps a frequency-adjusted rank below the "benign" tier boundary at 10, no
 # matter how common the variant is. Author choice, not an external constant.
@@ -396,25 +384,13 @@ def _calculate_frequency_adjustment(
     base_rank: float,
     gnomad_entry: Optional[GnomADEntry],
 ) -> float:
-    """Adjust significance rank based on gnomAD allele frequency.
+    """Apply an optional display penalty; never change source classifications.
 
-    Common variants are less likely to be truly pathogenic, so we increase
-    their rank (making them less significant). Rare variants keep their
-    original rank. See the COMMON_AF_THRESHOLD/_PENALTY family above for
-    which parts of this are cited to ACMG/AMP and which are author choices.
-
-    The adjustment is bounded so it never crosses major tier boundaries
-    completely — a pathogenic variant with high AF will be downgraded but
-    still noted as unusual.
-
-    Args:
-        base_rank: The original significance rank (lower = more significant)
-        gnomad_entry: gnomAD frequency data, or None
-
-    Returns:
-        Adjusted rank as float (higher = less significant)
+    Valid frequencies above the configured tiers increase the numeric rank
+    (lower display priority). Missing/invalid values leave it unchanged.
+    The cap never improves a rank already at or beyond the cap.
     """
-    if gnomad_entry is None or gnomad_entry.allele_frequency is None:
+    if gnomad_entry is None or not valid_frequency(gnomad_entry.allele_frequency):
         return base_rank
 
     af = gnomad_entry.allele_frequency
@@ -430,7 +406,7 @@ def _calculate_frequency_adjustment(
         # Rare — no adjustment needed
         return base_rank
 
-    return min(base_rank + adjustment, MAX_ADJUSTED_RANK)
+    return max(base_rank, min(base_rank + adjustment, MAX_ADJUSTED_RANK))
 
 
 def _clinvar_entry(cv_data: Dict[str, Any]) -> ClinVarEntry:
@@ -858,11 +834,8 @@ def analyze_variants_with_stats(
                 nhomalt=gn.get("nhomalt"),
             )
 
-        # Adjust significance rank based on population frequency. Not for
-        # pharmacogenomic findings: the adjustment encodes "a common allele is
-        # unlikely to be pathogenic", and a drug-response allele is not a
-        # pathogenicity claim, most are common by nature (VKORC1 -1639G>A is
-        # carried by a third of Europeans) and no less actionable for it.
+        # This optional frequency display penalty is not applied to PGx:
+        # allele commonness does not determine drug-response applicability.
         pharmacogenomic = category == VariantCategory.PHARMACOGENOMICS.value
         adjusted_rank = (
             _calculate_frequency_adjustment(sig_rank, gnomad_entry)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -649,7 +649,7 @@ class TestRankingOrderRegression:
         }
 
     def test_pinned_triage_order(self, tmp_dir):
-        """Multi-star pathogenic < zero-star pathogenic < VUS < common benign < rare benign."""
+        """Multi-star pathogenic < zero-star pathogenic < VUS < tied benign rows."""
         from pathlib import Path
 
         db_path = str(Path(tmp_dir) / "ranking_regression.db")
@@ -727,5 +727,5 @@ class TestRankingOrderRegression:
         assert ranks["rs_path_4star"] == pytest.approx(0.6)
         assert ranks["rs_path_0star"] == pytest.approx(1.0)
         assert ranks["rs_vus"] == pytest.approx(7.0)
-        assert ranks["rs_benign_common"] == pytest.approx(9.9)
+        assert ranks["rs_benign_common"] == pytest.approx(10.0)
         assert ranks["rs_benign_rare"] == pytest.approx(10.0)

--- a/tests/test_gnomad.py
+++ b/tests/test_gnomad.py
@@ -436,3 +436,26 @@ class TestGnomADPrompts:
 
         assert "Population Frequency" in prompt
         assert "5.0000%" in prompt
+
+@pytest.mark.parametrize('af', [float('nan'), float('inf'), -0.1, 1.1, True, '0.2'])
+def test_invalid_frequency_does_not_rank_or_prompt(af):
+    entry = GnomADEntry(rsid='rs1', allele_frequency=af)
+    assert _calculate_frequency_adjustment(2.0, entry) == 2.0
+    assert 'No population frequency data' in format_gnomad_summary(entry)
+
+@pytest.mark.parametrize('rank', [9.9, 10, 11, 99])
+def test_frequency_cap_never_improves_priority(rank):
+    entry = GnomADEntry(rsid='rs1', allele_frequency=0.5)
+    assert _calculate_frequency_adjustment(rank, entry) == rank
+
+@pytest.mark.parametrize('af', [0, 0.00005, 0.005, 0.03, 0.3, 1])
+def test_frequency_context_does_not_infer_pathogenicity(af):
+    text = format_gnomad_summary(GnomADEntry(rsid='rs1', allele_frequency=af))
+    assert 'Frequency alone does not establish benignity or pathogenicity' in text
+    assert 'typically benign' not in text
+    assert 'more likely to be clinically significant' not in text
+
+@pytest.mark.parametrize('popmax', [float('inf'), 2, True, '0.5'])
+def test_invalid_popmax_is_not_prompted(popmax):
+    text = format_gnomad_summary(GnomADEntry(rsid='rs1', allele_frequency=0.1, af_popmax=popmax))
+    assert 'Highest in any population' not in text


### PR DESCRIPTION
Frequency context implied that rarity predicts clinical importance and presented 1% as a general BS1 cutoff. Describe frequency without that inference, document all rank thresholds as display heuristics, and explicitly preserve source classifications.

Ignore nonfinite, out-of-range and nonnumeric frequencies in ranking and prompt context. Fix the cap so it cannot increase the priority of an already-benign row. Zero frequency is described as unobserved in the recorded source sample, and interval labels include their exact endpoints.

Validation: full regression suite, including invalid frequencies, prompt context and the corrected benign ranking invariant; executable fixture baseline.

Closes #13
