### PR TITLE
Honor VCF record and sample filter failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Set aside annotated VCF sites with failed record FILTER or sample FT before
+  matching, and report the excluded count separately from negative findings.
+
 - Separate frequency display heuristics from clinical evidence, ignore invalid
   frequency values, and prevent rank caps from increasing benign-row priority.
 

--- a/README.md
+++ b/README.md
@@ -561,3 +561,16 @@ Allelio is provided "as-is" for educational and informational purposes only. It 
 ---
 
 **Made with care by the Allelio community.**
+
+### VCF filter handling
+
+An explicit failure in record `FILTER` or sample `FORMAT/FT` sets an annotated
+site aside before ClinVar, GWAS or genotype-specific PGx interpretation. CLI,
+web results and HTML exports report the count separately; an excluded site is
+not a negative finding. Raw filter values remain in the parsed VCF evidence.
+
+`PASS` means the upstream filters passed; `.` or an absent filter means filtering
+is unknown or not applied, and does not itself exclude the site. Allelio does
+not infer PASS or introduce arbitrary QUAL/GQ/DP cutoffs. Passing filters does
+not validate a genotype or remove the other identity and allele checks. See the
+[VCF specification](https://samtools.github.io/hts-specs/VCFv4.3.pdf).

--- a/allelio/analysis/lookup.py
+++ b/allelio/analysis/lookup.py
@@ -10,6 +10,7 @@ from allelio.analysis.zygosity import Zygosity, ZygosityCall, call_zygosity, gen
 from allelio.parsers.base import VCFEvidence
 from allelio.analysis.identity import vcf_identity_reason
 from allelio.analysis.frequency import valid_frequency
+from allelio.analysis.quality import vcf_filter_reason
 
 
 # ClinVar review status to star rating mapping (0-4 stars)
@@ -284,6 +285,8 @@ class AnalysisStats:
         zygosity_unknown_sites: sites reported without a zygosity call,
             because the source does not give the allele or the genotype does
             not match it on either strand.
+        vcf_filter_failed_sites: annotated sites set aside because VCF FILTER
+            or FORMAT/FT explicitly failed; not reference calls or benign findings.
         benign_sites: sites left out because every match was benign
             (unless include_benign).
     """
@@ -291,6 +294,7 @@ class AnalysisStats:
     reference_genotype_sites: int = 0
     zygosity_unknown_sites: int = 0
     benign_sites: int = 0
+    vcf_filter_failed_sites: int = 0
 
 
 def _determine_category(clinvar_entry: Optional[ClinVarEntry], gwas_entries: List[GWASEntry]) -> str:
@@ -735,6 +739,10 @@ def analyze_variants_with_stats(
         genotype = getattr(original_variant, 'genotype', None)
 
         vcf_evidence = getattr(original_variant, 'vcf_evidence', None)
+        if vcf_filter_reason(vcf_evidence):
+            # Do not let rejected genotypes enter any source-specific matcher.
+            stats.vcf_filter_failed_sites += 1
+            continue
         # Do not let non-SNP sequences reach legacy SNP/GWAS/PGx matching as
         # concatenated bases. Their complete alleles remain in source evidence.
         if vcf_evidence is not None and any(

--- a/allelio/analysis/quality.py
+++ b/allelio/analysis/quality.py
@@ -1,0 +1,15 @@
+"""Honor explicit upstream VCF filter failures without inventing thresholds."""
+from typing import Optional
+from allelio.parsers.base import VCFEvidence
+
+
+def vcf_filter_reason(evidence: Optional[VCFEvidence]) -> Optional[str]:
+    """Missing/not-applied filters do not mean PASS, but are not failures."""
+    if evidence is None:
+        return None
+    failures = []
+    for label, status in (('FILTER', evidence.filter_status),
+                          ('FORMAT/FT', evidence.genotype_filter)):
+        if status not in (None, '', '.', 'PASS'):
+            failures.append(f'{label}={status}')
+    return 'VCF filter failure: ' + '; '.join(failures) if failures else None

--- a/allelio/analysis/zygosity.py
+++ b/allelio/analysis/zygosity.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Sequence
 
+from allelio.analysis.quality import vcf_filter_reason
 from allelio.parsers.base import VCFEvidence
 
 
@@ -208,6 +209,10 @@ def call_vcf_zygosity(evidence: VCFEvidence, ref: Optional[str], alt: Optional[s
     alt = (alt or "").upper()
     def unknown(reason):
         return ZygosityCall(Zygosity.UNKNOWN, None, allele=alt or None, note=reason)
+
+    reason = vcf_filter_reason(evidence)
+    if reason:
+        return unknown(reason)
 
     options = (evidence.reference,) + evidence.alternates
     if not options or any(a not in _COMPLEMENT for a in options):

--- a/allelio/cli.py
+++ b/allelio/cli.py
@@ -243,6 +243,12 @@ def analyze(
         # this person carries only the reference allele is not a finding for
         # them, and a reader should know those were seen and set aside rather
         # than missed.
+        if analysis_stats.vcf_filter_failed_sites:
+            console.print(
+                f"  [yellow]{analysis_stats.vcf_filter_failed_sites:,} annotated positions were "
+                "set aside because VCF record or sample filters failed. "
+                "These are not negative findings.[/yellow]"
+            )
         if analysis_stats.reference_genotype_sites:
             console.print(
                 f"  [dim]{analysis_stats.reference_genotype_sites:,} annotated positions where "
@@ -426,6 +432,7 @@ def analyze(
             "significant_variants": len(significant),
             "skipped_i_id_rows": parse_stats.i_id_rows if parse_stats else 0,
             "reference_genotype_sites": analysis_stats.reference_genotype_sites,
+            "vcf_filter_failed_sites": analysis_stats.vcf_filter_failed_sites,
             "zygosity_unknown_sites": analysis_stats.zygosity_unknown_sites,
         }
         

--- a/allelio/parsers/base.py
+++ b/allelio/parsers/base.py
@@ -31,6 +31,7 @@ class VCFEvidence:
     filter_status: Optional[str] = None
     genotype_quality: Optional[str] = None
     depth: Optional[str] = None
+    genotype_filter: Optional[str] = None
 
     @property
     def ploidy(self) -> int:

--- a/allelio/parsers/vcf_parser.py
+++ b/allelio/parsers/vcf_parser.py
@@ -185,6 +185,7 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
                     quality=available(parts[5]), filter_status=available(parts[6]),
                     genotype_quality=available(fields.get('GQ')),
                     depth=available(fields.get('DP')),
+                    genotype_filter=available(fields.get('FT')),
                 )
                 # Yield valid variant
                 yield Variant(

--- a/allelio/report.py
+++ b/allelio/report.py
@@ -460,6 +460,13 @@ def generate_html_report(
     # Annotated positions where this person carries only the reference allele
     # are not findings for them. They are counted here so the omission is
     # visible, the same way the i-ID gap is.
+    failed_filters = metadata.get("vcf_filter_failed_sites", 0)
+    if failed_filters:
+        gap_note += (
+            f'<div class="gap-note"><strong>VCF filters failed:</strong> '
+            f'{int(failed_filters):,} annotated positions were set aside because '
+            'record or sample filters failed. These are not negative findings.</div>'
+        )
     if reference_genotype_sites:
         gap_note += (
             f'<div class="gap-note"><strong>Set aside:</strong> '

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -253,7 +253,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         )
         analysis_stats = getattr(analysis_results, "stats", None) or AnalysisStats()
 
-        if not analysis_results:
+        if not analysis_results and not analysis_stats.vcf_filter_failed_sites:
             raise HTTPException(
                 status_code=400,
                 detail="No variants found in database"
@@ -274,16 +274,19 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
 
         # rsID -> Explanation. The credit rides on the card from here to the
         # browser; nothing else on this payload decides who wrote what.
-        explanations = await ai_engine.explain_variants_batch(
+        explanations = (await ai_engine.explain_variants_batch(
             top_variants, progress_callback=on_explained
-        )
+        )) if top_variants else {}
 
         # Generate executive summary
         _progress.update(stage="Summarizing", done=0, total=0)
         try:
-            if not ai_engine.will_explain():
-                raise RuntimeError("no model server answering")
-            summary = await ai_engine.generate_summary(top_variants)
+            if not top_variants:
+                summary = "No reportable findings remain. Annotated positions with failed VCF filters were set aside; this is not a negative result."
+            else:
+                if not ai_engine.will_explain():
+                    raise RuntimeError("no model server answering")
+                summary = await ai_engine.generate_summary(top_variants)
         except Exception:
             summary = ("AI summary unavailable. Variant findings below come "
                        "straight from ClinVar and the GWAS Catalog.")
@@ -339,6 +342,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             "gene_groups": group_findings(formatted_results),
             "total_variants": len(analysis_results),
             "reference_genotype_sites": analysis_stats.reference_genotype_sites,
+            "vcf_filter_failed_sites": analysis_stats.vcf_filter_failed_sites,
             "zygosity_unknown_sites": analysis_stats.zygosity_unknown_sites,
             "analyzed_at": _get_timestamp(),
             # Which release of each reference source the findings were looked
@@ -572,6 +576,14 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
         set_aside = (
             f"<p><strong>Set aside:</strong> {int(ref_sites):,} annotated positions where "
             "you carry only the reference allele (not findings).</p>"
+        )
+
+    failed_filters = analysis_data.get("vcf_filter_failed_sites") or 0
+    if failed_filters:
+        set_aside += (
+            f"<p><strong>VCF filters failed:</strong> {int(failed_filters):,} annotated "
+            "positions were set aside because record or sample filters failed. "
+            "These are not negative findings.</p>"
         )
 
     # Every finding referenced by the gene overview must remain reachable.

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -412,6 +412,11 @@
             border-bottom-color: var(--primary);
         }
 
+        .gap-banner {
+            padding: 1rem; margin-bottom: 1rem; border: 1px solid var(--gray-300);
+            border-left: 4px solid #b45309; border-radius: 8px;
+        }
+
         /* Executive Summary */
         .executive-summary {
             background: linear-gradient(135deg, var(--primary), var(--primary-light));
@@ -1111,6 +1116,7 @@
 
             <!-- Who wrote the explanations below, for this run. The status pill
                  at the top is read once at page load and can be stale by now. -->
+            <div class="gap-banner" id="vcfFilterNotice" style="display: none;" role="status"></div>
             <div class="summary-text" id="modelUsed" style="display: none;"></div>
 
             <!-- Category Tabs -->
@@ -1381,6 +1387,14 @@
             // Leave it on the last tab clicked and a fresh set of results comes
             // up reading "All" while showing only pharmacogenomics.
             currentCategory = 'all';
+
+            const filterNotice = document.getElementById('vcfFilterNotice');
+            const failedFilters = analysisResults.vcf_filter_failed_sites;
+            const hasFailures = Number.isInteger(failedFilters) && failedFilters > 0;
+            filterNotice.textContent = hasFailures
+                ? `${failedFilters.toLocaleString()} annotated positions were set aside because VCF record or sample filters failed. These are not negative findings.`
+                : '';
+            filterNotice.style.display = hasFailures ? 'block' : 'none';
 
             // Executive Summary
             const executiveSummary = document.getElementById('executiveSummary');

--- a/tests/test_vcf_filters.py
+++ b/tests/test_vcf_filters.py
@@ -1,0 +1,136 @@
+"""Explicit failed filters must not become positive or negative findings."""
+from dataclasses import replace
+import pytest
+from allelio.parsers.base import VCFEvidence
+from allelio.parsers.vcf_parser import parse_vcf
+from allelio.analysis.quality import vcf_filter_reason
+from allelio.analysis.zygosity import call_vcf_zygosity
+from allelio.analysis.lookup import analyze_variants_with_stats
+from allelio.report import generate_html_report
+from allelio.web.app import app
+from allelio.web.routes import _generate_html_report
+
+
+@pytest.mark.parametrize('site,sample,failed', [
+    ('PASS', 'PASS', False), (None, None, False), ('.', '.', False),
+    ('q10', 'PASS', True), ('PASS', 'lowDP', True),
+    ('q10;s50', 'lowDP', True), ('PASS;q10', None, True),
+])
+def test_filter_evidence_blocks_direct_count(site, sample, failed):
+    e = VCFEvidence('A', ('G',), (0, 1), ('A', 'G'), False,
+                    filter_status=site, genotype_filter=sample)
+    assert bool(vcf_filter_reason(e)) is failed
+    call = call_vcf_zygosity(e, 'A', 'G')
+    assert call.alt_copies == (None if failed else 1)
+    if failed:
+        assert 'VCF filter failure' in call.note
+
+
+class SourceDB:
+    """Small source adapter; failure gating must precede all matchers."""
+    def __init__(self, source):
+        self.source = source
+
+    def lookup_rsids_batch(self, rsids):
+        return {'rs1': {'clinvar': [dict(rsid='rs1', ref_allele='A', alt_allele='G',
+            assembly='GRCh38', chromosome='1', position_vcf=100,
+            clinical_significance='Pathogenic')] if self.source == 'clinvar' else [],
+            'gwas': [dict(rsid='rs1', risk_allele='G', trait='Example')] if self.source == 'gwas' else []}}
+
+    def lookup_clingen_genes(self, genes):
+        return {}
+
+    def lookup_clinpgx(self, rsids):
+        return {'rs1': [dict(rsid='rs1', genotype='AG', level='1A', gene='EXAMPLE',
+            annotation_text='Genotype-specific example')]} if self.source == 'pgx' else {}
+
+
+@pytest.mark.parametrize('source', ['clinvar', 'gwas', 'pgx'])
+@pytest.mark.parametrize('site,sample', [('q10', 'PASS'), ('PASS', 'lowDP')])
+def test_failed_calls_never_reach_source_matching(tmp_path, source, site, sample):
+    p = tmp_path / 'input.vcf'
+    p.write_text('##fileformat=VCFv4.3\n##reference=GRCh38\n'
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n'
+        f'1\t100\trs1\tA\tG\t90\t{site}\t.\tGT:FT:GQ:DP\t0/1:{sample}:99:40\n')
+    variants = parse_vcf(str(p))
+    assert variants[0].genotype == 'AG'
+    assert variants[0].vcf_evidence.genotype_filter == sample
+    results, stats = analyze_variants_with_stats(variants, SourceDB(source), include_benign=True, include_reference=True)
+    assert results == []
+    assert stats.vcf_filter_failed_sites == 1 and stats.annotated_sites == 1
+    assert stats.reference_genotype_sites == stats.benign_sites == 0
+    # The same annotation and genotype are usable when upstream filters pass.
+    variants[0].vcf_evidence = replace(variants[0].vcf_evidence, filter_status='PASS', genotype_filter='PASS')
+    results, stats = analyze_variants_with_stats(variants, SourceDB(source), include_benign=True)
+    assert len(results) == 1 and stats.vcf_filter_failed_sites == 0
+
+
+def test_both_exports_explain_excluded_calls_even_without_findings():
+    meta = {'vcf_filter_failed_sites': 3}
+    for document in (generate_html_report([], {}, '', meta), _generate_html_report(meta)):
+        assert '3 annotated positions' in document
+        assert 'record or sample filters failed' in document
+        assert 'not negative findings' in document
+
+
+def test_cli_reports_filter_exclusions(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+    from allelio import cli
+    from allelio.database.store import AllelioDB
+    db = AllelioDB(str(tmp_path / 'db.sqlite'))
+    db.initialize()
+    db.insert_clinvar_batch([dict(rsid='rs1', ref_allele='A', alt_allele='G',
+        clinical_significance='Pathogenic', gene='EXAMPLE', conditions='',
+        review_status='', last_evaluated='')])
+    monkeypatch.setattr(cli, 'AllelioDB', lambda: db)
+    p = tmp_path / 'input.vcf'
+    p.write_text('##fileformat=VCFv4.3\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n'
+                 '1\t100\trs1\tA\tG\t90\tq10\t.\tGT\t0/1\n')
+    output = tmp_path / 'report.html'
+    result = CliRunner().invoke(cli.analyze, [str(p), '--no-ai', '-o', str(output)])
+    assert result.exit_code == 0, result.output
+    assert 'filters failed' in ' '.join(result.output.split())
+    assert '1 annotated positions' in output.read_text()
+
+
+def test_web_returns_exclusion_count_when_all_findings_filtered(monkeypatch):
+    from fastapi.testclient import TestClient
+    from allelio.web import routes
+    from allelio.analysis.lookup import AnalysisResults, AnalysisStats
+    class DB:
+        def is_initialized(self): return True
+        def close(self): pass
+    class Engine:
+        status = "unavailable"
+        model = "none"
+        async def check_connection(self): return False
+        def will_explain(self): return False
+    monkeypatch.setattr(routes, 'AllelioDB', DB)
+    monkeypatch.setattr(routes, 'AIEngine', Engine)
+    monkeypatch.setattr(routes, 'parse_genotype_file', lambda p: [object()])
+    monkeypatch.setattr(routes, 'analyze_variants', lambda *a: AnalysisResults([], AnalysisStats(vcf_filter_failed_sites=2)))
+    response = TestClient(app, base_url='http://127.0.0.1').post('/api/analyze',
+        files={'file': ('input.vcf', b'synthetic', 'text/plain')})
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload['vcf_filter_failed_sites'] == 2 and payload['results'] == []
+    assert 'not a negative result' in payload['summary']
+
+
+def test_web_filter_notice_clears_when_loading_an_older_report():
+    import json
+    import shutil
+    import subprocess
+    from pathlib import Path
+    template = (Path(__file__).resolve().parents[1] / 'allelio/web/templates/index.html').read_text()
+    start = template.index("            const filterNotice =")
+    code = template[start:template.index('            // Executive Summary', start)]
+    script = '''const notice = {style: {}, textContent: ''};
+const document = {getElementById: () => notice};
+const render = new Function('analysisResults', 'document', CODE);
+render({vcf_filter_failed_sites: 2}, document);
+if (notice.style.display !== 'block' || !notice.textContent.includes('not negative findings')) throw Error('missing notice');
+render({}, document);
+if (notice.style.display !== 'none' || notice.textContent !== '') throw Error('stale notice');
+'''.replace('CODE', json.dumps(code))
+    subprocess.run([shutil.which('node') or 'node', '-e', script], check=True)


### PR DESCRIPTION
VCF filter failures were preserved but ignored during matching, and sample FORMAT/FT was not retained. Preserve FT and set aside annotated sites with explicit record or sample filter failures before ClinVar, GWAS or genotype-specific PGx matching. The direct VCF allele-count helper also abstains with a reason.

Report excluded counts separately in CLI output, saved web payloads, web results and both HTML exports. An all-filtered web analysis now returns an explanatory empty report instead of claiming nothing was found in the database. It generates no variant explanations or AI summary for the empty result set. Older reports default to no filter notice.

PASS and missing/not-applied status remain distinct in parsed evidence. Missing filters do not cause exclusion, and no QUAL/GQ/DP threshold is invented. Passing filters does not bypass identity or allele checks.

Validation covers record/sample failures across all three sources, passing controls, parsed evidence retention, direct allele-count abstention, empty CLI/web reports, both exports and clearing stale browser notices. Full regression suite and executable fixture baseline run locally.

Closes #15
