### PR TITLE
Add versioned structured evidence JSON exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,3 +352,8 @@ Contributions follow [CONTRIBUTING.md](CONTRIBUTING.md) and the
 Allelio's code is [MIT licensed](LICENSE). Reference data and model weights
 retain their respective licenses and terms. The software is provided as-is
 for research and education, without a claim of clinical validation.
+
+Structured evidence is available with `allelio analyze input.txt --no-ai
+--json-output evidence.json` or **Export Evidence JSON** in the web report.
+See the [versioned export contract](docs/evidence-export.md) for retained source
+fields, input evidence, and interpretation limits.

--- a/allelio/cli.py
+++ b/allelio/cli.py
@@ -16,6 +16,7 @@ from rich.table import Table
 from allelio.analysis.lookup import analyze_variants, AnalysisStats
 from allelio.database import AllelioDB, setup_database, staleness_warning, sources_summary, provenance_of
 from allelio.parsers import parse_genotype_file_with_stats
+from allelio.evidence import build_evidence_export, write_evidence_export
 from allelio.report import generate_html_report
 from allelio.analysis.genes import group_findings, gene_label
 
@@ -112,6 +113,8 @@ def setup(no_gnomad: bool):
     default=False,
     help="Only show trait associations — exclude health conditions and risk factors",
 )
+@click.option("--json-output", type=click.Path(dir_okay=False), default=None,
+              help="Also save a versioned structured evidence JSON file.")
 def analyze(
     file: str,
     output: str,
@@ -120,6 +123,7 @@ def analyze(
     model: Optional[str],
     top: int,
     traits_only: bool,
+    json_output: Optional[str] = None,
 ):
     """Analyze a genotype file for significant variants.
     
@@ -130,6 +134,9 @@ def analyze(
     """
     console.print("\n[bold cyan]Allelio Variant Analysis[/bold cyan]\n")
     
+    if json_output and Path(json_output).resolve() in {Path(file).resolve(), Path(output).resolve()}:
+        raise click.UsageError("JSON output must differ from the input and HTML paths.")
+
     # Check if database exists
     db = AllelioDB()
     if not db.is_initialized():
@@ -417,6 +424,18 @@ def analyze(
                              escape(group["function"] + source + " " + group["note"]))
     console.print(groups_table)
     
+    if json_output:
+        try:
+            write_evidence_export(build_evidence_export(
+                results, variants, provenance_of(db),
+                {"include_benign": include_benign, "include_reference": False,
+                 "traits_only": traits_only, "frequency_adjustment": True},
+                analysis_stats,
+            ), json_output)
+        except Exception as exc:
+            raise click.ClickException(f"Failed to write evidence JSON: {exc}") from exc
+        console.print(f"Evidence JSON saved to: {json_output}")
+
     # Generate HTML report
     try:
         if traits_only:

--- a/allelio/evidence.py
+++ b/allelio/evidence.py
@@ -1,0 +1,78 @@
+"""Versioned, local structured evidence exports (no AI interpretation)."""
+
+import json
+import math
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from allelio import __version__
+from allelio.analysis.genes import group_findings
+
+SCHEMA_VERSION = "1.0"
+
+
+def _json_value(value):
+    """Represent unavailable/non-finite source numbers as JSON null."""
+    if is_dataclass(value):
+        value = asdict(value)
+    if isinstance(value, dict):
+        return {str(k): _json_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(v) for v in value]
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    return value
+
+
+def build_evidence_export(results, inputs, provenance, configuration=None, stats=None):
+    """Preserve parsed observations and every source field retained in findings.
+
+    IDs are document-local indices, not normalized genomic identifiers.
+    Source records are the selected database annotations, not a raw database dump.
+    AI text is deliberately separate from this reproducible evidence contract.
+    """
+    observations = []
+    by_rsid = {}
+    for index, variant in enumerate(inputs):
+        record = _json_value(variant)
+        if not isinstance(record, dict):
+            record = {"rsid": str(variant)}
+        record["input_id"] = "input-" + str(index + 1)
+        observations.append(record)
+        by_rsid.setdefault(record.get("rsid"), []).append(record["input_id"])
+    findings = []
+    for index, result in enumerate(results):
+        record = _json_value(result)
+        record["finding_id"] = "finding-" + str(index + 1)
+        record["input_ids"] = by_rsid.get(result.rsid, [])
+        findings.append(record)
+    groups = group_findings(results)
+    for group in groups:
+        group["finding_ids"] = [findings[i]["finding_id"] for i in group["indices"]]
+    return _json_value({
+        "schema_version": SCHEMA_VERSION,
+        "software": {"name": "Allelio", "version": __version__},
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "configuration": configuration or {},
+        "provenance": provenance,
+        "inputs": observations,
+        "findings": findings,
+        "gene_groups": groups,
+        "analysis_stats": stats,
+        "limitations": [
+            "Research and education only; not a clinical interpretation.",
+            "Document-local IDs do not assert normalized genomic identity.",
+            "Source records are annotations retained by matching, not all database candidates.",
+            "Missing and non-finite numeric values are null, not zero.",
+            "Parsed inputs omit rows rejected by parsing; absent findings are not negative results.",
+        ],
+    })
+
+
+def write_evidence_export(document, path):
+    """Write strict JSON; callers must surface write errors."""
+    serialized = json.dumps(document, ensure_ascii=False, allow_nan=False, indent=2)
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(serialized + "\n", encoding="utf-8")

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
 from starlette.background import BackgroundTask
 
+from allelio.evidence import build_evidence_export
 from allelio.report_style import REPORT_CSS
 from allelio import __version__
 from allelio.parsers import parse_genotype_file
@@ -337,6 +338,11 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             formatted_results.append(result_dict)
 
         payload = {
+            "evidence_export": build_evidence_export(
+                analysis_results, genotypes, provenance_of(db),
+                {"include_benign": False, "include_reference": False,
+                 "traits_only": False, "frequency_adjustment": True}, analysis_stats,
+            ),
             "summary": summary,
             "results": formatted_results,
             "gene_groups": group_findings(formatted_results),

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1127,6 +1127,7 @@
 
             <!-- Export -->
             <div class="export-container">
+                <button class="export-button" id="evidenceButton">Export Evidence JSON</button>
                 <button class="export-button" id="exportButton">📥 Export Report</button>
                 <button class="export-button secondary" id="saveButton">💾 Save results on this computer</button>
             </div>
@@ -1184,6 +1185,7 @@
 
             // Export Button
             document.getElementById('exportButton').addEventListener('click', exportReport);
+            document.getElementById('evidenceButton').addEventListener('click', exportEvidence);
 
             // Saving results on this machine — opt-in, and reversible
             document.getElementById('saveButton').addEventListener('click', saveResults);
@@ -1614,6 +1616,20 @@
         }
 
         // Export Report
+        function exportEvidence() {
+            if (!analysisResults || !analysisResults.evidence_export) {
+                alert('Evidence JSON is unavailable for this older saved analysis. Run the analysis again.');
+                return;
+            }
+            const blob = new Blob([JSON.stringify(analysisResults.evidence_export, null, 2)], {type: 'application/json'});
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = 'allelio-evidence.json';
+            link.click();
+            setTimeout(() => URL.revokeObjectURL(url), 1000);
+        }
+
         async function exportReport() {
             if (!analysisResults) return;
 

--- a/docs/evidence-export.md
+++ b/docs/evidence-export.md
@@ -1,0 +1,32 @@
+# Structured evidence export, version 1.0
+
+Use `allelio analyze example.txt --no-ai --json-output evidence.json` to save
+JSON alongside the HTML report. In the web interface, choose **Export Evidence
+JSON** after analysis. Older saved analyses require a new run to obtain evidence.
+The export contains genetic observations; share it only as deliberately as the
+original input file.
+
+The top-level `schema_version` is `1.0`. Consumers must check the major version,
+accept additive fields, and treat missing/null values as unavailable. A major
+version change indicates incompatible field changes. JSON numbers are finite;
+non-finite source numbers become null. The document contains:
+
+- `software`, `generated_at`, `configuration`, `provenance`: software version,
+  UTC time, analysis filters, and reference-source versions available locally.
+- `inputs`: all parsed observations, including original VCF alleles, indices,
+  phase, reference declaration, and quality evidence when available.
+- `findings`: all returned findings, independent of the AI explanation limit.
+  Fields mirror `VariantResult`: source entries (ClinVar, GWAS, gnomAD, ClinGen,
+  PGx), category/rank, allele role/copies, strand decision, zygosity and inheritance
+  notes. These are selected annotations, not every candidate database record.
+- `gene_groups`: the same groups as the report, with `finding_ids` references.
+- `analysis_stats` and `limitations`: exclusion counts and interpretation limits.
+
+`input_id` and `finding_id` are unique within a document. A finding's `input_ids`
+references observations sharing its rsID; this linkage does not verify build or
+allele equivalence. These IDs are not VRS IDs or normalized variant identifiers.
+Raw VCF reference declarations are not certified genome assemblies. Null source
+identity fields stay null. AI prose is excluded from this evidence document.
+
+Version 1.0 captures parsed observations, not rows discarded by parsing. No
+annotation or an omitted finding must not be interpreted as a negative test.

--- a/tests/test_evidence_export.py
+++ b/tests/test_evidence_export.py
@@ -1,0 +1,59 @@
+import json
+
+from allelio.evidence import build_evidence_export, write_evidence_export
+from allelio.parsers.base import Variant, VCFEvidence
+from allelio.analysis.lookup import VariantResult, GnomADEntry, AnalysisStats
+
+
+def test_round_trip_preserves_input_and_uncertainty(tmp_path):
+    evidence = VCFEvidence('A', ('C', 'AT'), (1, 2), ('C', 'AT'), True,
+                           reference_declaration='GRCh38', phase_set='123',
+                           filter_status='PASS', depth='20')
+    variants = [Variant('rs1', '1', 123, 'CAT', evidence)]
+    result = VariantResult('rs1', chromosome='1', position=123, genotype='--',
+                           zygosity_note='Unsupported non-SNP matching')
+    document = build_evidence_export([result], variants, {'clinvar': {'version': 'test'}}, stats=AnalysisStats())
+    path = tmp_path / 'evidence.json'
+    write_evidence_export(document, path)
+    loaded = json.loads(path.read_text())
+    assert loaded['schema_version'] == '1.0'
+    assert loaded['inputs'][0]['vcf_evidence']['alleles'] == ['C', 'AT']
+    assert loaded['inputs'][0]['genotype'] == 'CAT'
+    assert loaded['findings'][0]['genotype'] == '--'
+    assert loaded['findings'][0]['input_ids'] == ['input-1']
+    assert loaded['findings'][0]['zygosity_note'] == result.zygosity_note
+    assert loaded['provenance']['clinvar']['version'] == 'test'
+
+
+def test_all_findings_and_strict_json(tmp_path):
+    results = [VariantResult('rs' + str(i)) for i in range(105)]
+    results[0].gnomad_entry = GnomADEntry(rsid='rs0', allele_frequency=float('nan'))
+    document = build_evidence_export(results, [], {})
+    write_evidence_export(document, tmp_path / 'all.json')
+    assert len(document['findings']) == 105
+    assert document['findings'][0]['gnomad_entry']['allele_frequency'] is None
+    assert document['findings'][0]['matched_allele'] is None
+    finding_ids = {row['finding_id'] for row in document['findings']}
+    for group in document['gene_groups']:
+        assert set(group['finding_ids']) <= finding_ids
+
+
+def test_cli_writes_evidence_and_rejects_path_collision(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+    from allelio import cli
+    from allelio.database.store import AllelioDB
+    db = AllelioDB(str(tmp_path / 'db.sqlite'))
+    db.initialize()
+    db.insert_clinvar_batch([dict(rsid='rs1', clinical_significance='Pathogenic',
+        gene='EXAMPLE', conditions='', review_status='', last_evaluated='')])
+    monkeypatch.setattr(cli, 'AllelioDB', lambda: db)
+    source = tmp_path / 'input.txt'
+    source.write_text('rs1\t1\t100\tAG\n')
+    output = tmp_path / 'report.html'
+    sidecar = tmp_path / 'evidence.json'
+    result = CliRunner().invoke(cli.analyze, [str(source), '--no-ai', '-o', str(output), '--json-output', str(sidecar)])
+    assert result.exit_code == 0, result.output
+    assert json.loads(sidecar.read_text())['findings'][0]['clinvar_entries'][0]['gene'] == 'EXAMPLE'
+    collision = CliRunner().invoke(cli.analyze, [str(source), '--json-output', str(source)])
+    assert collision.exit_code != 0
+    assert source.read_text() == 'rs1\t1\t100\tAG\n'

--- a/tests/test_vcf_filters.py
+++ b/tests/test_vcf_filters.py
@@ -113,6 +113,8 @@ def test_web_returns_exclusion_count_when_all_findings_filtered(monkeypatch):
         files={'file': ('input.vcf', b'synthetic', 'text/plain')})
     assert response.status_code == 200, response.text
     payload = response.json()
+    assert payload['evidence_export']['schema_version'] == '1.0'
+    assert payload['evidence_export']['analysis_stats']['vcf_filter_failed_sites'] == 2
     assert payload['vcf_filter_failed_sites'] == 2 and payload['results'] == []
     assert 'not a negative result' in payload['summary']
 


### PR DESCRIPTION
Adds a versioned evidence JSON download to the web report and `--json-output` to the CLI. The shared builder retains parsed input evidence, selected source annotations, matching and inheritance notes, gene groups, reference provenance, and analysis options for every returned finding. Original VCF evidence survives even when the matching layer masks an unsupported genotype.

Documents versioning, document-local IDs, null/non-finite values, and the distinction between selected annotations and raw database candidates. AI prose remains separate. CLI rejects input/HTML path collisions and surfaces JSON write failures.

Validation: full test suite plus synthetic round-trip, 105-finding export, strict JSON, and CLI sidecar/collision tests.

Closes #18.
