### PR TITLE
Account for input exclusions and conflicting duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,3 +357,7 @@ Structured evidence is available with `allelio analyze input.txt --no-ai
 --json-output evidence.json` or **Export Evidence JSON** in the web report.
 See the [versioned export contract](docs/evidence-export.md) for retained source
 fields, input evidence, and interpretation limits.
+
+Reports also show [input coverage and exclusions](docs/input-coverage.md),
+including no-calls, unsupported identifiers, duplicate conflicts, failed filters,
+and missing annotations. These counts are not a negative genetic test.

--- a/allelio/analysis/lookup.py
+++ b/allelio/analysis/lookup.py
@@ -295,6 +295,9 @@ class AnalysisStats:
     zygosity_unknown_sites: int = 0
     benign_sites: int = 0
     vcf_filter_failed_sites: int = 0
+    dispositions: Dict[str, str] = field(default_factory=dict)
+    duplicate_rows: int = 0
+    conflicting_input_sites: int = 0
 
 
 def _determine_category(clinvar_entry: Optional[ClinVarEntry], gwas_entries: List[GWASEntry]) -> str:
@@ -691,17 +694,26 @@ def analyze_variants_with_stats(
     if not variants:
         return [], stats
 
-    # Extract rsIDs from variant objects
-    rsids = [getattr(v, 'rsid', str(v)) for v in variants]
-    rsids = [r for r in rsids if r]  # Filter empty rsids
-
+    # Collapse only exactly agreeing observations. Conflicts never depend on
+    # input order, including differences in VCF phase/build/filter evidence.
+    grouped = {}
+    for variant in variants:
+        rsid = getattr(variant, 'rsid', str(variant))
+        grouped.setdefault(rsid, []).append(variant)
+    rsid_to_variant = {}
+    for rsid, rows in grouped.items():
+        if not rsid or not rsid.startswith('rs'):
+            stats.dispositions[rsid] = 'unsupported_identifier'
+        elif any(row != rows[0] for row in rows[1:]):
+            stats.dispositions[rsid] = 'conflicting_input'
+            stats.conflicting_input_sites += 1
+        else:
+            rsid_to_variant[rsid] = rows[0]
+            stats.duplicate_rows += len(rows) - 1
+            stats.dispositions[rsid] = 'no_annotation'
+    rsids = list(rsid_to_variant)
     if not rsids:
         return [], stats
-
-    # Create mapping of rsid to original variant for metadata
-    rsid_to_variant = {
-        getattr(v, 'rsid', str(v)): v for v in variants
-    }
 
     # Batch lookup from database
     lookup_results = db.lookup_rsids_batch(rsids)
@@ -726,11 +738,12 @@ def analyze_variants_with_stats(
     # Build results
     results = []
 
-    for rsid, data in lookup_results.items():
+    for rsid in rsids:
+        data = lookup_results.get(rsid) or {"clinvar": [], "gwas": []}
         pgx_rows = pgx_by_rsid.get(rsid) or []
-        if not data["clinvar"] and not data["gwas"] and not pgx_rows:
-            continue
-        stats.annotated_sites += 1
+        annotated = bool(data["clinvar"] or data["gwas"] or pgx_rows)
+        if annotated:
+            stats.annotated_sites += 1
 
         # Get variant metadata
         original_variant = rsid_to_variant.get(rsid)
@@ -741,7 +754,11 @@ def analyze_variants_with_stats(
         vcf_evidence = getattr(original_variant, 'vcf_evidence', None)
         if vcf_filter_reason(vcf_evidence):
             # Do not let rejected genotypes enter any source-specific matcher.
-            stats.vcf_filter_failed_sites += 1
+            if annotated:
+                stats.vcf_filter_failed_sites += 1
+            stats.dispositions[rsid] = "failed_filter"
+            continue
+        if not annotated:
             continue
         # Do not let non-SNP sequences reach legacy SNP/GWAS/PGx matching as
         # concatenated bases. Their complete alleles remain in source evidence.
@@ -798,6 +815,7 @@ def analyze_variants_with_stats(
         if site_is_reference:
             stats.reference_genotype_sites += 1
             if not include_reference:
+                stats.dispositions[rsid] = "reference_or_no_applicable_annotation"
                 continue
             if call is None:
                 call = ZygosityCall(Zygosity.HOMOZYGOUS_REFERENCE, 0)
@@ -853,6 +871,7 @@ def analyze_variants_with_stats(
         # Skip benign variants unless requested
         if not include_benign and adjusted_rank >= 8:
             stats.benign_sites += 1
+            stats.dispositions[rsid] = "rank_filtered"
             continue
 
         if call is None:
@@ -903,6 +922,7 @@ def analyze_variants_with_stats(
             pgx_entries=pgx_entries,
         )
 
+        stats.dispositions[rsid] = "reported"
         results.append(result)
 
     # Sort by significance rank (lower = more significant); ties by rsID so

--- a/allelio/cli.py
+++ b/allelio/cli.py
@@ -16,6 +16,7 @@ from rich.table import Table
 from allelio.analysis.lookup import analyze_variants, AnalysisStats
 from allelio.database import AllelioDB, setup_database, staleness_warning, sources_summary, provenance_of
 from allelio.parsers import parse_genotype_file_with_stats
+from allelio.coverage import build_coverage, coverage_text
 from allelio.evidence import build_evidence_export, write_evidence_export
 from allelio.report import generate_html_report
 from allelio.analysis.genes import group_findings, gene_label
@@ -271,6 +272,9 @@ def analyze(
         console.print(f"\n[bold red]✗[/bold red] Analysis failed: {e}\n", style="red")
         raise click.Abort()
     
+    coverage = build_coverage(variants, results, analysis_stats)
+    console.print(escape(coverage_text(coverage)))
+
     # Generate AI explanations if enabled
     # rsID -> Explanation: the text and, where the model wrote it, its name.
     # Everything printed about who wrote what is counted off this, so there is
@@ -443,6 +447,7 @@ def analyze(
         else:
             summary = f"Analysis of {len(variants):,} variants found {len(significant)} significant findings."
         metadata = {
+            "coverage": coverage,
             "generated_at": __import__("datetime").datetime.now().isoformat(),
             "db_version": db.version(),
             "provenance": provenance_of(db),

--- a/allelio/coverage.py
+++ b/allelio/coverage.py
@@ -1,0 +1,52 @@
+"""Conserved input-row accounting, separate from counts of findings."""
+from collections import Counter
+from html import escape
+
+
+def build_coverage(inputs, results, stats):
+    audit = getattr(inputs, 'audit', None)
+    dispositions = getattr(stats, 'dispositions', {})
+    reported = {r.rsid for r in results}
+    rows = []
+    seen = set()
+    for index, variant in enumerate(inputs):
+        rsid = getattr(variant, 'rsid', str(variant))
+        status = dispositions.get(rsid, 'reported' if rsid in reported else 'unaccounted')
+        if status == 'reported' and rsid not in reported:
+            status = 'report_filtered'
+        if status not in ('conflicting_input', 'unsupported_identifier') and rsid in seen:
+            status = 'duplicate_row'
+        seen.add(rsid)
+        rows.append({'line': getattr(variant, 'source_line', None),
+                     'input_id': 'input-' + str(index + 1), 'rsid': rsid, 'status': status})
+    if audit is not None:
+        rows.extend(dict(row) for row in audit.rows if row['status'] != 'parsed')
+        rows.sort(key=lambda row: row['line'] or 0)
+        total = len(audit.rows)
+    else:
+        total = len(inputs)
+    counts = dict(sorted(Counter(row['status'] for row in rows).items()))
+    return {
+        'scope': 'input_data_rows' if audit is not None else 'parsed_inputs_only',
+        'total_rows': total,
+        'accounted_rows': len(rows),
+        'counts': counts,
+        'rows': rows,
+        'returned_findings': len(results),
+        'complete': len(rows) == total and not counts.get('unaccounted'),
+        'limitations': 'Rows absent from the input cannot be counted. Coverage is not a negative genetic test or clinical sensitivity estimate.',
+    }
+
+
+def coverage_text(coverage):
+    if not coverage:
+        return ''
+    counts = '; '.join(f"{key.replace('_', ' ')}: {value:,}" for key, value in coverage['counts'].items())
+    scope = 'input data rows' if coverage['scope'] == 'input_data_rows' else 'parsed inputs only'
+    return (f"Input coverage ({scope}): {coverage['accounted_rows']:,}/{coverage['total_rows']:,} rows accounted for. "
+            + counts + '. ' + coverage['limitations'])
+
+
+def coverage_html(coverage):
+    text = coverage_text(coverage)
+    return '<p class="gap-note">' + escape(text) + '</p>' if text else ''

--- a/allelio/evidence.py
+++ b/allelio/evidence.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from allelio import __version__
+from allelio.coverage import build_coverage
 from allelio.analysis.genes import group_findings
 
 SCHEMA_VERSION = "1.0"
@@ -60,12 +61,13 @@ def build_evidence_export(results, inputs, provenance, configuration=None, stats
         "findings": findings,
         "gene_groups": groups,
         "analysis_stats": stats,
+        "coverage": build_coverage(inputs, results, stats),
         "limitations": [
             "Research and education only; not a clinical interpretation.",
             "Document-local IDs do not assert normalized genomic identity.",
             "Source records are annotations retained by matching, not all database candidates.",
             "Missing and non-finite numeric values are null, not zero.",
-            "Parsed inputs omit rows rejected by parsing; absent findings are not negative results.",
+            "Coverage records parsing exclusions when an input audit is available; absent findings are not negative results.",
         ],
     })
 

--- a/allelio/parsers/ancestry.py
+++ b/allelio/parsers/ancestry.py
@@ -16,10 +16,10 @@ Format specification:
 import gzip
 from typing import List, Generator
 
-from .base import Variant
+from .base import ParseAudit, ParsedVariants, Variant
 
 
-def _parse_ancestry_lines(filepath: str) -> Generator[Variant, None, None]:
+def _parse_ancestry_lines(filepath: str, audit=None) -> Generator[Variant, None, None]:
     """Generate Variant objects from an AncestryDNA format file.
     
     Args:
@@ -34,11 +34,11 @@ def _parse_ancestry_lines(filepath: str) -> Generator[Variant, None, None]:
     with file_opener(filepath, 'rt', encoding='utf-8', errors='replace') as f:
         header_seen = False
         
-        for line in f:
-            line = line.rstrip('\n')
+        for line_number, line in enumerate(f, 1):
+            line = line.rstrip('\r\n')
             
             # Skip empty lines and comments
-            if not line or line.startswith('#'):
+            if not line.strip() or line.startswith('#'):
                 continue
             
             # Skip header line (starts with 'rsid')
@@ -46,6 +46,8 @@ def _parse_ancestry_lines(filepath: str) -> Generator[Variant, None, None]:
                 header_seen = True
                 continue
             
+            entry = audit.row(line_number) if audit is not None else {}
+
             # Parse tab-delimited line
             parts = line.split('\t')
             
@@ -69,21 +71,28 @@ def _parse_ancestry_lines(filepath: str) -> Generator[Variant, None, None]:
                 continue
             
             # Skip no-calls
-            if genotype in ('00', '0', '--'):
+            if genotype in ('00', '0', '--', '.', '') or '0' in genotype or '-' in genotype:
+                entry['status'] = 'no_call'
                 continue
             
             # Parse position as integer
             try:
                 position = int(position_str)
             except ValueError:
+                entry['status'] = 'invalid_position'
+                continue
+            if position <= 0:
+                entry['status'] = 'invalid_position'
                 continue
             
+            entry.update(status='parsed', rsid=rsid)
             # Yield valid variant
             yield Variant(
                 rsid=rsid,
                 chromosome=chromosome,
                 position=position,
-                genotype=genotype
+                genotype=genotype,
+                source_line=line_number,
             )
 
 
@@ -98,4 +107,5 @@ def parse_ancestry(filepath: str) -> List[Variant]:
     Returns:
         List of Variant objects parsed from the file
     """
-    return list(_parse_ancestry_lines(filepath))
+    audit = ParseAudit()
+    return ParsedVariants(_parse_ancestry_lines(filepath, audit=audit), audit)

--- a/allelio/parsers/base.py
+++ b/allelio/parsers/base.py
@@ -7,7 +7,7 @@ This module provides:
 """
 
 import gzip
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -53,6 +53,25 @@ class Variant:
     position: int
     genotype: str
     vcf_evidence: Optional[VCFEvidence] = None
+    source_line: Optional[int] = field(default=None, compare=False)
+
+
+class ParseAudit:
+    """One disposition per nonblank, nonheader input row."""
+    def __init__(self):
+        self.rows = []
+
+    def row(self, line):
+        record = {"line": line, "status": "malformed_row"}
+        self.rows.append(record)
+        return record
+
+
+class ParsedVariants(list):
+    """List-compatible parser result carrying row accounting."""
+    def __init__(self, variants, audit):
+        super().__init__(variants)
+        self.audit = audit
 
 
 def detect_format(filepath: str) -> str:
@@ -172,9 +191,8 @@ def parse_genotype_file_with_stats(filepath: str) -> Tuple[List[Variant], Option
     """Like parse_genotype_file, but also reports 23andMe i-ID row counts.
 
     Only the 23andMe format carries the internal `i`-prefixed identifiers
-    this counts (see twentythree.ParseStats and PUB-11-lite in
-    PUBLICATION_PLAN.md); AncestryDNA and VCF have no such gap, so their
-    stats are None.
+    this counts (see twentythree.ParseStats); other formats return None.
+    All formats also carry row dispositions on the returned list.audit.
 
     Args:
         filepath: Path to the genotype file (can be gzipped)

--- a/allelio/parsers/twentythree.py
+++ b/allelio/parsers/twentythree.py
@@ -14,7 +14,7 @@ import gzip
 from dataclasses import dataclass
 from typing import List, Generator, Optional, Tuple
 
-from .base import Variant
+from .base import ParseAudit, ParsedVariants, Variant
 
 
 @dataclass
@@ -35,7 +35,7 @@ class ParseStats:
 
 
 def _parse_23andme_lines(
-    filepath: str, stats: Optional[ParseStats] = None
+    filepath: str, stats: Optional[ParseStats] = None, audit=None
 ) -> Generator[Variant, None, None]:
     """Generate Variant objects from a 23andMe format file.
 
@@ -50,12 +50,14 @@ def _parse_23andme_lines(
     file_opener = gzip.open if filepath.endswith('.gz') else open
 
     with file_opener(filepath, 'rt', encoding='utf-8', errors='replace') as f:
-        for line in f:
-            line = line.rstrip('\n')
+        for line_number, line in enumerate(f, 1):
+            line = line.rstrip('\r\n')
 
             # Skip empty lines and comments
-            if not line or line.startswith('#'):
+            if not line.strip() or line.startswith('#'):
                 continue
+
+            entry = audit.row(line_number) if audit is not None else {}
 
             # Parse tab-delimited line
             parts = line.split('\t')
@@ -66,16 +68,22 @@ def _parse_23andme_lines(
 
             # Validate rsid format (must start with 'rs' or 'i')
             if not (rsid.startswith('rs') or rsid.startswith('i')):
+                entry['status'] = 'unsupported_identifier'
                 continue
 
             # Skip no-calls
-            if genotype == '--':
+            if genotype in ('--', '00', '0', '.', ''):
+                entry['status'] = 'no_call'
                 continue
 
             # Parse position as integer
             try:
                 position = int(position_str)
             except ValueError:
+                entry['status'] = 'invalid_position'
+                continue
+            if position <= 0:
+                entry['status'] = 'invalid_position'
                 continue
 
             if stats is not None:
@@ -85,12 +93,14 @@ def _parse_23andme_lines(
                 else:
                     stats.i_id_rows += 1
 
+            entry.update(status='parsed', rsid=rsid)
             # Yield valid variant
             yield Variant(
                 rsid=rsid,
                 chromosome=chromosome,
                 position=position,
-                genotype=genotype
+                genotype=genotype,
+                source_line=line_number,
             )
 
 
@@ -103,7 +113,8 @@ def parse_23andme(filepath: str) -> List[Variant]:
     Returns:
         List of Variant objects parsed from the file
     """
-    return list(_parse_23andme_lines(filepath))
+    audit = ParseAudit()
+    return ParsedVariants(_parse_23andme_lines(filepath, audit=audit), audit)
 
 
 def parse_23andme_with_stats(filepath: str) -> Tuple[List[Variant], ParseStats]:
@@ -123,5 +134,6 @@ def parse_23andme_with_stats(filepath: str) -> Tuple[List[Variant], ParseStats]:
         the row counts collected while parsing it.
     """
     stats = ParseStats()
-    variants = list(_parse_23andme_lines(filepath, stats))
+    audit = ParseAudit()
+    variants = ParsedVariants(_parse_23andme_lines(filepath, stats, audit), audit)
     return variants, stats

--- a/allelio/parsers/vcf_parser.py
+++ b/allelio/parsers/vcf_parser.py
@@ -15,7 +15,7 @@ Format specification:
 import gzip
 from typing import List, Generator, Optional, Tuple
 
-from .base import Variant, VCFEvidence
+from .base import ParseAudit, ParsedVariants, Variant, VCFEvidence
 
 
 def _parse_gt_field(gt_str: str, ref: str, alt: str) -> Optional[str]:
@@ -70,7 +70,7 @@ def _parse_gt_field(gt_str: str, ref: str, alt: str) -> Optional[str]:
         return None
 
 
-def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
+def _parse_vcf_lines(filepath: str, audit=None) -> Generator[Variant, None, None]:
     """Generate Variant objects from a VCF format file.
     
     Args:
@@ -89,11 +89,11 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
         gt_index = None
         reference_declaration = None
         
-        for line in f:
-            line = line.rstrip('\n')
+        for line_number, line in enumerate(f, 1):
+            line = line.rstrip('\r\n')
             
             # Skip empty lines
-            if not line:
+            if not line.strip():
                 continue
             
             # Skip meta-info lines
@@ -128,6 +128,8 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
             if line.startswith('#'):
                 continue
             
+            entry = audit.row(line_number) if audit is not None else {}
+
             # Parse data line
             if header_line is None:
                 continue
@@ -139,7 +141,13 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
             
             try:
                 chromosome = parts[chrom_index]
-                position = int(parts[pos_index])
+                try:
+                    position = int(parts[pos_index])
+                    if position <= 0:
+                        raise ValueError('Nonpositive position')
+                except ValueError:
+                    entry['status'] = 'invalid_position'
+                    continue
                 rsid = parts[id_index]
                 ref = parts[ref_index]
                 alt = parts[alt_index]
@@ -147,7 +155,8 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
                 sample_data = parts[sample_column_index]
                 
                 # Skip if no rsid
-                if rsid == '.':
+                if rsid in ('.', ''):
+                    entry['status'] = 'unsupported_identifier'
                     continue
                 
                 # Parse FORMAT to find GT index
@@ -155,11 +164,13 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
                 try:
                     gt_index = format_parts.index('GT')
                 except ValueError:
+                    entry['status'] = 'missing_genotype'
                     continue
                 
                 # Parse sample GT field
                 sample_parts = sample_data.split(':')
                 if gt_index >= len(sample_parts):
+                    entry["status"] = "missing_genotype"
                     continue
                 
                 gt_str = sample_parts[gt_index]
@@ -167,6 +178,7 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
                 
                 # Skip no-calls
                 if genotype is None:
+                    entry['status'] = 'no_call' if '.' in gt_str else 'unsupported_genotype'
                     continue
                 
                 fields = dict(zip(format_parts, sample_parts))
@@ -187,6 +199,7 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
                     depth=available(fields.get('DP')),
                     genotype_filter=available(fields.get('FT')),
                 )
+                entry.update(status='parsed', rsid=rsid)
                 # Yield valid variant
                 yield Variant(
                     rsid=rsid,
@@ -194,6 +207,7 @@ def _parse_vcf_lines(filepath: str) -> Generator[Variant, None, None]:
                     position=position,
                     genotype=genotype,
                     vcf_evidence=evidence,
+                    source_line=line_number,
                 )
             
             except (ValueError, IndexError):
@@ -209,4 +223,5 @@ def parse_vcf(filepath: str) -> List[Variant]:
     Returns:
         List of Variant objects parsed from the file
     """
-    return list(_parse_vcf_lines(filepath))
+    audit = ParseAudit()
+    return ParsedVariants(_parse_vcf_lines(filepath, audit=audit), audit)

--- a/allelio/report.py
+++ b/allelio/report.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 import html as html_escape
 from urllib.parse import quote
 
+from allelio.coverage import coverage_html
 from allelio.report_style import REPORT_CSS
 from allelio.ai.attribution import Explanation, attribution
 from allelio.analysis.lookup import _get_review_stars
@@ -449,9 +450,9 @@ def generate_html_report(
     # never looked up because every lookup is keyed by rsID, not 23andMe's
     # internal i-prefixed probe IDs. See README "Known gaps: 23andMe internal
     # IDs" and PUB-11-lite in PUBLICATION_PLAN.md.
-    gap_note = ""
+    gap_note = coverage_html(metadata.get("coverage"))
     if skipped_i_id_rows:
-        gap_note = (
+        gap_note += (
             f'<div class="gap-note"><strong>Known gap:</strong> '
             f'skipped {skipped_i_id_rows:,} rows with 23andMe internal (i) IDs '
             f'— not yet looked up. See README: known gaps.</div>'

--- a/allelio/web/routes.py
+++ b/allelio/web/routes.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse
 from starlette.background import BackgroundTask
 
+from allelio.coverage import build_coverage, coverage_text, coverage_html
 from allelio.evidence import build_evidence_export
 from allelio.report_style import REPORT_CSS
 from allelio import __version__
@@ -233,7 +234,8 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             None, parse_genotype_file, temp_file_path
         )
         
-        if not genotypes:
+        has_row_audit = bool(getattr(getattr(genotypes, "audit", None), "rows", None))
+        if not genotypes and not has_row_audit:
             raise HTTPException(
                 status_code=400, 
                 detail="No valid genotype data found in file"
@@ -254,7 +256,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         )
         analysis_stats = getattr(analysis_results, "stats", None) or AnalysisStats()
 
-        if not analysis_results and not analysis_stats.vcf_filter_failed_sites:
+        if not analysis_results and not analysis_stats.vcf_filter_failed_sites and not has_row_audit:
             raise HTTPException(
                 status_code=400,
                 detail="No variants found in database"
@@ -283,7 +285,7 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
         _progress.update(stage="Summarizing", done=0, total=0)
         try:
             if not top_variants:
-                summary = "No reportable findings remain. Annotated positions with failed VCF filters were set aside; this is not a negative result."
+                summary = "No reportable findings remain. See input coverage for exclusions; this is not a negative result."
             else:
                 if not ai_engine.will_explain():
                     raise RuntimeError("no model server answering")
@@ -337,7 +339,10 @@ async def analyze_file(file: UploadFile = File(...)) -> Dict[str, Any]:
             }
             formatted_results.append(result_dict)
 
+        coverage = build_coverage(genotypes, analysis_results, analysis_stats)
         payload = {
+            "coverage": {k: v for k, v in coverage.items() if k != "rows"},
+            "coverage_summary": coverage_text(coverage),
             "evidence_export": build_evidence_export(
                 analysis_results, genotypes, provenance_of(db),
                 {"include_benign": False, "include_reference": False,
@@ -576,10 +581,10 @@ def _generate_html_report(analysis_data: Dict[str, Any]) -> str:
     total_variants = escape(str(analysis_data.get("total_variants", 0)))
     analyzed_at = escape(str(analysis_data.get("analyzed_at") or "Unknown"))
     sources = escape(str(analysis_data.get("sources") or "not recorded"))
-    set_aside = ""
+    set_aside = coverage_html(analysis_data.get("coverage"))
     ref_sites = analysis_data.get("reference_genotype_sites") or 0
     if ref_sites:
-        set_aside = (
+        set_aside += (
             f"<p><strong>Set aside:</strong> {int(ref_sites):,} annotated positions where "
             "you carry only the reference allele (not findings).</p>"
         )

--- a/allelio/web/templates/index.html
+++ b/allelio/web/templates/index.html
@@ -1116,6 +1116,7 @@
 
             <!-- Who wrote the explanations below, for this run. The status pill
                  at the top is read once at page load and can be stale by now. -->
+            <div class="gap-banner" id="coverageNotice" style="display: none;" role="status"></div>
             <div class="gap-banner" id="vcfFilterNotice" style="display: none;" role="status"></div>
             <div class="summary-text" id="modelUsed" style="display: none;"></div>
 
@@ -1397,6 +1398,11 @@
                 ? `${failedFilters.toLocaleString()} annotated positions were set aside because VCF record or sample filters failed. These are not negative findings.`
                 : '';
             filterNotice.style.display = hasFailures ? 'block' : 'none';
+
+            // Coverage is absent in reports saved before row accounting.
+            const coverageNotice = document.getElementById('coverageNotice');
+            coverageNotice.textContent = analysisResults.coverage_summary || '';
+            coverageNotice.style.display = analysisResults.coverage_summary ? 'block' : 'none';
 
             // Executive Summary
             const executiveSummary = document.getElementById('executiveSummary');

--- a/docs/evidence-export.md
+++ b/docs/evidence-export.md
@@ -28,5 +28,6 @@ allele equivalence. These IDs are not VRS IDs or normalized variant identifiers.
 Raw VCF reference declarations are not certified genome assemblies. Null source
 identity fields stay null. AI prose is excluded from this evidence document.
 
-Version 1.0 captures parsed observations, not rows discarded by parsing. No
-annotation or an omitted finding must not be interpreted as a negative test.
+The additive `coverage` field records input row dispositions, including parsing
+exclusions, when an audit is available. See [input coverage](input-coverage.md).
+No annotation or an omitted finding must not be interpreted as a negative test.

--- a/docs/input-coverage.md
+++ b/docs/input-coverage.md
@@ -1,0 +1,50 @@
+# Input coverage and exclusions
+
+Every nonblank, noncomment data row in a recognized input format receives one
+final disposition. Ancestry's header and VCF headers are excluded from the row
+denominator. Counts are shown in the CLI, web report, and exported HTML; the
+[evidence JSON](evidence-export.md) also contains row numbers and dispositions.
+Rows absent from the input cannot be counted. This is input-processing coverage,
+not assay coverage, a negative genetic test, or a clinical sensitivity estimate.
+
+| Disposition | Meaning |
+| --- | --- |
+| `malformed_row` | Missing columns or unusable row/header structure |
+| `invalid_position` | Position is not a positive integer |
+| `unsupported_identifier` | Identifier is unavailable or outside rsID lookup (including internal i-IDs) |
+| `no_call` | Missing genotype, including partially missing VCF GT |
+| `missing_genotype` | VCF lacks the required sample GT field |
+| `unsupported_genotype` | VCF GT cannot be parsed, including unsupported ploidy/indices |
+| `conflicting_input` | Same identifier has disagreeing parsed observations; all are excluded |
+| `duplicate_row` | Additional exactly agreeing observation collapsed into the first |
+| `failed_filter` | Parsed VCF observation explicitly fails FILTER or FORMAT/FT |
+| `no_annotation` | No ClinVar/GWAS/PGx candidate in the installed references |
+| `reference_or_no_applicable_annotation` | Matching left no applicable finding under the current reference filter |
+| `rank_filtered` | Excluded by the default rank filter, including benign findings |
+| `report_filtered` | Returned by analysis but removed by a report option such as traits-only |
+| `reported` | Representative observation contributing a returned finding |
+| `unaccounted` | A custom caller supplied inputs without corresponding analysis dispositions |
+
+Rows have one disposition, chosen in processing order: parsing, identifier
+support/conflicts, duplicate collapse, upstream filters, annotation/matching,
+and report filters. For example, a duplicate of a failed-filter row is counted
+as a duplicate; the representative row counts as failed. Missing annotations
+refer to the installed data, not biological absence. The reference/no-applicable
+category intentionally does not claim every excluded row is a verified reference
+call. Legacy `benign_sites` and reference counters remain available; the new
+rank/no-applicable names describe their broader filtering semantics.
+
+Exact duplicate comparison includes chromosome, position, genotype, and all
+retained VCF evidence (including phase, build declaration, and quality), but
+ignores source line number. Different spellings are not normalized to establish
+agreement. Conflicting parsed observations never use a last-row-wins rule.
+The first agreeing row is the representative, and changing input order does not
+change the resulting biological observation.
+
+`coverage.counts` sums to `coverage.total_rows`; `accounted_rows` exposes the
+number represented by dispositions. `complete` is false if accounting is missing
+or any row is `unaccounted`. Library callers providing plain lists get the explicit
+scope `parsed_inputs_only`; file parsers attach a row audit and use
+`input_data_rows`. `returned_findings` is separate from input row counts. Old saved
+reports have no fabricated coverage; rerun them to obtain it. Unrecognized files
+still produce a parsing error rather than an invented denominator.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,116 @@
+"""Input conservation and duplicate conflict regression fixtures."""
+from dataclasses import replace
+import pytest
+from allelio.parsers.base import parse_genotype_file, parse_genotype_file_with_stats, Variant, VCFEvidence
+from allelio.analysis.lookup import analyze_variants, AnalysisStats
+from allelio.coverage import build_coverage
+from allelio.evidence import build_evidence_export
+
+
+class DB:
+    def lookup_rsids_batch(self, rsids):
+        return {rsid: {'clinvar': [], 'gwas': [dict(rsid=rsid, trait='Example', risk_allele='G')]} for rsid in rsids if rsid != 'rs9'}
+    def lookup_clingen_genes(self, genes): return {}
+    def lookup_clinpgx(self, rsids): return {}
+
+
+@pytest.mark.parametrize('header,row', [
+    ('# source\n', 'rs1\t1\t100\tAG\n'),
+    ('rsid\tchromosome\tposition\tallele1\tallele2\n', 'rs1\t1\t100\tA\tG\n'),
+    ('##fileformat=VCFv4.3\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n', '1\t100\trs1\tA\tG\t.\tPASS\t.\tGT\t0/1\n'),
+])
+def test_all_parsers_account_for_duplicates_and_malformed_rows(tmp_path, header, row):
+    path = tmp_path / 'input.txt'
+    path.write_text(header + row + row + '\nmalformed\n')
+    variants = parse_genotype_file(str(path))
+    results = analyze_variants(variants, DB())
+    coverage = build_coverage(variants, results, results.stats)
+    assert coverage['complete']
+    assert coverage['total_rows'] == coverage['accounted_rows'] == 3
+    assert coverage['counts'] == {'duplicate_row': 1, 'malformed_row': 1, 'reported': 1}
+    assert sum(coverage['counts'].values()) == 3
+    assert len({r['line'] for r in coverage['rows']}) == 3
+    parsed_with_stats, _ = parse_genotype_file_with_stats(str(path))
+    assert len(parsed_with_stats.audit.rows) == 3
+
+
+def test_conflicts_abstain_independent_of_input_order():
+    one = Variant('rs1', '1', 100, 'AG')
+    for two in [replace(one, genotype='AA'), replace(one, position=101),
+                replace(one, vcf_evidence=VCFEvidence('A', ('G',), (0, 1), ('A', 'G'), False))]:
+        for inputs in ([one, two], [two, one]):
+            results = analyze_variants(inputs, DB())
+            assert not results
+            assert results.stats.conflicting_input_sites == 1
+            assert build_coverage(inputs, results, results.stats)['counts'] == {'conflicting_input': 2}
+
+
+def test_no_calls_unknown_ids_missing_annotation_and_filters(tmp_path):
+    path = tmp_path / 'input.vcf'
+    path.write_text('##fileformat=VCFv4.3\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n'
+        '1\t100\trs1\tA\tG\t.\tPASS\t.\tGT\t./1\n'
+        '1\t101\t.\tA\tG\t.\tPASS\t.\tGT\t0/1\n'
+        '1\t102\trs9\tA\tG\t.\tPASS\t.\tGT\t0/1\n'
+        '1\t103\trs8\tA\tG\t.\tq10\t.\tGT\t0/1\n'
+        '1\t104\trs2\tA\tG\t.\tPASS\t.\tGT\t0/1/1\n')
+    inputs = parse_genotype_file(str(path))
+    results = analyze_variants(inputs, DB())
+    doc = build_evidence_export(results, inputs, {}, stats=results.stats)
+    assert doc['coverage']['counts'] == dict(no_call=1, unsupported_identifier=1, no_annotation=1, failed_filter=1, unsupported_genotype=1)
+    assert doc['coverage']['total_rows'] == 5
+    assert doc['coverage']['complete']
+
+
+def test_downstream_report_filter_is_separate():
+    inputs = [Variant('rs1', '1', 100, 'AG')]
+    results = analyze_variants(inputs, DB())
+    assert build_coverage(inputs, [], results.stats)['counts'] == {'report_filtered': 1}
+    assert build_coverage(inputs, [], AnalysisStats())['counts'] == {'unaccounted': 1}
+
+
+def test_web_returns_coverage_when_all_rows_are_no_calls(monkeypatch):
+    from fastapi.testclient import TestClient
+    from allelio.web.app import app
+    from allelio.web import routes
+    class WebDB(DB):
+        def is_initialized(self): return True
+        def close(self): pass
+    class Engine:
+        status = 'unavailable'
+        model = 'none'
+        async def check_connection(self): return False
+        def will_explain(self): return False
+    monkeypatch.setattr(routes, 'AllelioDB', WebDB)
+    monkeypatch.setattr(routes, 'AIEngine', Engine)
+    response = TestClient(app, base_url='http://127.0.0.1').post('/api/analyze',
+        files={'file': ('input.txt', b'# example\nrs1\t1\t100\t--\n', 'text/plain')})
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload['results'] == []
+    assert payload['coverage']['counts'] == {'no_call': 1}
+    assert payload['evidence_export']['coverage']['rows'][0]['line'] == 2
+    assert 'not a negative result' in payload['summary']
+    assert 'no call: 1' in routes._generate_html_report(payload)
+
+
+def test_cli_html_and_json_agree_on_coverage(tmp_path, monkeypatch):
+    import json
+    from click.testing import CliRunner
+    from allelio import cli
+    from allelio.database.store import AllelioDB
+    db = AllelioDB(str(tmp_path / 'db.sqlite'))
+    db.initialize()
+    db.insert_clinvar_batch([dict(rsid='rs1000', clinical_significance='Benign', gene='',
+        conditions='', review_status='', last_evaluated='')])
+    monkeypatch.setattr(cli, 'AllelioDB', lambda: db)
+    path = tmp_path / 'input.txt'
+    path.write_text('rs1\t1\t100\t--\ni1\t1\t101\tAG\nrs9\t1\t102\tAG\n')
+    output = tmp_path / 'report.html'
+    sidecar = tmp_path / 'evidence.json'
+    result = CliRunner().invoke(cli.analyze, [str(path), '--no-ai', '-o', str(output), '--json-output', str(sidecar)])
+    assert result.exit_code == 0, result.output
+    coverage = json.loads(sidecar.read_text())['coverage']
+    assert coverage['counts'] == dict(no_call=1, unsupported_identifier=1, no_annotation=1)
+    assert coverage['accounted_rows'] == 3
+    assert '3/3 rows accounted for' in output.read_text()
+    assert '3/3 rows accounted for' in result.output

--- a/tests/test_vcf_filters.py
+++ b/tests/test_vcf_filters.py
@@ -126,7 +126,7 @@ def test_web_filter_notice_clears_when_loading_an_older_report():
     from pathlib import Path
     template = (Path(__file__).resolve().parents[1] / 'allelio/web/templates/index.html').read_text()
     start = template.index("            const filterNotice =")
-    code = template[start:template.index('            // Executive Summary', start)]
+    code = template[start:template.index('            // Coverage is absent', start)]
     script = '''const notice = {style: {}, textContent: ''};
 const document = {getElementById: () => notice};
 const render = new Function('analysisResults', 'document', CODE);


### PR DESCRIPTION
Every data row in a recognized input format now receives a final disposition, shown as coverage counts in CLI/web/HTML and detailed row accounting in evidence JSON. Reports containing only excluded or unannotated inputs retain their accounting instead of losing it behind an empty-results error.

Previously, duplicate rsIDs silently selected the last row. Exactly agreeing parsed observations now collapse; any disagreement in position, genotype, or retained VCF evidence excludes that identifier regardless of input order. Parsing exclusions, duplicate/conflict rows, upstream filter failures, missing annotations, rank/matching exclusions, and report filters have separate dispositions. Counts describe input processing, not clinical sensitivity or negative tests.

Validation: full regression suite, three-format row-conservation fixtures, conflict-order tests, no-call/unsupported-genotype fixtures, CLI HTML/JSON consistency, empty web report tests, development baseline, and wheel build.

Closes #20.
