### PR TITLE
Export candidate-level matching decisions and exclusion reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Candidate-level matching trace in the evidence JSON (`matching`): one
+  decision per reference record considered, retained, rejected, or
+  unresolved, with the stage, a structured reason code, the identity the
+  source gave the record, and a document-local `candidate_id`; findings
+  link to their supporting candidates and sites to their candidates.
+  Decisions are recorded by the matching functions themselves for ClinVar,
+  GWAS, ClinPGx, gnomAD, and ClinGen (at condition level). Candidate counts
+  are kept apart from input-row coverage and finding counts. Candidates at
+  reference-genotype sites are counted by default and listed with
+  `--detailed-trace`. No AI text enters the trace (`docs/matching-trace.md`).
+
 - Gene groups in CLI, web, and HTML reports, with distinct-finding counts,
   source-backed function descriptions where available, and individual details.
   Shared gene associations and unassigned findings remain visible. HTML exports

--- a/allelio/analysis/lookup.py
+++ b/allelio/analysis/lookup.py
@@ -14,6 +14,8 @@ from allelio.analysis.frequency import (
     frequency_identity, valid_frequency,
 )
 from allelio.analysis.identity import declared_build
+from allelio.analysis import trace as tr
+from allelio.analysis.trace import MatchTrace
 from allelio.analysis.quality import vcf_filter_reason
 from allelio.analysis.inheritance import (
     ClinGenEntry, InheritanceResolution, is_carrier, resolve_inheritance,
@@ -400,6 +402,10 @@ class AnalysisStats:
     dispositions: Dict[str, str] = field(default_factory=dict)
     duplicate_rows: int = 0
     conflicting_input_sites: int = 0
+    # One decision per candidate source record considered, with its reason;
+    # see allelio/analysis/trace.py. Counted separately from input rows and
+    # from returned findings.
+    trace: MatchTrace = field(default_factory=MatchTrace)
 
 
 def _determine_category(clinvar_entry: Optional[ClinVarEntry], gwas_entries: List[GWASEntry]) -> str:
@@ -560,6 +566,7 @@ def _select_clinvar_rows(
     genotype: Optional[str], rows: List[Dict[str, Any]],
     vcf_evidence: Optional[VCFEvidence] = None,
     chromosome: Optional[str] = None, position: Optional[int] = None,
+    trace: Optional[MatchTrace] = None, rsid: Optional[str] = None,
 ) -> Tuple[List[ClinVarEntry], Optional[ZygosityCall], bool]:
     """Pick the ClinVar rows that apply to this genotype.
 
@@ -583,6 +590,11 @@ def _select_clinvar_rows(
     # those are the ones to judge by; the degenerate row is dropped so it
     # cannot resurface as a "zygosity unknown" finding beside them.
     if any(e.ref_allele and e.alt_allele and e.ref_allele != e.alt_allele for e in entries):
+        for e in entries:
+            if e.ref_allele and e.ref_allele == e.alt_allele and trace is not None:
+                trace.add(rsid or e.rsid, "clinvar", tr.source_identity("clinvar", e), tr.REJECTED,
+                          tr.STAGE_APPLICABILITY, "haplotype_row_superseded",
+                          "record names no allele of its own; allele-specific records at this site decide")
         entries = [e for e in entries if not (e.ref_allele and e.ref_allele == e.alt_allele)]
     for entry in entries:
         if vcf_evidence is not None:
@@ -603,6 +615,26 @@ def _select_clinvar_rows(
         else:
             entry.allele_match, entry.allele_match_note = "absent", f"no copy of {call.allele}"
             absent.append((entry, call))
+
+    if trace is not None:
+        for entry, call in carried:
+            trace.add(rsid or entry.rsid, "clinvar", tr.source_identity("clinvar", entry), tr.RETAINED,
+                      tr.STAGE_ALLELE, "allele_carried", entry.allele_match_note)
+        for entry, call in unknown:
+            code = tr.reason_from_note(call.note)
+            stage = tr.STAGE_IDENTITY if code in (
+                "vcf_build_undeclared", "source_identity_unavailable", "build_mismatch",
+                "chromosome_unsupported", "mitochondrial_unsupported", "chromosome_mismatch",
+                "position_mismatch",
+            ) else tr.STAGE_ALLELE
+            note = call.note
+            if carried:
+                note = f"{call.note}; not shown: an allele-specific record at this site was matched"
+            trace.add(rsid or entry.rsid, "clinvar", tr.source_identity("clinvar", entry), tr.UNRESOLVED,
+                      stage, code, note)
+        for entry, call in absent:
+            trace.add(rsid or entry.rsid, "clinvar", tr.source_identity("clinvar", entry), tr.REJECTED,
+                      tr.STAGE_ALLELE, "allele_absent", entry.allele_match_note)
 
     if carried:
         carried.sort(key=lambda ec: _rank_clinvar(ec[0]))
@@ -626,6 +658,7 @@ def _gwas_call(
     genotype: Optional[str],
     entries: List[GWASEntry],
     site_alleles: Optional[set] = None,
+    trace: Optional[MatchTrace] = None, rsid: Optional[str] = None,
 ) -> Optional[ZygosityCall]:
     """Zygosity against the GWAS risk alleles, if the catalogue names any.
 
@@ -645,31 +678,48 @@ def _gwas_call(
     ambiguous = site_alleles in ({"A", "T"}, {"C", "G"})
     unknown: Optional[ZygosityCall] = None
     absent: Optional[ZygosityCall] = None
-    seen = set()
+    carried: Optional[ZygosityCall] = None
+    calls: Dict[str, ZygosityCall] = {}
     for e in entries:
         allele = (e.risk_allele or "").upper()
-        if not allele or allele in seen:
+        if not allele:
+            if trace is not None:
+                trace.add(rsid or e.rsid, "gwas", tr.source_identity("gwas", e), tr.UNRESOLVED,
+                          tr.STAGE_ALLELE, "risk_allele_not_recorded", "the catalogue names no risk allele")
             continue
-        seen.add(allele)
-        flipped = False
-        if (
-            site_alleles and allele not in site_alleles and not ambiguous
-            and _COMPLEMENT.get(allele) in site_alleles
-        ):
-            allele = _COMPLEMENT[allele]
-            flipped = True
-        call = call_zygosity(genotype, None, allele)
-        if flipped and call.alt_copies is not None:
-            call = ZygosityCall(
-                call.zygosity, call.alt_copies, e.risk_allele.upper(),
-                strand_flipped=True, allele_role="risk",
-            )
-        if call.alt_copies:
-            return call
-        if call.alt_copies is None:
-            unknown = unknown or call
-        else:
-            absent = absent or call
+        call = calls.get(allele)
+        if call is None:
+            forward, flipped = allele, False
+            if (
+                site_alleles and allele not in site_alleles and not ambiguous
+                and _COMPLEMENT.get(allele) in site_alleles
+            ):
+                forward, flipped = _COMPLEMENT[allele], True
+            call = call_zygosity(genotype, None, forward)
+            if flipped and call.alt_copies is not None:
+                call = ZygosityCall(
+                    call.zygosity, call.alt_copies, allele, strand_flipped=True, allele_role="risk",
+                )
+            calls[allele] = call
+            if call.alt_copies:
+                carried = carried or call
+            elif call.alt_copies is None:
+                unknown = unknown or call
+            else:
+                absent = absent or call
+        if trace is not None:
+            flip = " (risk allele read on the opposite strand)" if call.strand_flipped else ""
+            if call.alt_copies:
+                trace.add(rsid or e.rsid, "gwas", tr.source_identity("gwas", e), tr.RETAINED, tr.STAGE_ALLELE,
+                          "risk_allele_carried", f"{call.alt_copies} of risk allele {allele}{flip}")
+            elif call.alt_copies is None:
+                trace.add(rsid or e.rsid, "gwas", tr.source_identity("gwas", e), tr.UNRESOLVED, tr.STAGE_ALLELE,
+                          tr.reason_from_note(call.note), call.note)
+            else:
+                trace.add(rsid or e.rsid, "gwas", tr.source_identity("gwas", e), tr.REJECTED, tr.STAGE_ALLELE,
+                          "risk_allele_absent", f"no copy of risk allele {allele}{flip}")
+    if carried is not None:
+        return carried
     if unknown is not None:
         return unknown
     return absent
@@ -683,6 +733,7 @@ def _match_pgx(
     rows: List[Dict[str, Any]],
     site_alleles: Optional[set] = None,
     min_level: str = PGX_DEFAULT_MIN_LEVEL,
+    trace: Optional[MatchTrace] = None, rsid: Optional[str] = None,
 ) -> List[PGxEntry]:
     """The ClinPGx rows whose genotype is this person's genotype.
 
@@ -693,11 +744,27 @@ def _match_pgx(
     the entry flagged. Rows below ``min_level`` are dropped. Best level first.
     """
     alleles = genotype_alleles(genotype)
-    if len(alleles) != 2 or not rows:
+    if not rows:
+        return []
+
+    def decide(r, decision, stage, reason, note=None):
+        if trace is not None:
+            trace.add(rsid or r.get("rsid"), "clinpgx", tr.source_identity("clinpgx", r), decision, stage, reason, note)
+
+    if len(alleles) != 2:
+        for r in rows:
+            decide(r, tr.UNRESOLVED, tr.STAGE_ALLELE, "genotype_unavailable",
+                   "no diploid SNP genotype to match the annotation's genotype against")
         return []
     key = "".join(sorted(alleles))
     max_rank = pgx_level_rank(min_level)
-    usable = [r for r in rows if pgx_level_rank(r.get("level")) <= max_rank]
+    usable = []
+    for r in rows:
+        if pgx_level_rank(r.get("level")) <= max_rank:
+            usable.append(r)
+        else:
+            decide(r, tr.REJECTED, tr.STAGE_LEVEL, "pgx_below_min_level",
+                   f"level {r.get('level')} is below the reporting threshold {min_level}")
     if not usable:
         return []
     by_genotype: Dict[str, List[Dict[str, Any]]] = {}
@@ -715,6 +782,14 @@ def _match_pgx(
         comp = "".join(sorted(_PGX_COMPLEMENT.get(a, a) for a in alleles))
         if not ambiguous and comp in by_genotype and not any(a in letters for a in alleles):
             matched, flipped = by_genotype[comp], True
+    for r in usable:
+        if matched and r in matched:
+            decide(r, tr.RETAINED, tr.STAGE_APPLICABILITY, "pgx_genotype_matched",
+                   f"annotation written for genotype {r.get('genotype')}"
+                   + (" (genotype read on the opposite strand)" if flipped else ""))
+        else:
+            decide(r, tr.REJECTED, tr.STAGE_APPLICABILITY, "pgx_other_genotype",
+                   f"annotation is for genotype {r.get('genotype')}, not {key}")
     if not matched:
         return []
     entries = [
@@ -885,25 +960,38 @@ def analyze_variants_with_stats(
         genotype = getattr(original_variant, 'genotype', None)
 
         vcf_evidence = getattr(original_variant, 'vcf_evidence', None)
-        if vcf_filter_reason(vcf_evidence):
+        trace = stats.trace
+        filter_reason = vcf_filter_reason(vcf_evidence)
+        if filter_reason:
             # Do not let rejected genotypes enter any source-specific matcher.
+            # Every candidate at the site is rejected at the filter stage.
             if annotated:
                 stats.vcf_filter_failed_sites += 1
+            for source, rows in (("clinvar", data["clinvar"]), ("gwas", data["gwas"]),
+                                 ("clinpgx", pgx_rows), ("gnomad", data.get("gnomad") or [])):
+                for row in rows:
+                    trace.add(rsid, source, tr.source_identity(source, row), tr.REJECTED, tr.STAGE_FILTER,
+                              "vcf_filter_failed", filter_reason)
             stats.dispositions[rsid] = "failed_filter"
             continue
         if not annotated:
             continue
         # Do not let non-SNP sequences reach legacy SNP/GWAS/PGx matching as
         # concatenated bases. Their complete alleles remain in source evidence.
-        if vcf_evidence is not None and any(
+        non_snp = vcf_evidence is not None and any(
             a not in {"A", "C", "G", "T"}
             for a in (vcf_evidence.reference,) + vcf_evidence.alternates
-        ):
+        )
+        if non_snp:
             genotype = "--"
+            for source, rows in (("gwas", data["gwas"]), ("clinpgx", pgx_rows)):
+                for row in rows:
+                    trace.add(rsid, source, tr.source_identity(source, row), tr.UNRESOLVED, tr.STAGE_ALLELE,
+                              "non_snp_unsupported", "VCF non-SNP record requires build-aware normalization")
 
         # ClinVar rows that apply to this genotype (allele-aware)
         clinvar_entries, call, is_reference = _select_clinvar_rows(
-            genotype, data["clinvar"], vcf_evidence, chromosome, position
+            genotype, data["clinvar"], vcf_evidence, chromosome, position, trace=trace, rsid=rsid
         )
         clinvar_entry = clinvar_entries[0] if clinvar_entries else None
 
@@ -925,11 +1013,14 @@ def analyze_variants_with_stats(
         # not a ClinVar finding for them. If GWAS rows remain, judge those on
         # their own risk allele; otherwise the site is a reference genotype.
         gwas_reference = False
+        gwas_judged = False
         if gwas_entries and (is_reference or call is None):
+            gwas_judged = True
             site_alleles = {
                 a for cv in data["clinvar"] for a in (cv.get("ref_allele"), cv.get("alt_allele")) if a
             }
-            gcall = _gwas_call(genotype, gwas_entries, site_alleles)
+            gcall = _gwas_call(genotype, gwas_entries, site_alleles,
+                               trace=None if non_snp else trace, rsid=rsid)
             if gcall is not None and gcall.alt_copies == 0:
                 gwas_reference = True
             elif is_reference or call is None:
@@ -939,7 +1030,8 @@ def analyze_variants_with_stats(
         site_alleles_pgx = {
             a for cv in data["clinvar"] for a in (cv.get("ref_allele"), cv.get("alt_allele")) if a
         }
-        pgx_entries = _match_pgx(genotype, pgx_rows, site_alleles_pgx, pgx_min_level)
+        pgx_entries = _match_pgx(genotype, pgx_rows, site_alleles_pgx, pgx_min_level,
+                                 trace=None if non_snp else trace, rsid=rsid)
 
         site_is_reference = (
             (is_reference or not clinvar_entries) and (gwas_reference or not gwas_entries)
@@ -957,6 +1049,13 @@ def analyze_variants_with_stats(
             clinvar_entries = []
         elif gwas_reference:
             gwas_entries = []
+        if gwas_entries and not gwas_judged and call is not None and call.alt_copies:
+            # ClinVar decided the genotype; the associations ride along on the
+            # ClinVar call and were not judged against their own risk allele.
+            for e in gwas_entries:
+                trace.add(rsid, "gwas", tr.source_identity("gwas", e), tr.RETAINED, tr.STAGE_APPLICABILITY,
+                          "reported_with_clinvar_match",
+                          "association shown with the ClinVar allele match; risk allele not judged separately")
         clinvar_entry = clinvar_entries[0] if clinvar_entries else None
 
         # Determine category
@@ -990,6 +1089,16 @@ def analyze_variants_with_stats(
             matched_allele = _COMPLEMENT.get(matched_allele or "", matched_allele)
         anchor = _allele_anchor(data["clinvar"], matched_allele, vcf_evidence, chromosome, position)
         gnomad_entries, gnomad_entry = _gnomad_entries(rsid, data.get("gnomad") or [], anchor)
+        for e in gnomad_entries:
+            if e.describes_matched_allele:
+                trace.add(rsid, "gnomad", tr.source_identity("gnomad", e), tr.RETAINED, tr.STAGE_FREQUENCY,
+                          "frequency_identity_matched", e.identity_note)
+            elif e.identity == FREQUENCY_UNVERIFIED:
+                trace.add(rsid, "gnomad", tr.source_identity("gnomad", e), tr.UNRESOLVED, tr.STAGE_FREQUENCY,
+                          "frequency_identity_unverified", e.identity_note)
+            else:
+                trace.add(rsid, "gnomad", tr.source_identity("gnomad", e), tr.REJECTED, tr.STAGE_FREQUENCY,
+                          f"frequency_{e.identity}", e.identity_note)
 
         # This optional frequency display penalty is not applied to PGx:
         # allele commonness does not determine drug-response applicability.
@@ -1034,6 +1143,19 @@ def analyze_variants_with_stats(
                     entry.conditions, entry.condition_ids, clingen_entries
                 )
             resolution = clinvar_entry.inheritance
+            matched_ids = {id(m) for m in resolution.matched}
+            for curation in clingen_entries:
+                if id(curation) in matched_ids:
+                    trace.add(rsid, "clingen", tr.source_identity("clingen", curation), tr.RETAINED,
+                              tr.STAGE_CONDITION, "condition_matched_by_mondo",
+                              f"{curation.mondo_id} is named by the assertion; resolution {resolution.status}")
+                else:
+                    reason = ("assertion_has_no_condition_identifiers"
+                              if resolution.status in ("no_identifiers", "identifiers_not_stored")
+                              else "condition_not_named_by_assertion")
+                    trace.add(rsid, "clingen", tr.source_identity("clingen", curation), tr.REJECTED,
+                              tr.STAGE_CONDITION, reason,
+                              f"{curation.mondo_id or 'no MONDO id'} is not among the assertion's condition identifiers")
             inheritance, inheritance_note = resolution.inheritance, resolution.note
             if category == VariantCategory.HEALTH_CONDITIONS.value and is_carrier(
                 resolution, call.alt_copies, genotype

--- a/allelio/analysis/trace.py
+++ b/allelio/analysis/trace.py
@@ -1,0 +1,136 @@
+"""Candidate-level matching trace: what happened to every source record.
+
+Matching a person's genotype against reference data considers more records
+than end up in a finding: the other alternate allele at a multiallelic site,
+a frequency row for a different build, a ClinPGx annotation for another
+genotype, a ClinGen curation for a condition the assertion does not name.
+The trace records one decision per candidate record, with a structured
+reason code and the identity the source gave it, so an export can show why
+a record was retained, rejected, or left unresolved instead of only what
+was kept.
+
+Decisions come from the matching functions themselves (they append to the
+trace as they decide); nothing here re-implements a match.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# Decisions.
+RETAINED = "retained"        # the record applies to this person and fed the result
+REJECTED = "rejected"        # checked and found not to apply
+UNRESOLVED = "unresolved"    # could not be checked; kept without a verdict
+
+# Stages, in the order a record meets them.
+STAGE_FILTER = "filter"              # VCF FILTER / FORMAT FT
+STAGE_IDENTITY = "identity"          # build, chromosome, position agreement
+STAGE_ALLELE = "allele"              # does the genotype carry the record's allele
+STAGE_APPLICABILITY = "applicability"  # is the record about this person's genotype
+STAGE_LEVEL = "level"                # evidence-level threshold (ClinPGx)
+STAGE_FREQUENCY = "frequency"        # frequency record identity
+STAGE_CONDITION = "condition"        # ClinGen curation versus the assertion's condition
+
+# Reason codes are stable identifiers; the note carries the human sentence.
+# Abstention notes written by the zygosity and identity checks map onto
+# codes by prefix, so the same sentence always yields the same code.
+_NOTE_CODES = (
+    ("no call", "genotype_no_call"),
+    ("annotated allele not recorded", "allele_not_recorded"),
+    ("annotation is not allele-specific", "annotation_not_allele_specific"),
+    ("annotation is not SNP allele-specific", "annotation_not_allele_specific"),
+    ("may be on the opposite strand", "strand_ambiguous"),
+    ("does not match annotated alleles", "genotype_allele_mismatch"),
+    ("VCF reference build is unknown", "vcf_build_undeclared"),
+    ("ClinVar reference identity unavailable", "source_identity_unavailable"),
+    ("VCF and ClinVar reference builds differ", "build_mismatch"),
+    ("unsupported chromosome identity", "chromosome_unsupported"),
+    ("mitochondrial reference identity", "mitochondrial_unsupported"),
+    ("VCF and ClinVar chromosomes differ", "chromosome_mismatch"),
+    ("VCF and ClinVar positions differ", "position_mismatch"),
+    ("VCF non-SNP record requires", "non_snp_unsupported"),
+    ("unsupported or inconsistent VCF ploidy", "ploidy_unsupported"),
+    ("invalid VCF allele index", "vcf_index_invalid"),
+    ("VCF alleles disagree with genotype indices", "vcf_alleles_inconsistent"),
+    ("VCF reference allele does not match annotation", "vcf_reference_mismatch"),
+    ("annotated alternate is not declared in VCF", "vcf_alternate_undeclared"),
+)
+UNRESOLVED_OTHER = "unresolved_other"
+
+
+def reason_from_note(note: Optional[str]) -> str:
+    """The reason code for an abstention note; ``unresolved_other`` if unmapped."""
+    text = (note or "").strip()
+    for prefix, code in _NOTE_CODES:
+        if text.startswith(prefix) or prefix in text:
+            return code
+    return UNRESOLVED_OTHER
+
+
+@dataclass
+class CandidateDecision:
+    """One source record at one input site, and what matching decided.
+
+    ``identity`` is whatever identity the source gave the record (allele and
+    variation IDs, assembly, chromosome, position, REF/ALT for ClinVar; study
+    and risk allele for GWAS; annotation and genotype for ClinPGx; alleles and
+    assembly for gnomAD; disease and MONDO id for ClinGen). ``candidate_id``
+    is assigned at export time and is local to that document.
+    """
+    rsid: str
+    source: str
+    identity: Dict[str, Any]
+    decision: str
+    stage: str
+    reason: str
+    note: Optional[str] = None
+    candidate_id: Optional[str] = None
+
+
+@dataclass
+class MatchTrace:
+    """Every candidate decision of one analysis, in the order they were made."""
+    candidates: List[CandidateDecision] = field(default_factory=list)
+
+    def add(self, rsid: str, source: str, identity: Dict[str, Any], decision: str,
+            stage: str, reason: str, note: Optional[str] = None) -> CandidateDecision:
+        decision_record = CandidateDecision(rsid, source, identity, decision, stage, reason, note)
+        self.candidates.append(decision_record)
+        return decision_record
+
+    def at(self, rsid: str) -> List[CandidateDecision]:
+        return [c for c in self.candidates if c.rsid == rsid]
+
+
+# What each source's identity dict is built from.
+_IDENTITY_KEYS = {
+    "clinvar": ("allele_id", "variation_id", "assembly", "chromosome", "position_vcf", "ref_allele",
+                "alt_allele", "gene", "clinical_significance", "review_status"),
+    "gwas": ("study", "pubmed_id", "trait", "risk_allele", "mapped_gene"),
+    "clinpgx": ("annotation_id", "genotype", "level", "drugs", "gene"),
+    "gnomad": ("assembly", "chromosome", "position", "ref_allele", "alt_allele", "source_version",
+               "allele_frequency"),
+    "clingen": ("gene", "disease", "mondo_id", "moi", "classification"),
+}
+
+
+def source_identity(source: str, record: Any) -> Dict[str, Any]:
+    """The identity fields a source gave a record, from a dict or an object."""
+    get = record.get if isinstance(record, dict) else (lambda k, d=None: getattr(record, k, d))
+    identity = {}
+    for key in _IDENTITY_KEYS.get(source, ()):
+        value = get(key)
+        if value not in (None, ""):
+            identity[key] = value
+    return identity
+
+
+# Every annotation path Allelio matches, and whether its decisions are
+# recorded per candidate record. A path listed as partial says what is
+# missing rather than leaving the reader to guess.
+PATHS = {
+    "clinvar": "traced: filter, identity, allele, applicability decisions per record",
+    "gwas": "traced: risk-allele decisions per association; strand inference noted",
+    "clinpgx": "traced: evidence-level threshold and genotype match per annotation row",
+    "gnomad": "traced: frequency-record identity per allele row",
+    "clingen": "traced at condition level: each curation for the gene against the assertion's MONDO identifiers",
+}

--- a/allelio/cli.py
+++ b/allelio/cli.py
@@ -116,6 +116,9 @@ def setup(no_gnomad: bool):
 )
 @click.option("--json-output", type=click.Path(dir_okay=False), default=None,
               help="Also save a versioned structured evidence JSON file.")
+@click.option("--detailed-trace", is_flag=True, default=False,
+              help="In the evidence JSON, list every candidate source record, including those at "
+                   "reference-genotype sites (large on whole-array files); by default they are counted only.")
 def analyze(
     file: str,
     output: str,
@@ -125,6 +128,7 @@ def analyze(
     top: int,
     traits_only: bool,
     json_output: Optional[str] = None,
+    detailed_trace: bool = False,
 ):
     """Analyze a genotype file for significant variants.
     
@@ -435,8 +439,9 @@ def analyze(
             write_evidence_export(build_evidence_export(
                 results, variants, provenance_of(db),
                 {"include_benign": include_benign, "include_reference": False,
-                 "traits_only": traits_only, "frequency_adjustment": True},
-                analysis_stats,
+                 "traits_only": traits_only, "frequency_adjustment": True,
+                 "detailed_trace": detailed_trace},
+                analysis_stats, detailed_trace=detailed_trace,
             ), json_output)
         except Exception as exc:
             raise click.ClickException(f"Failed to write evidence JSON: {exc}") from exc

--- a/allelio/evidence.py
+++ b/allelio/evidence.py
@@ -6,11 +6,20 @@ from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+from collections import Counter
+
 from allelio import __version__
 from allelio.coverage import build_coverage
 from allelio.analysis.genes import group_findings
+from allelio.analysis.trace import PATHS, RETAINED
 
 SCHEMA_VERSION = "1.0"
+
+# Site dispositions whose candidates are exported only on request: a site
+# where the person carries none of the annotated alleles has its records
+# rejected as "allele_absent", and on a whole-array file there are tens of
+# thousands of them. Their counts are always in the document.
+DETAILED_ONLY_DISPOSITIONS = {"reference_or_no_applicable_annotation"}
 
 
 def _json_value(value):
@@ -26,12 +35,79 @@ def _json_value(value):
     return value
 
 
-def build_evidence_export(results, inputs, provenance, configuration=None, stats=None):
+def build_matching_trace(stats, finding_ids_by_rsid, input_ids_by_rsid, detailed=False):
+    """The candidate-level matching trace as a JSON-ready section.
+
+    Every candidate decision gets a document-local ``candidate_id``; sites
+    link their candidates to the finding (if any) and the input rows for
+    the rsID. Counts are over candidate records, not input rows or findings.
+    Unless ``detailed``, candidates at sites set aside as reference genotype
+    are counted but not listed (see DETAILED_ONLY_DISPOSITIONS).
+    """
+    trace = getattr(stats, "trace", None)
+    candidates = list(getattr(trace, "candidates", []) or [])
+    dispositions = getattr(stats, "dispositions", {}) or {}
+    by_site = {}
+    for index, candidate in enumerate(candidates):
+        candidate.candidate_id = "candidate-" + str(index + 1)
+        by_site.setdefault(candidate.rsid, []).append(candidate)
+    sites, listed = [], []
+    for rsid, site_candidates in by_site.items():
+        disposition = dispositions.get(rsid)
+        include = detailed or disposition not in DETAILED_ONLY_DISPOSITIONS
+        counts = dict(sorted(Counter(c.decision for c in site_candidates).items()))
+        sites.append({
+            "rsid": rsid,
+            "input_ids": input_ids_by_rsid.get(rsid, []),
+            "finding_id": finding_ids_by_rsid.get(rsid),
+            "disposition": disposition,
+            "candidate_count": len(site_candidates),
+            "counts": counts,
+            "candidate_ids": [c.candidate_id for c in site_candidates] if include else None,
+            "candidates_listed": include,
+        })
+        if include:
+            listed.extend(site_candidates)
+    by_source = {}
+    for candidate in candidates:
+        by_source.setdefault(candidate.source, Counter())[candidate.decision] += 1
+    return {
+        "schema": "candidate-trace/1",
+        "candidate_count": len(candidates),
+        "counts": dict(sorted(Counter(c.decision for c in candidates).items())),
+        "by_source": {source: dict(sorted(counts.items())) for source, counts in sorted(by_source.items())},
+        "sites_with_candidates": len(sites),
+        "listed_candidate_count": len(listed),
+        "detailed": bool(detailed),
+        "paths": dict(PATHS),
+        "sites": sites,
+        "candidates": [
+            {
+                "candidate_id": c.candidate_id, "rsid": c.rsid, "source": c.source,
+                "identity": dict(c.identity), "decision": c.decision, "stage": c.stage,
+                "reason": c.reason, "note": c.note,
+                "finding_id": finding_ids_by_rsid.get(c.rsid) if c.decision == RETAINED else None,
+            }
+            for c in listed
+        ],
+        "limitations": [
+            "Candidate counts are over reference records considered, not input rows (see coverage) or findings.",
+            "A retained candidate at a site without a finding was set aside by a later rule; the site disposition says which.",
+            "Candidate IDs are local to this document and carry no genomic identity of their own; the identity field is what the source gave.",
+            "Traces record Allelio's matching decisions only; no AI-generated reasoning is included.",
+            "Candidates at reference-genotype sites are counted but listed only in a detailed export.",
+        ],
+    }
+
+
+def build_evidence_export(results, inputs, provenance, configuration=None, stats=None, detailed_trace=False):
     """Preserve parsed observations and every source field retained in findings.
 
     IDs are document-local indices, not normalized genomic identifiers.
     Source records are the selected database annotations, not a raw database dump.
     AI text is deliberately separate from this reproducible evidence contract.
+    ``detailed_trace`` lists every candidate record, including those at
+    reference-genotype sites; otherwise those are counted only.
     """
     observations = []
     by_rsid = {}
@@ -43,11 +119,20 @@ def build_evidence_export(results, inputs, provenance, configuration=None, stats
         observations.append(record)
         by_rsid.setdefault(record.get("rsid"), []).append(record["input_id"])
     findings = []
+    finding_ids_by_rsid = {}
     for index, result in enumerate(results):
         record = _json_value(result)
         record["finding_id"] = "finding-" + str(index + 1)
         record["input_ids"] = by_rsid.get(result.rsid, [])
+        finding_ids_by_rsid.setdefault(result.rsid, record["finding_id"])
         findings.append(record)
+    matching = build_matching_trace(stats, finding_ids_by_rsid, by_rsid, detailed=detailed_trace)
+    supporting = {}
+    for candidate in matching["candidates"]:
+        if candidate["decision"] == RETAINED and candidate["finding_id"]:
+            supporting.setdefault(candidate["finding_id"], []).append(candidate["candidate_id"])
+    for record in findings:
+        record["candidate_ids"] = supporting.get(record["finding_id"], [])
     groups = group_findings(results)
     for group in groups:
         group["finding_ids"] = [findings[i]["finding_id"] for i in group["indices"]]
@@ -60,16 +145,28 @@ def build_evidence_export(results, inputs, provenance, configuration=None, stats
         "inputs": observations,
         "findings": findings,
         "gene_groups": groups,
-        "analysis_stats": stats,
+        "analysis_stats": _stats_without_trace(stats),
         "coverage": build_coverage(inputs, results, stats),
+        "matching": matching,
         "limitations": [
             "Research and education only; not a clinical interpretation.",
             "Document-local IDs do not assert normalized genomic identity.",
             "Source records are annotations retained by matching, not all database candidates.",
             "Missing and non-finite numeric values are null, not zero.",
             "Coverage records parsing exclusions when an input audit is available; absent findings are not negative results.",
+            "The matching section records why each candidate source record was retained, rejected, or left unresolved; its counts are over records, not rows or findings.",
         ],
     })
+
+
+def _stats_without_trace(stats):
+    """``analysis_stats`` as before; the trace is exported as ``matching``."""
+    if stats is None:
+        return None
+    record = _json_value(stats)
+    if isinstance(record, dict):
+        record.pop("trace", None)
+    return record
 
 
 def write_evidence_export(document, path):

--- a/docs/evidence-export.md
+++ b/docs/evidence-export.md
@@ -44,6 +44,12 @@ allele equivalence. These IDs are not VRS IDs or normalized variant identifiers.
 Raw VCF reference declarations are not certified genome assemblies. Null source
 identity fields stay null. AI prose is excluded from this evidence document.
 
+The additive `matching` field is the candidate-level selection trail: one
+decision per reference record considered, with stage, reason code, source
+identity, and document-local `candidate_id`; findings carry `candidate_ids` for
+the records that support them. Its counts are over records, not rows or
+findings. See [matching trace](matching-trace.md).
+
 The additive `coverage` field records input row dispositions, including parsing
 exclusions, when an audit is available. See [input coverage](input-coverage.md).
 No annotation or an omitted finding must not be interpreted as a negative test.

--- a/docs/matching-trace.md
+++ b/docs/matching-trace.md
@@ -1,0 +1,77 @@
+# Candidate matching trace
+
+The evidence JSON's `matching` section records what happened to every
+reference record Allelio considered for an input site: retained, rejected, or
+left unresolved, at which stage, with a structured reason code and the
+identity the source gave the record. It is the selection trail behind the
+`findings`, which list only what was kept.
+
+## Where decisions come from
+
+The matching functions record their own decisions as they make them; the
+trace does not re-run a match. One decision per candidate record:
+
+| Source | Stage(s) | Retained when | Rejected when | Unresolved when |
+|---|---|---|---|---|
+| ClinVar | filter, identity, allele, applicability | the genotype carries the record's allele (`allele_carried`) | the genotype carries no copy (`allele_absent`), the row names no allele of its own beside allele-specific rows (`haplotype_row_superseded`), or the VCF record failed its filter (`vcf_filter_failed`) | identity or allele could not be checked: `vcf_build_undeclared`, `source_identity_unavailable`, `build_mismatch`, `chromosome_mismatch`, `position_mismatch`, `mitochondrial_unsupported`, `allele_not_recorded`, `annotation_not_allele_specific`, `strand_ambiguous`, `genotype_allele_mismatch`, `genotype_no_call`, `non_snp_unsupported`, and the other VCF codes in `allelio/analysis/trace.py` |
+| GWAS Catalog | allele, applicability | the genotype carries the risk allele (`risk_allele_carried`), or the association is shown with a ClinVar allele match (`reported_with_clinvar_match`) | no copy of the risk allele (`risk_allele_absent`) | the catalogue names no risk allele (`risk_allele_not_recorded`), or the genotype could not be judged |
+| ClinPGx | level, applicability | the annotation row is written for this genotype (`pgx_genotype_matched`) | below the reporting level (`pgx_below_min_level`) or for another genotype (`pgx_other_genotype`) | no diploid SNP genotype (`genotype_unavailable`, `non_snp_unsupported`) |
+| gnomAD | frequency | the record's identity agrees with the matched allele (`frequency_identity_matched`) | another allele, build, position, or orientation (`frequency_other_allele`, `frequency_build_mismatch`, ...) | no allele in the record or nothing to compare to (`frequency_identity_unverified`) |
+| ClinGen | condition | the curation's MONDO identifier is named by the assertion (`condition_matched_by_mondo`) | it is not (`condition_not_named_by_assertion`), or the assertion has no identifiers (`assertion_has_no_condition_identifiers`) | |
+
+`paths` in the section states, for every annotation path, what is traced.
+A strand inference or an opposite-strand read is named in the note, never
+silent.
+
+## Document structure
+
+```json
+"matching": {
+  "schema": "candidate-trace/1",
+  "candidate_count": 41,
+  "counts": {"rejected": 12, "retained": 25, "unresolved": 4},
+  "by_source": {"clingen": {...}, "clinvar": {...}, ...},
+  "sites_with_candidates": 17,
+  "listed_candidate_count": 38,
+  "detailed": false,
+  "paths": {"clinvar": "traced: ...", ...},
+  "sites": [{"rsid": "rs334", "input_ids": ["input-5"], "finding_id": "finding-5",
+             "disposition": "reported", "candidate_count": 4,
+             "counts": {"rejected": 1, "retained": 3}, "candidate_ids": ["candidate-9", ...],
+             "candidates_listed": true}],
+  "candidates": [{"candidate_id": "candidate-9", "rsid": "rs334", "source": "clinvar",
+                  "identity": {"allele_id": "15333", "assembly": "GRCh38", "chromosome": "11",
+                               "position_vcf": 5227002, "ref_allele": "T", "alt_allele": "A", ...},
+                  "decision": "retained", "stage": "allele", "reason": "allele_carried",
+                  "note": "1 copy of A", "finding_id": "finding-5"}]
+}
+```
+
+Each finding also carries `candidate_ids`, the retained candidates that
+support it. `candidate_id`, `finding_id` and `input_id` are local to one
+document. A candidate's `identity` is whatever the source gave (ClinVar
+allele and variation IDs, assembly, chromosome, position, REF and ALT; GWAS
+study and risk allele; ClinPGx annotation and genotype; gnomAD alleles and
+assembly; ClinGen disease and MONDO id); a rejected or unresolved candidate
+keeps it, so the record can be looked up.
+
+## Counts that must not be confused
+
+- `matching.candidate_count` counts reference records considered.
+- `coverage` counts input rows and their dispositions.
+- `findings` (and `coverage.returned_findings`) count what was returned.
+
+A site can have retained candidates and no finding: a benign match below the
+default display cutoff, for instance. The site's `disposition` says which
+later rule set it aside, and the candidate's `finding_id` is null.
+
+## Size and the detailed export
+
+On a whole-array file most annotated sites are reference genotype: the
+person carries none of the annotated alleles, and every record there is
+rejected as `allele_absent`. Those sites are always counted, but their
+candidates are listed only with `allelio analyze --detailed-trace` (recorded
+in `configuration.detailed_trace`). The web export uses the default form.
+
+The trace records Allelio's matching decisions only. AI-generated text is
+never part of it.

--- a/tests/test_matching_trace.py
+++ b/tests/test_matching_trace.py
@@ -1,0 +1,266 @@
+"""The evidence export explains why each candidate record was kept or not.
+
+All reference rows here are synthetic. The trace is read back through
+``build_evidence_export`` so the document-local references are what is
+tested, not internal objects.
+"""
+
+import json
+from collections import Counter
+
+import pytest
+
+from allelio.analysis.lookup import analyze_variants, analyze_variants_with_stats
+from allelio.analysis.trace import PATHS, reason_from_note
+from allelio.database.store import AllelioDB
+from allelio.evidence import build_evidence_export
+from allelio.parsers.base import VCFEvidence, Variant
+
+
+def _clinvar(rsid, ref, alt, sig, chrom="11", pos=5227002, allele_id="1", gene="HBB", **extra):
+    row = dict(rsid=rsid, ref_allele=ref, alt_allele=alt, gene=gene, clinical_significance=sig,
+               conditions="Cond", condition_ids="MONDO:MONDO:0900001,MedGen:C1", review_status="practice guideline",
+               last_evaluated="", assembly="GRCh38", chromosome=chrom, position_vcf=pos, allele_id=allele_id)
+    row.update(extra)
+    return row
+
+
+def _gwas(rsid, risk_allele, trait="Trait", study="Study A", pubmed="1"):
+    return dict(rsid=rsid, trait=trait, p_value=1e-9, odds_ratio="1.2", mapped_gene="HBB", study=study,
+                pubmed_id=pubmed, link="", risk_allele=risk_allele)
+
+
+def _gnomad(rsid, ref, alt, af, chrom="11", pos=5227002, assembly="GRCh38"):
+    return dict(rsid=rsid, chromosome=chrom, position=pos, ref_allele=ref, alt_allele=alt, assembly=assembly,
+                source_version="v4.1.1", allele_frequency=af, af_popmax=None, ac=None, an=None, nhomalt=None,
+                af_afr=None, af_eas=None, af_fin=None, af_nfe=None, af_sas=None)
+
+
+def _pgx(rsid, genotype, level, annotation_id, drugs="drug"):
+    return dict(annotation_id=annotation_id, genotype=genotype, rsid=rsid, gene="HBB", level=level, score=1.0,
+                phenotype_category="Efficacy", drugs=drugs, phenotypes="", url="", annotation_text="text",
+                allele_function="")
+
+
+@pytest.fixture
+def db(tmp_path):
+    db = AllelioDB(str(tmp_path / "trace.db"))
+    db.initialize()
+    db.insert_clinvar_batch([
+        # Multiallelic site with two records for one allele and a haplotype row.
+        _clinvar("rs334", "T", "A", "Pathogenic", allele_id="15333"),
+        _clinvar("rs334", "T", "G", "Likely benign", allele_id="15334"),
+        _clinvar("rs334", "T", "A", "Conflicting classifications of pathogenicity", allele_id="99999",
+                 review_status="criteria provided, conflicting classifications"),
+        _clinvar("rs334", "T", "T", "Benign", allele_id="77777"),
+        # A record whose allele ClinVar does not give.
+        _clinvar("rs500", "", "", "Pathogenic", chrom="1", pos=500, allele_id="500", gene="G2"),
+        # Reference-only site.
+        _clinvar("rs600", "C", "T", "Pathogenic", chrom="1", pos=600, allele_id="600", gene="G3"),
+        # VCF-anchored site.
+        _clinvar("rs700", "A", "G", "Pathogenic", chrom="1", pos=700, allele_id="700", gene="G4"),
+    ])
+    db.insert_gwas_batch([_gwas("rs334", "A"), _gwas("rs334", "T", trait="Other", study="Study B", pubmed="2"),
+                          _gwas("rs334", None, trait="No allele", study="Study C", pubmed="3"),
+                          _gwas("rs600", "T", study="Study D", pubmed="4")])
+    db.insert_gnomad_batch([_gnomad("rs334", "T", "A", 0.0127), _gnomad("rs334", "T", "G", 0.0005),
+                            _gnomad("rs600", "C", "T", 0.3), _gnomad("rs700", "A", "G", 0.2, chrom="1", pos=700),
+                            _gnomad("rs700", "A", "G", 0.9, chrom="1", pos=700, assembly="GRCh37")])
+    db.insert_clinpgx_batch([_pgx("rs334", "AT", "1A", "pa1"), _pgx("rs334", "TT", "1A", "pa2"),
+                             _pgx("rs334", "AT", "3", "pa3")])
+    db.insert_clingen_batch([
+        dict(gene="HBB", hgnc_id="HGNC:4827", disease="named condition", mondo_id="MONDO:0900001", moi="AR",
+             classification="Definitive", report_url="", classification_date=""),
+        dict(gene="HBB", hgnc_id="HGNC:4827", disease="other condition", mondo_id="MONDO:0900002", moi="AD",
+             classification="Definitive", report_url="", classification_date=""),
+    ])
+    return db
+
+
+def _export(db, variants, detailed=False, **kwargs):
+    results = analyze_variants(variants, db, **kwargs)
+    document = build_evidence_export(results, variants, {}, {"detailed_trace": detailed}, results.stats,
+                                     detailed_trace=detailed)
+    json.dumps(document, allow_nan=False)
+    return document
+
+
+def _by_reason(candidates, source=None):
+    return Counter((c["source"], c["reason"]) for c in candidates if source in (None, c["source"]))
+
+
+class TestMultipleCandidatesAtOneSite:
+    def test_every_record_gets_a_decision_and_the_finding_links_to_its_support(self, db):
+        variants = [Variant("rs334", "11", 5227002, "TA")]
+        document = _export(db, variants)
+        [finding] = document["findings"]
+        [site] = [s for s in document["matching"]["sites"] if s["rsid"] == "rs334"]
+        candidates = {c["candidate_id"]: c for c in document["matching"]["candidates"]}
+        assert site["finding_id"] == finding["finding_id"] and site["input_ids"] == ["input-1"]
+        assert site["candidates_listed"] and set(site["candidate_ids"]) <= set(candidates)
+        reasons = _by_reason(candidates.values())
+        # ClinVar: two distinct pathogenic-side records carried; the T>G record cannot be judged against
+        # a TA genotype (A is not one of its alleles) and is unresolved; the haplotype row is dropped
+        assert reasons[("clinvar", "allele_carried")] == 2
+        assert reasons[("clinvar", "genotype_allele_mismatch")] == 1
+        assert reasons[("clinvar", "haplotype_row_superseded")] == 1
+        # GWAS rides on the ClinVar match: every association, allele or not, is shown with it
+        assert reasons[("gwas", "reported_with_clinvar_match")] == 3
+        # ClinPGx: the AT row matched, TT is another genotype, level 3 is below the threshold
+        assert reasons[("clinpgx", "pgx_genotype_matched")] == 1
+        assert reasons[("clinpgx", "pgx_other_genotype")] == 1
+        assert reasons[("clinpgx", "pgx_below_min_level")] == 1
+        # gnomAD: T>A matched, T>G is the other allele
+        assert reasons[("gnomad", "frequency_identity_matched")] == 1
+        assert reasons[("gnomad", "frequency_other_allele")] == 1
+        # ClinGen: the named condition matched, the other curation is not named
+        assert reasons[("clingen", "condition_matched_by_mondo")] == 1
+        assert reasons[("clingen", "condition_not_named_by_assertion")] == 1
+        # The finding's supporting candidates are exactly the retained ones at the site
+        retained = {cid for cid in site["candidate_ids"] if candidates[cid]["decision"] == "retained"}
+        assert set(finding["candidate_ids"]) == retained and retained
+        assert all(candidates[cid]["finding_id"] == finding["finding_id"] for cid in retained)
+        rejected = [candidates[cid] for cid in site["candidate_ids"] if candidates[cid]["decision"] == "rejected"]
+        assert all(c["finding_id"] is None and c["identity"] for c in rejected)
+
+    def test_rejected_and_unresolved_candidates_keep_source_identity(self, db):
+        document = _export(db, [Variant("rs334", "11", 5227002, "TA")])
+        other_allele = next(c for c in document["matching"]["candidates"]
+                            if c["source"] == "clinvar" and c["reason"] == "genotype_allele_mismatch")
+        assert other_allele["identity"]["allele_id"] == "15334" and other_allele["identity"]["alt_allele"] == "G"
+        assert other_allele["decision"] == "unresolved" and other_allele["stage"] == "allele"
+        assert other_allele["note"].startswith("genotype TA does not match annotated alleles T/G")
+        assert "not shown" in other_allele["note"]
+        absent = _export(db, [Variant("rs600", "1", 600, "CC")], detailed=True)["matching"]["candidates"]
+        [c] = [c for c in absent if c["source"] == "clinvar"]
+        assert c["decision"] == "rejected" and c["reason"] == "allele_absent" and c["note"] == "no copy of T"
+        assert c["identity"]["allele_id"] == "600" and c["identity"]["position_vcf"] == 600
+        frequency = next(c for c in document["matching"]["candidates"] if c["reason"] == "frequency_other_allele")
+        assert frequency["identity"]["alt_allele"] == "G" and "T>G" in frequency["note"]
+
+
+class TestAmbiguousAndUnresolved:
+    def test_allele_not_recorded_is_unresolved(self, db):
+        document = _export(db, [Variant("rs500", "1", 500, "AG")])
+        [c] = [c for c in document["matching"]["candidates"] if c["source"] == "clinvar"]
+        assert c["decision"] == "unresolved" and c["reason"] == "allele_not_recorded"
+        assert document["findings"][0]["candidate_ids"] == []  # unresolved records do not support a finding
+
+    def test_strand_ambiguous_risk_allele(self, db):
+        db.insert_gwas_batch([_gwas("rs900", "G", study="Study E", pubmed="5")])
+        document = _export(db, [Variant("rs900", "1", 900, "CC")])
+        [c] = document["matching"]["candidates"]
+        assert (c["source"], c["decision"], c["reason"]) == ("gwas", "unresolved", "strand_ambiguous")
+        assert "may be on the opposite strand" in c["note"]
+
+    def test_opposite_strand_read_is_named_in_the_note(self, db):
+        document = _export(db, [Variant("rs334", "11", 5227002, "CC")], include_benign=True)
+        carried = [c for c in document["matching"]["candidates"]
+                   if c["source"] == "clinvar" and c["reason"] == "allele_carried"]
+        assert [c["note"] for c in carried] == ["2 copies of G (genotype read on the opposite strand)"]
+
+    def test_no_call_is_unresolved_across_sources(self, db):
+        document = _export(db, [Variant("rs334", "11", 5227002, "--")])
+        reasons = _by_reason(document["matching"]["candidates"])
+        assert reasons[("clinvar", "genotype_no_call")] == 3
+        assert reasons[("clinpgx", "genotype_unavailable")] == 3
+
+
+class TestBuildAndFilter:
+    def test_vcf_build_mismatch_is_an_identity_stage_decision(self, db):
+        evidence = VCFEvidence("A", ("G",), (0, 1), ("A", "G"), False, reference_declaration="GRCh37")
+        document = _export(db, [Variant("rs700", "1", 700, "AG", evidence)])
+        [c] = [c for c in document["matching"]["candidates"] if c["source"] == "clinvar"]
+        assert (c["decision"], c["stage"], c["reason"]) == ("unresolved", "identity", "build_mismatch")
+
+    def test_frequency_build_mismatch_is_rejected_with_its_identity(self, db):
+        # The fixture's second rs700 row (GRCh37) replaced the GRCh38 one: one extract is one assembly.
+        evidence = VCFEvidence("A", ("G",), (0, 1), ("A", "G"), False, reference_declaration="GRCh38")
+        document = _export(db, [Variant("rs700", "1", 700, "AG", evidence)])
+        [c] = [c for c in document["matching"]["candidates"] if c["source"] == "gnomad"]
+        assert (c["decision"], c["stage"], c["reason"]) == ("rejected", "frequency", "frequency_build_mismatch")
+        assert c["identity"]["assembly"] == "GRCh37" and c["identity"]["allele_frequency"] == 0.9
+        assert document["findings"][0]["candidate_ids"] and c["candidate_id"] not in document["findings"][0]["candidate_ids"]
+
+    def test_filter_failure_rejects_every_candidate_at_the_filter_stage(self, db):
+        evidence = VCFEvidence("T", ("A",), (0, 1), ("T", "A"), False, reference_declaration="GRCh38",
+                               filter_status="LowQual")
+        results, stats = analyze_variants_with_stats([Variant("rs334", "11", 5227002, "TA", evidence)], db)
+        assert results == [] and stats.dispositions["rs334"] == "failed_filter"
+        document = build_evidence_export(results, [Variant("rs334", "11", 5227002, "TA", evidence)], {}, stats=stats)
+        candidates = document["matching"]["candidates"]
+        assert candidates and all(c["stage"] == "filter" and c["reason"] == "vcf_filter_failed" for c in candidates)
+        assert {c["source"] for c in candidates} == {"clinvar", "gwas", "clinpgx", "gnomad"}
+        [site] = document["matching"]["sites"]
+        assert site["finding_id"] is None and site["disposition"] == "failed_filter"
+
+    def test_non_snp_vcf_record_marks_snp_paths_unsupported(self, db):
+        evidence = VCFEvidence("T", ("TA",), (0, 1), ("T", "TA"), False, reference_declaration="GRCh38")
+        results, stats = analyze_variants_with_stats([Variant("rs334", "11", 5227002, "TTA", evidence)], db)
+        reasons = Counter((c.source, c.reason) for c in stats.trace.candidates)
+        assert reasons[("gwas", "non_snp_unsupported")] == 3 and reasons[("clinpgx", "non_snp_unsupported")] == 3
+        clinvar = [c for c in stats.trace.candidates if c.source == "clinvar"]
+        assert Counter(c.reason for c in clinvar) == {"non_snp_unsupported": 3, "haplotype_row_superseded": 1}
+
+
+class TestReferenceOnlyAndCounts:
+    def test_reference_site_is_counted_but_listed_only_in_detail(self, db):
+        variants = [Variant("rs600", "1", 600, "CC"), Variant("rs334", "11", 5227002, "TA"), Variant("rs999", "1", 1, "AA")]
+        summary = _export(db, variants)
+        matching = summary["matching"]
+        [ref_site] = [s for s in matching["sites"] if s["rsid"] == "rs600"]
+        assert ref_site["disposition"] == "reference_or_no_applicable_annotation"
+        assert ref_site["finding_id"] is None and ref_site["candidates_listed"] is False
+        assert ref_site["candidate_ids"] is None and ref_site["counts"] == {"rejected": 2}
+        assert matching["candidate_count"] == matching["listed_candidate_count"] + ref_site["candidate_count"]
+        assert not any(c["rsid"] == "rs600" for c in matching["candidates"])
+        # rs999 has no reference record at all: no candidates, but it is in coverage
+        assert not any(s["rsid"] == "rs999" for s in matching["sites"])
+        assert any(row["rsid"] == "rs999" for row in summary["coverage"]["rows"])
+        detailed = _export(db, variants, detailed=True)["matching"]
+        assert detailed["detailed"] and detailed["listed_candidate_count"] == detailed["candidate_count"]
+        listed = [c for c in detailed["candidates"] if c["rsid"] == "rs600"]
+        assert {(c["source"], c["reason"]) for c in listed} == {("clinvar", "allele_absent"), ("gwas", "risk_allele_absent")}
+
+    def test_counts_are_records_not_rows_or_findings(self, db):
+        variants = [Variant("rs334", "11", 5227002, "TA"), Variant("rs334", "11", 5227002, "TA"),
+                    Variant("rs600", "1", 600, "CC")]
+        document = _export(db, variants)
+        matching, coverage = document["matching"], document["coverage"]
+        assert coverage["total_rows"] == 3 and coverage["returned_findings"] == 1
+        assert matching["sites_with_candidates"] == 2
+        assert matching["candidate_count"] == sum(matching["counts"].values()) > coverage["total_rows"]
+        assert sum(sum(v.values()) for v in matching["by_source"].values()) == matching["candidate_count"]
+        [site] = [s for s in matching["sites"] if s["rsid"] == "rs334"]
+        assert site["input_ids"] == ["input-1", "input-2"]
+
+    def test_retained_candidates_at_a_site_set_aside_later_have_no_finding(self, db):
+        db.insert_clinvar_batch([_clinvar("rs800", "G", "A", "Benign", chrom="1", pos=800, allele_id="800", gene="G5")])
+        document = _export(db, [Variant("rs800", "1", 800, "GA")])
+        assert document["findings"] == []
+        [site] = document["matching"]["sites"]
+        assert site["disposition"] == "rank_filtered" and site["finding_id"] is None
+        [c] = document["matching"]["candidates"]
+        assert c["decision"] == "retained" and c["finding_id"] is None
+
+
+class TestCrossSourceAndPaths:
+    def test_gwas_only_site_judged_on_its_own_risk_allele(self, db):
+        db.insert_gwas_batch([_gwas("rs900", "G", study="Study E", pubmed="5")])
+        document = _export(db, [Variant("rs900", "1", 900, "AG")])
+        [c] = document["matching"]["candidates"]
+        assert (c["source"], c["decision"], c["reason"]) == ("gwas", "retained", "risk_allele_carried")
+        assert document["findings"][0]["candidate_ids"] == [c["candidate_id"]]
+
+    def test_every_path_is_declared(self, db):
+        document = _export(db, [Variant("rs334", "11", 5227002, "TA")])
+        assert set(document["matching"]["paths"]) == {"clinvar", "gwas", "clinpgx", "gnomad", "clingen"} == set(PATHS)
+        assert all(text.startswith("traced") for text in document["matching"]["paths"].values())
+        assert "trace" not in document["analysis_stats"]
+        assert any("AI-generated" in line for line in document["matching"]["limitations"])
+
+    def test_reason_codes_are_stable_for_known_notes(self):
+        assert reason_from_note("VCF and ClinVar positions differ") == "position_mismatch"
+        assert reason_from_note("genotype AG does not match annotated alleles C/T") == "genotype_allele_mismatch"
+        assert reason_from_note("something new") == "unresolved_other"
+        assert reason_from_note(None) == "unresolved_other"


### PR DESCRIPTION
Stacked on #34 (base: `clinvar-context`), which is stacked on #33 and #32.

The evidence JSON gains a `matching` section: one decision per reference record considered for an input site, `retained`, `rejected`, or `unresolved`, with the stage (`filter`, `identity`, `allele`, `applicability`, `level`, `frequency`, `condition`), a structured reason code, the identity the source gave the record (ClinVar allele and variation IDs, assembly, chromosome, position, REF and ALT; GWAS study and risk allele; ClinPGx annotation and genotype; gnomAD alleles and assembly; ClinGen disease and MONDO id), a note, and a document-local `candidate_id`. Findings carry `candidate_ids` for the records that support them; each site lists its candidates, its input rows, its finding (or null), and its disposition, so a retained candidate at a site set aside by a later rule is explained rather than lost.

The decisions come from the existing matching functions, which append to the trace as they decide; nothing re-implements a match. `_select_clinvar_rows` records carried, absent, superseded haplotype rows, and every identity or allele abstention (the abstention notes map to stable codes such as `build_mismatch`, `position_mismatch`, `allele_not_recorded`, `strand_ambiguous`, `genotype_allele_mismatch`, `non_snp_unsupported`); `_gwas_call` records each association's risk-allele verdict, including strand inference and associations without a risk allele, or that the association rides on a ClinVar match; `_match_pgx` records the evidence-level threshold and genotype match per row; frequency records carry their identity verdict; ClinGen curations record whether the assertion names their MONDO identifier. VCF filter failures reject every candidate at the filter stage. `paths` in the section states what is traced for each source.

Counts are kept apart: `matching.candidate_count` is over records, `coverage` over input rows, `findings` over what was returned. On a whole-array file most annotated sites are reference genotype, so their candidates are counted but listed only with `allelio analyze --detailed-trace` (recorded in `configuration.detailed_trace`); the web export uses the default form. On the shipped example the default trace is 156 candidates (154 listed) and about 80 KB. The trace records Allelio's decisions only; AI text never enters it. `analysis_stats` is unchanged (the trace is exported as `matching`, not duplicated there).

Validation: full suite (764 passed); new `tests/test_matching_trace.py` reads the trace back through the export and covers a multiallelic site with two distinct records and a haplotype row, an allele ClinVar does not record, a strand-ambiguous risk allele, an opposite-strand read, no-calls, a VCF build mismatch at the identity stage, a frequency build mismatch, a filter failure, a non-SNP VCF record, a reference-only site (counted, listed only in detail), duplicate input rows, a retained candidate at a rank-filtered site, a GWAS-only site, and the path declarations. Docs: `docs/matching-trace.md`, evidence export, changelog.

Closes #25.