### PR TITLE
Publish and validate a machine-readable schema for evidence JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- A machine-readable JSON Schema (2020-12) for the evidence JSON ships in
+  the package (`allelio/schemas/evidence-1.0.json`, one file per minor
+  version, available from an installed wheel via `allelio.schema`). It
+  describes inputs, findings, every source record type, gene groups,
+  provenance, configuration, coverage, and the matching trace, with
+  required, optional, and null semantics stated per field; within a major
+  version fields are only added and unknown properties must be ignored.
+  `allelio validate-evidence FILE` (and `allelio.schema.validate_evidence`)
+  runs the schema plus the checks it cannot express: document-local
+  references resolve, ids are well formed and ordered, only retained
+  candidates support a finding, and coverage and candidate counts are
+  conserved. Errors name the JSON location and what was expected. Synthetic
+  valid and invalid fixtures, real CLI and web exports, empty results, and
+  a database without recorded releases are validated in tests, and the
+  schema's presence in a built wheel is checked (`docs/evidence-schema.md`).
+
 - Candidate-level matching trace in the evidence JSON (`matching`): one
   decision per reference record considered, retained, rejected, or
   unresolved, with the stage, a structured reason code, the identity the

--- a/README.md
+++ b/README.md
@@ -361,7 +361,9 @@ for research and education, without a claim of clinical validation.
 Structured evidence is available with `allelio analyze input.txt --no-ai
 --json-output evidence.json` or **Export Evidence JSON** in the web report.
 See the [versioned export contract](docs/evidence-export.md) for retained source
-fields, input evidence, and interpretation limits.
+fields, input evidence, and interpretation limits. A JSON Schema ships with the
+package and `allelio validate-evidence evidence.json` checks a file against it
+and the reference and count rules ([evidence schema](docs/evidence-schema.md)).
 
 Reports also show [input coverage and exclusions](docs/input-coverage.md),
 including no-calls, unsupported identifiers, duplicate conflicts, failed filters,

--- a/allelio/cli.py
+++ b/allelio/cli.py
@@ -789,6 +789,26 @@ def info(file: Optional[str]):
         raise click.Abort()
 
 
+@allelio.command("validate-evidence")
+@click.argument("file", type=click.Path(exists=True, dir_okay=False))
+def validate_evidence_command(file: str):
+    """Check an evidence JSON file against the shipped schema.
+
+    Reports every structural violation (JSON Schema 2020-12) and every
+    broken document-local reference or unconserved count, one per line, and
+    exits non-zero if there are any. Reads only the file named.
+    """
+    from allelio.schema import DEFAULT_SCHEMA_VERSION, validate_evidence_file
+
+    errors = validate_evidence_file(file)
+    if errors:
+        console.print(f"[bold red]✗[/bold red] {escape(file)}: {len(errors)} problem(s) against schema {DEFAULT_SCHEMA_VERSION}")
+        for line in errors:
+            console.print(f"  {escape(line)}")
+        raise SystemExit(1)
+    console.print(f"[bold green]✓[/bold green] {escape(file)} is valid evidence JSON (schema {DEFAULT_SCHEMA_VERSION})")
+
+
 main = allelio
 
 if __name__ == "__main__":

--- a/allelio/schema.py
+++ b/allelio/schema.py
@@ -1,0 +1,238 @@
+"""Validate an evidence JSON document against the shipped schema.
+
+The schema (``allelio/schemas/evidence-<major.minor>.json``, JSON Schema
+2020-12) is the structural contract. Two things it cannot say are checked
+here as well: that every document-local reference (``input_id``,
+``finding_id``, ``candidate_id``) points at something in the same document,
+and that the counts which must be conserved (coverage rows, candidate
+records, returned findings) add up. Every problem is reported as one line
+naming where it is and what was expected, so a consumer can act on it.
+"""
+
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:  # Python 3.9+: importlib.resources.files
+    from importlib.resources import files as _package_files
+except ImportError:  # pragma: no cover
+    _package_files = None
+
+SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema"
+SCHEMA_MAJOR = "1"
+DEFAULT_SCHEMA_VERSION = "1.0"
+
+_ID_PATTERNS = {
+    "input_id": re.compile(r"^input-[1-9][0-9]*$"),
+    "finding_id": re.compile(r"^finding-[1-9][0-9]*$"),
+    "candidate_id": re.compile(r"^candidate-[1-9][0-9]*$"),
+}
+
+
+def schema_path(version: str = DEFAULT_SCHEMA_VERSION) -> Path:
+    """Where the packaged schema for ``version`` lives (works from a wheel)."""
+    name = f"evidence-{version}.json"
+    if _package_files is not None:
+        resource = _package_files("allelio").joinpath("schemas").joinpath(name)
+        return Path(str(resource))
+    return Path(__file__).parent / "schemas" / name
+
+
+def load_schema(version: str = DEFAULT_SCHEMA_VERSION) -> Dict[str, Any]:
+    """The schema document for ``version``; raises FileNotFoundError if unshipped."""
+    return json.loads(schema_path(version).read_text(encoding="utf-8"))
+
+
+def schema_version_for(document: Dict[str, Any]) -> str:
+    """Which shipped schema a document should be checked against.
+
+    Minor versions are additive, so a document at 1.3 validates against the
+    newest shipped 1.x schema at or below it; here that is 1.0.
+    """
+    return DEFAULT_SCHEMA_VERSION
+
+
+def _structural_errors(document: Any, schema: Dict[str, Any]) -> List[str]:
+    """Schema violations as ``path: message`` lines, most general first."""
+    try:
+        import jsonschema
+    except ImportError:  # pragma: no cover - jsonschema is a declared dependency
+        return ["jsonschema is not installed; structural validation skipped (pip install jsonschema)"]
+    validator = jsonschema.Draft202012Validator(schema, format_checker=jsonschema.FormatChecker())
+    errors = []
+    for error in sorted(validator.iter_errors(document), key=lambda e: list(e.absolute_path)):
+        where = "/".join(str(p) for p in error.absolute_path) or "(document)"
+        errors.append(f"{where}: {error.message}")
+    return errors
+
+
+def _ids(items: Any, key: str) -> List[Any]:
+    return [item.get(key) for item in items if isinstance(item, dict)] if isinstance(items, list) else []
+
+
+def semantic_errors(document: Dict[str, Any]) -> List[str]:
+    """Reference and conservation checks JSON Schema alone cannot express.
+
+    Assumes the document is structurally valid enough to walk; anything
+    missing is skipped rather than reported twice.
+    """
+    errors: List[str] = []
+    if not isinstance(document, dict):
+        return ["(document): expected a JSON object"]
+
+    inputs = document.get("inputs") or []
+    findings = document.get("findings") or []
+    matching = document.get("matching") or {}
+    coverage = document.get("coverage") or {}
+
+    def check_ids(kind: str, values: List[Any], where: str, contiguous: bool) -> set:
+        """Ids are document-local: unique, well formed, ascending; contiguous where every one is listed."""
+        seen, previous = set(), 0
+        pattern = _ID_PATTERNS[kind]
+        for index, value in enumerate(values):
+            if not isinstance(value, str) or not pattern.match(value):
+                errors.append(f"{where}/{index}/{kind}: {value!r} is not a document-local {kind}")
+                continue
+            number = int(value.split("-")[1])
+            if contiguous and number != index + 1:
+                errors.append(f"{where}/{index}/{kind}: expected {kind.split('_')[0]}-{index + 1} (sequential), got {value!r}")
+            elif number <= previous:
+                errors.append(f"{where}/{index}/{kind}: {value!r} is out of order or duplicated")
+            if value in seen:
+                errors.append(f"{where}/{index}/{kind}: duplicate id {value!r}")
+            seen.add(value)
+            previous = number
+        return seen
+
+    input_ids = check_ids("input_id", _ids(inputs, "input_id"), "inputs", contiguous=True)
+    finding_ids = check_ids("finding_id", _ids(findings, "finding_id"), "findings", contiguous=True)
+    candidates = matching.get("candidates") or [] if isinstance(matching, dict) else []
+    # Candidate ids number every candidate considered, listed or not, so the
+    # listed ones are ascending but need not be contiguous.
+    candidate_ids = check_ids("candidate_id", _ids(candidates, "candidate_id"), "matching/candidates", contiguous=False)
+
+    def check_refs(values: Any, known: set, kind: str, where: str) -> None:
+        if not isinstance(values, list):
+            return
+        for value in values:
+            if value not in known:
+                errors.append(f"{where}: {kind} {value!r} does not exist in this document")
+
+    for index, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            continue
+        check_refs(finding.get("input_ids"), input_ids, "input_id", f"findings/{index}/input_ids")
+        rsids = {inp.get("rsid") for inp in inputs if isinstance(inp, dict) and inp.get("input_id") in set(finding.get("input_ids") or [])}
+        if rsids and rsids != {finding.get("rsid")}:
+            errors.append(f"findings/{index}/input_ids: referenced inputs carry rsIDs {sorted(rsids)}, finding is {finding.get('rsid')!r}")
+        if candidates:
+            check_refs(finding.get("candidate_ids"), candidate_ids, "candidate_id", f"findings/{index}/candidate_ids")
+            for cid in finding.get("candidate_ids") or []:
+                candidate = next((c for c in candidates if c.get("candidate_id") == cid), None)
+                if candidate and candidate.get("decision") != "retained":
+                    errors.append(f"findings/{index}/candidate_ids: {cid} is {candidate.get('decision')!r}, only retained candidates support a finding")
+    for index, group in enumerate(document.get("gene_groups") or []):
+        if isinstance(group, dict):
+            check_refs(group.get("finding_ids"), finding_ids, "finding_id", f"gene_groups/{index}/finding_ids")
+            if isinstance(group.get("indices"), list) and any(
+                not isinstance(i, int) or i < 0 or i >= len(findings) for i in group["indices"]
+            ):
+                errors.append(f"gene_groups/{index}/indices: index outside findings")
+            if isinstance(group.get("count"), int) and isinstance(group.get("finding_ids"), list) \
+                    and group["count"] != len(set(group["finding_ids"])):
+                errors.append(f"gene_groups/{index}/count: {group['count']} but {len(set(group['finding_ids']))} distinct finding_ids")
+
+    # Coverage: rows are conserved and the finding count is the findings array.
+    if isinstance(coverage, dict) and coverage:
+        rows = coverage.get("rows") or []
+        counts = coverage.get("counts") or {}
+        if isinstance(rows, list) and coverage.get("accounted_rows") != len(rows):
+            errors.append(f"coverage/accounted_rows: {coverage.get('accounted_rows')} but {len(rows)} rows listed")
+        if isinstance(counts, dict) and isinstance(rows, list):
+            observed = dict(Counter(r.get("status") for r in rows if isinstance(r, dict)))
+            if {k: v for k, v in counts.items()} != observed:
+                errors.append(f"coverage/counts: {counts} does not match the listed rows {observed}")
+        if isinstance(coverage.get("accounted_rows"), int) and isinstance(coverage.get("total_rows"), int) \
+                and coverage["accounted_rows"] > coverage["total_rows"]:
+            errors.append("coverage/accounted_rows: exceeds total_rows")
+        if coverage.get("returned_findings") != len(findings):
+            errors.append(f"coverage/returned_findings: {coverage.get('returned_findings')} but {len(findings)} findings")
+        complete = coverage.get("accounted_rows") == coverage.get("total_rows") and not (counts or {}).get("unaccounted")
+        if isinstance(coverage.get("complete"), bool) and coverage["complete"] != complete:
+            errors.append(f"coverage/complete: {coverage['complete']} but rows say {complete}")
+        for index, row in enumerate(rows if isinstance(rows, list) else []):
+            if isinstance(row, dict) and row.get("input_id") is not None and row["input_id"] not in input_ids:
+                errors.append(f"coverage/rows/{index}/input_id: {row['input_id']!r} does not exist in this document")
+
+    # Matching: candidate counts are conserved and sites reference what they list.
+    if isinstance(matching, dict) and matching:
+        counts = matching.get("counts") or {}
+        total = matching.get("candidate_count")
+        if isinstance(counts, dict) and sum(counts.values()) != total:
+            errors.append(f"matching/counts: sum {sum(counts.values())} but candidate_count {total}")
+        by_source = matching.get("by_source") or {}
+        if isinstance(by_source, dict) and sum(sum(v.values()) for v in by_source.values() if isinstance(v, dict)) != total:
+            errors.append("matching/by_source: does not sum to candidate_count")
+        if matching.get("listed_candidate_count") != len(candidates):
+            errors.append(f"matching/listed_candidate_count: {matching.get('listed_candidate_count')} but {len(candidates)} candidates listed")
+        sites = matching.get("sites") or []
+        if isinstance(sites, list):
+            if matching.get("sites_with_candidates") != len(sites):
+                errors.append(f"matching/sites_with_candidates: {matching.get('sites_with_candidates')} but {len(sites)} sites")
+            if sum(s.get("candidate_count", 0) for s in sites if isinstance(s, dict)) != total:
+                errors.append("matching/sites: candidate_count over sites does not sum to matching/candidate_count")
+            listed = 0
+            for index, site in enumerate(sites):
+                if not isinstance(site, dict):
+                    continue
+                check_refs(site.get("input_ids"), input_ids, "input_id", f"matching/sites/{index}/input_ids")
+                if site.get("finding_id") is not None and site["finding_id"] not in finding_ids:
+                    errors.append(f"matching/sites/{index}/finding_id: {site['finding_id']!r} does not exist in this document")
+                ids = site.get("candidate_ids")
+                if site.get("candidates_listed"):
+                    if not isinstance(ids, list):
+                        errors.append(f"matching/sites/{index}/candidate_ids: listed site must enumerate its candidates")
+                    else:
+                        listed += len(ids)
+                        check_refs(ids, candidate_ids, "candidate_id", f"matching/sites/{index}/candidate_ids")
+                        if len(ids) != site.get("candidate_count"):
+                            errors.append(f"matching/sites/{index}/candidate_count: {site.get('candidate_count')} but {len(ids)} candidate_ids")
+                elif ids is not None:
+                    errors.append(f"matching/sites/{index}/candidate_ids: must be null when candidates are not listed")
+            if listed != len(candidates):
+                errors.append(f"matching/sites: listed candidate_ids total {listed} but {len(candidates)} candidates")
+        for index, candidate in enumerate(candidates):
+            if isinstance(candidate, dict) and candidate.get("finding_id") is not None:
+                if candidate["finding_id"] not in finding_ids:
+                    errors.append(f"matching/candidates/{index}/finding_id: {candidate['finding_id']!r} does not exist in this document")
+                elif candidate.get("decision") != "retained":
+                    errors.append(f"matching/candidates/{index}/finding_id: a {candidate.get('decision')!r} candidate cannot support a finding")
+    return errors
+
+
+def validate_evidence(document: Any, schema: Optional[Dict[str, Any]] = None) -> List[str]:
+    """All problems with ``document``: structural first, then semantic.
+
+    Returns an empty list for a valid document. Each line names the JSON
+    location and what was expected.
+    """
+    if not isinstance(document, dict):
+        return ["(document): expected a JSON object"]
+    declared = str(document.get("schema_version", ""))
+    if declared.split(".")[0] != SCHEMA_MAJOR:
+        return [f"schema_version: {declared!r} is not a {SCHEMA_MAJOR}.x document; this validator ships schema {DEFAULT_SCHEMA_VERSION}"]
+    schema = schema or load_schema(schema_version_for(document))
+    errors = _structural_errors(document, schema)
+    errors.extend(semantic_errors(document))
+    return errors
+
+
+def validate_evidence_file(path: str) -> List[str]:
+    """Validate the JSON file at ``path``; a parse failure is one error line."""
+    try:
+        document = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return [f"{path}: not readable as JSON ({exc})"]
+    return validate_evidence(document)

--- a/allelio/schemas/evidence-1.0.json
+++ b/allelio/schemas/evidence-1.0.json
@@ -1,0 +1,1452 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/alexwbend/allelio/schemas/evidence-1.0.json",
+  "title": "Allelio structured evidence export",
+  "description": "Schema for the evidence JSON written by `allelio analyze --json-output` and the web Export Evidence JSON action, schema_version 1.x. Dialect: JSON Schema 2020-12. Compatibility: within a major version fields are only added, so objects allow additional properties and consumers must ignore unknown ones; a missing or null value means unavailable, never zero or false. input_id, finding_id and candidate_id are local to one document and are not VRS IDs or normalised genomic identifiers. AI-generated text is never part of this document. Cross-document references and conserved counts are checked by allelio.schema.validate_evidence, which JSON Schema alone cannot express.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "software",
+    "generated_at",
+    "configuration",
+    "provenance",
+    "inputs",
+    "findings",
+    "gene_groups",
+    "coverage",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+$",
+      "description": "Major.minor. Consumers check the major version."
+    },
+    "software": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "Allelio"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC, ISO 8601."
+    },
+    "configuration": {
+      "type": "object",
+      "properties": {
+        "include_benign": {
+          "type": "boolean"
+        },
+        "include_reference": {
+          "type": "boolean"
+        },
+        "traits_only": {
+          "type": "boolean"
+        },
+        "frequency_adjustment": {
+          "type": "boolean"
+        },
+        "detailed_trace": {
+          "type": "boolean"
+        }
+      },
+      "description": "Analysis options in force. Unknown options may appear; absent means default."
+    },
+    "provenance": {
+      "type": "object",
+      "description": "One entry per reference source, keyed by source id (clinvar, gwas, gnomad, clingen, clinpgx). All values null on a database built before provenance was recorded; release 'unavailable' means the source was not loaded.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "release": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "release_source": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sha256": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "description": "Any key absent from the source's metadata is null."
+      }
+    },
+    "inputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/input"
+      },
+      "description": "Every parsed observation, in input order."
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/finding"
+      },
+      "description": "Every returned finding, in display order; not limited by the AI explanation cap."
+    },
+    "gene_groups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/gene_group"
+      }
+    },
+    "analysis_stats": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "annotated_sites": {
+          "type": "integer"
+        },
+        "reference_genotype_sites": {
+          "type": "integer"
+        },
+        "zygosity_unknown_sites": {
+          "type": "integer"
+        },
+        "benign_sites": {
+          "type": "integer"
+        },
+        "vcf_filter_failed_sites": {
+          "type": "integer"
+        },
+        "duplicate_rows": {
+          "type": "integer"
+        },
+        "conflicting_input_sites": {
+          "type": "integer"
+        },
+        "dispositions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Final disposition per input identifier (rsID or unsupported id)."
+        }
+      },
+      "description": "Site counts of what was set aside. Null when no analysis statistics were available."
+    },
+    "coverage": {
+      "$ref": "#/$defs/coverage"
+    },
+    "matching": {
+      "$ref": "#/$defs/matching"
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "$defs": {
+    "input": {
+      "type": "object",
+      "properties": {
+        "input_id": {
+          "type": "string",
+          "pattern": "^input-[1-9][0-9]*$",
+          "description": "Document-local; input-N in input order."
+        },
+        "rsid": {
+          "type": "string"
+        },
+        "chromosome": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "position": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "genotype": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_line": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "1-based line in the source file when the parser recorded it."
+        },
+        "vcf_evidence": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "reference": {
+              "type": "string"
+            },
+            "alternates": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "allele_indices": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "alleles": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "phased": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "reference_declaration": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "phase_set": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "quality": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "filter_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "genotype_quality": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "depth": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "genotype_filter": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "reference",
+            "alternates",
+            "allele_indices",
+            "alleles"
+          ],
+          "description": "Original VCF record evidence. reference_declaration is the raw header value, not a certified assembly."
+        }
+      },
+      "required": [
+        "input_id",
+        "rsid"
+      ]
+    },
+    "finding": {
+      "type": "object",
+      "properties": {
+        "finding_id": {
+          "type": "string",
+          "pattern": "^finding-[1-9][0-9]*$",
+          "description": "Document-local; finding-N in display order."
+        },
+        "input_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^input-[1-9][0-9]*$",
+            "description": ""
+          },
+          "description": "Observations sharing this finding's rsID. Sharing an rsID does not verify build or allele equivalence."
+        },
+        "candidate_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^candidate-[1-9][0-9]*$",
+            "description": ""
+          },
+          "description": "Retained matching candidates that support this finding; empty when the trace is absent."
+        },
+        "rsid": {
+          "type": "string"
+        },
+        "chromosome": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "position": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "genotype": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "category": {
+          "type": "string"
+        },
+        "significance_rank": {
+          "type": "number",
+          "description": "Display priority only; lower shows first. Not a clinical score."
+        },
+        "zygosity": {
+          "type": "string"
+        },
+        "alt_copies": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "matched_allele": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strand_flipped": {
+          "type": "boolean"
+        },
+        "zygosity_note": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "allele_role": {
+          "type": "string",
+          "enum": [
+            "alternate",
+            "risk"
+          ]
+        },
+        "clinvar_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/clinvar_entry"
+          }
+        },
+        "gwas_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/gwas_entry"
+          }
+        },
+        "gnomad_entry": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/gnomad_entry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The matched frequency record, or the only record at the site flagged as context, or null."
+        },
+        "gnomad_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/gnomad_entry"
+          },
+          "description": "Every frequency record at the rsID with its identity verdict."
+        },
+        "clingen_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/clingen_entry"
+          }
+        },
+        "inheritance": {
+          "type": "string"
+        },
+        "inheritance_note": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "inheritance_resolution": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/inheritance_resolution"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pgx_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/pgx_entry"
+          }
+        }
+      },
+      "required": [
+        "finding_id",
+        "input_ids",
+        "rsid",
+        "category",
+        "significance_rank",
+        "zygosity",
+        "clinvar_entries",
+        "gwas_entries",
+        "inheritance"
+      ]
+    },
+    "clinvar_entry": {
+      "type": "object",
+      "properties": {
+        "rsid": {
+          "type": "string"
+        },
+        "gene": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "clinical_significance": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Source classification verbatim. See classification_type."
+        },
+        "classification_type": {
+          "type": "string",
+          "enum": [
+            "germline",
+            "unsplit",
+            "unknown"
+          ],
+          "description": "germline: aggregate germline classification (post-2024 file); unsplit: pre-split file mixing origins; unknown: legacy database."
+        },
+        "conditions": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "condition_ids": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "ClinVar PhenotypeIDS verbatim; '' when ClinVar gives none, null when not stored."
+        },
+        "review_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "review_stars": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4
+        },
+        "last_evaluated": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ref_allele": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "alt_allele": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assembly": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "chromosome": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "position_vcf": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "allele_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "variation_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "hgnc_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "origin": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "origin_simple": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rcv_accessions": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "number_submitters": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "variant_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "somatic_clinical_impact": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "somatic_review_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "somatic_last_evaluated": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "oncogenicity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "oncogenicity_review_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "oncogenicity_last_evaluated": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "allele_match": {
+          "type": "string",
+          "enum": [
+            "carried",
+            "unknown",
+            "absent"
+          ],
+          "description": "Whether this person carries the record's allele; separate from the classification."
+        },
+        "allele_match_note": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "display_rank": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Allelio's presentation rank for this row; separate from the classification."
+        },
+        "inheritance": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/inheritance_resolution"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "rsid",
+        "clinical_significance",
+        "classification_type",
+        "allele_match"
+      ]
+    },
+    "gwas_entry": {
+      "type": "object",
+      "properties": {
+        "rsid": {
+          "type": "string"
+        },
+        "trait": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "p_value": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "odds_ratio": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mapped_gene": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "study": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pubmed_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "risk_allele": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "rsid"
+      ]
+    },
+    "gnomad_entry": {
+      "type": "object",
+      "properties": {
+        "rsid": {
+          "type": "string"
+        },
+        "allele_frequency": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "af_popmax": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "ac": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "an": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "nhomalt": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "af_afr": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "af_eas": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "af_fin": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "af_nfe": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "af_sas": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "chromosome": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "position": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "ref_allele": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "alt_allele": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "assembly": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identity": {
+          "type": "string",
+          "enum": [
+            "matched",
+            "unverified",
+            "build_mismatch",
+            "position_mismatch",
+            "other_allele",
+            "alleles_swapped",
+            "orientation_reversed",
+            "allele_mismatch"
+          ],
+          "description": "Only 'matched' means the frequency describes the matched allele or affected ranking."
+        },
+        "identity_note": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "rsid",
+        "identity"
+      ]
+    },
+    "clingen_entry": {
+      "type": "object",
+      "properties": {
+        "gene": {
+          "type": "string"
+        },
+        "disease": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "moi": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "classification": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "report_url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mondo_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "gene"
+      ]
+    },
+    "condition_ref": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mondo_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identifiers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "identifiers"
+      ]
+    },
+    "inheritance_resolution": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "resolved",
+            "conflicting",
+            "unmapped",
+            "no_identifiers",
+            "identifiers_not_stored",
+            "not_established",
+            "not_curated"
+          ]
+        },
+        "inheritance": {
+          "type": "string"
+        },
+        "note": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "condition": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "condition_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "matched": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/clingen_entry"
+          }
+        },
+        "conditions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/condition_ref"
+          }
+        },
+        "unmatched_condition_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "gene_inheritance": {
+          "type": "string"
+        },
+        "gene_note": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mapping": {
+          "type": "object",
+          "properties": {
+            "method": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "method",
+            "version"
+          ]
+        }
+      },
+      "required": [
+        "status",
+        "inheritance",
+        "matched",
+        "conditions",
+        "gene_inheritance",
+        "mapping"
+      ]
+    },
+    "pgx_entry": {
+      "type": "object",
+      "properties": {
+        "rsid": {
+          "type": "string"
+        },
+        "annotation_id": {
+          "type": "string"
+        },
+        "gene": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "level": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "phenotype_category": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "drugs": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "phenotypes": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "genotype": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "annotation_text": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "allele_function": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strand_flipped": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "rsid",
+        "annotation_id"
+      ]
+    },
+    "gene_group": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "hgnc_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "gene": {
+          "type": "string"
+        },
+        "symbols": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "indices": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "count": {
+          "type": "integer"
+        },
+        "function": {
+          "type": "string"
+        },
+        "function_source": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "function_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "note": {
+          "type": "string"
+        },
+        "finding_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^finding-[1-9][0-9]*$",
+            "description": ""
+          }
+        }
+      },
+      "required": [
+        "key",
+        "gene",
+        "indices",
+        "count",
+        "finding_ids"
+      ]
+    },
+    "coverage": {
+      "type": "object",
+      "properties": {
+        "scope": {
+          "type": "string",
+          "enum": [
+            "input_data_rows",
+            "parsed_inputs_only"
+          ]
+        },
+        "total_rows": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "accounted_rows": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "counts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "rows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "line": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "input_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Absent or null for rows excluded at parsing."
+              },
+              "rsid": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          }
+        },
+        "returned_findings": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "complete": {
+          "type": "boolean"
+        },
+        "limitations": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "scope",
+        "total_rows",
+        "accounted_rows",
+        "counts",
+        "rows",
+        "returned_findings",
+        "complete"
+      ],
+      "description": "Conserved input-row accounting. Counts are over input rows, never a negative test."
+    },
+    "matching": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "const": "candidate-trace/1"
+        },
+        "candidate_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "counts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "by_source": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "sites_with_candidates": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "listed_candidate_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "detailed": {
+          "type": "boolean"
+        },
+        "paths": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "sites": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rsid": {
+                "type": "string"
+              },
+              "input_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^input-[1-9][0-9]*$",
+                  "description": ""
+                }
+              },
+              "finding_id": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "pattern": "^finding-[1-9][0-9]*$",
+                    "description": ""
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "disposition": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "candidate_count": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "counts": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "candidate_ids": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^candidate-[1-9][0-9]*$",
+                      "description": ""
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Null when the site's candidates are counted but not listed."
+              },
+              "candidates_listed": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "rsid",
+              "input_ids",
+              "candidate_count",
+              "counts",
+              "candidates_listed"
+            ]
+          }
+        },
+        "candidates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "candidate_id": {
+                "type": "string",
+                "pattern": "^candidate-[1-9][0-9]*$",
+                "description": "Document-local; candidate-N in decision order."
+              },
+              "rsid": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string",
+                "enum": [
+                  "clinvar",
+                  "gwas",
+                  "clinpgx",
+                  "gnomad",
+                  "clingen"
+                ]
+              },
+              "identity": {
+                "type": "object",
+                "description": "Whatever identity the source gave the record."
+              },
+              "decision": {
+                "type": "string",
+                "enum": [
+                  "retained",
+                  "rejected",
+                  "unresolved"
+                ]
+              },
+              "stage": {
+                "type": "string",
+                "enum": [
+                  "filter",
+                  "identity",
+                  "allele",
+                  "applicability",
+                  "level",
+                  "frequency",
+                  "condition"
+                ]
+              },
+              "reason": {
+                "type": "string",
+                "pattern": "^[a-z0-9_]+$"
+              },
+              "note": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "finding_id": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "pattern": "^finding-[1-9][0-9]*$",
+                    "description": ""
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "candidate_id",
+              "rsid",
+              "source",
+              "identity",
+              "decision",
+              "stage",
+              "reason"
+            ]
+          }
+        },
+        "limitations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "schema",
+        "candidate_count",
+        "counts",
+        "by_source",
+        "sites_with_candidates",
+        "listed_candidate_count",
+        "detailed",
+        "paths",
+        "sites",
+        "candidates"
+      ],
+      "description": "Candidate-level matching trace. Counts are over reference records, not rows or findings."
+    }
+  }
+}

--- a/docs/evidence-export.md
+++ b/docs/evidence-export.md
@@ -9,7 +9,10 @@ original input file.
 The top-level `schema_version` is `1.0`. Consumers must check the major version,
 accept additive fields, and treat missing/null values as unavailable. A major
 version change indicates incompatible field changes. JSON numbers are finite;
-non-finite source numbers become null. The document contains:
+non-finite source numbers become null. A JSON Schema (2020-12) for the document
+ships with the package, and `allelio validate-evidence evidence.json` checks a
+file against it plus the reference and count rules a schema cannot express; see
+[evidence schema](evidence-schema.md). The document contains:
 
 - `software`, `generated_at`, `configuration`, `provenance`: software version,
   UTC time, analysis filters, and reference-source versions available locally.

--- a/docs/evidence-schema.md
+++ b/docs/evidence-schema.md
@@ -1,0 +1,106 @@
+# Evidence JSON Schema
+
+The structured evidence export (`allelio analyze --json-output`, or **Export
+Evidence JSON** in the web interface) has a machine-readable contract that
+ships inside the package: `allelio/schemas/evidence-1.0.json`.
+
+## Dialect and version
+
+- Dialect: JSON Schema 2020-12 (`$schema` is
+  `https://json-schema.org/draft/2020-12/schema`).
+- One schema file per `schema_version` minor: `evidence-<major>.<minor>.json`.
+  The document's `schema_version` names the version it was written against.
+- The schema is available from an installed wheel:
+  `allelio.schema.load_schema()` returns it, `allelio.schema.schema_path()`
+  says where it is.
+
+## Compatibility policy
+
+Within a major version, fields are only added. Every object therefore allows
+additional properties, and a consumer must ignore properties it does not know.
+A field that is absent or `null` means unavailable, never zero, false, or
+"none found". Enumerations (`identity`, `allele_match`, `classification_type`,
+`decision`, `stage`, resolution `status`) may gain values in a minor version;
+consumers should treat an unknown value as "unknown", not as an error.
+Removing or retyping a field, or changing the meaning of an existing value, is
+a major version change, and the file name changes with it.
+
+A document at 1.x validates against the newest shipped 1.y schema with y at or
+below x; the fields it adds beyond that schema are accepted as additional
+properties.
+
+## What the schema describes
+
+`inputs` (parsed observations with optional VCF evidence), `findings` (every
+returned finding, mirroring `VariantResult`), the source record types (ClinVar,
+GWAS Catalog, gnomAD with its identity verdict, ClinGen, ClinPGx, and the
+condition-level inheritance resolution), `gene_groups`, `provenance`,
+`configuration`, `analysis_stats`, `coverage`, and `matching` (the candidate
+trace, when present). Required and optional fields and their null semantics
+are stated per object; `description` fields carry the meaning.
+
+`input_id`, `finding_id` and `candidate_id` are local to one document. They
+are indices, not identifiers: they are not VRS IDs, not normalised variant
+identifiers, and two documents may use the same id for different things. The
+genomic identity a record has is in its own fields (`assembly`, `chromosome`,
+`position_vcf`, `ref_allele`, `alt_allele`, `allele_id`, and so on), and a
+finding's `input_ids` links observations by rsID only, which verifies neither
+build nor allele equivalence.
+
+## Checks beyond JSON Schema
+
+`allelio.schema.validate_evidence(document)` runs the structural validation
+and then the checks a schema cannot express:
+
+- Every `input_ids`, `finding_ids`, `finding_id`, and `candidate_ids`
+  reference resolves inside the document; ids are well formed, unique, and
+  ascending (`input-N` and `finding-N` contiguous; `candidate-N` ascending,
+  since candidates at unlisted sites keep their number).
+- A finding's referenced inputs share its rsID; only retained candidates
+  support a finding; a rejected or unresolved candidate carries no
+  `finding_id`.
+- Gene group `indices` fall inside `findings` and `count` matches its
+  distinct `finding_ids`.
+- Coverage is conserved: `accounted_rows` equals the rows listed, `counts`
+  equals the tally of listed row statuses, `accounted_rows` never exceeds
+  `total_rows`, `returned_findings` equals the number of findings, and
+  `complete` follows from the counts.
+- Matching is conserved: `counts` and `by_source` sum to `candidate_count`,
+  site `candidate_count`s sum to it, `listed_candidate_count` equals the
+  candidates listed, a listed site enumerates exactly its candidates and an
+  unlisted site's `candidate_ids` is null.
+
+Every problem is one line naming the JSON location and what was expected, for
+example `findings/0/input_ids: input_id 'input-9' does not exist in this
+document`.
+
+## Using it
+
+```bash
+allelio validate-evidence evidence.json
+```
+
+exits 0 when the file is valid and 1 with one line per problem otherwise. From
+Python:
+
+```python
+from allelio.schema import validate_evidence_file
+problems = validate_evidence_file("evidence.json")   # [] when valid
+```
+
+Other validators can load `allelio/schemas/evidence-1.0.json` directly for the
+structural part; the reference and count checks above are Allelio's own.
+
+## Fixtures
+
+`tests/fixtures/evidence_schema/` holds small synthetic documents: a minimal
+valid one (no inputs, no findings), a small valid one with a finding and a
+matching trace, and invalid ones for a missing required section, a wrong
+type, an unknown enumeration value, a dangling reference, unconserved
+coverage counts, a finding supported by a rejected candidate, and a wrong
+major version. `tests/test_evidence_schema.py` validates real CLI and web
+exports (including empty results and a database without recorded releases),
+each fixture, and the schema's presence in a built wheel.
+
+This schema describes Allelio's export. It does not claim conformance to
+GA4GH VRS, Phenopackets, or any other genomic standard.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "aiofiles>=23.2.0",
     "rich>=13.0.0",
     "python-multipart>=0.0.6",
+    "jsonschema>=4.17",  # validates evidence JSON against the shipped schema (allelio/schemas)
 ]
 
 [project.optional-dependencies]
@@ -61,5 +62,7 @@ include = ["allelio*"]
 # with the package. Without this, a wheel install builds fine and `allelio
 # serve` starts fine, then every page load 500s on a missing template —
 # invisible from a source checkout, broken for everyone who pip-installs.
+# The evidence JSON Schema ships with the package too, so an installed wheel
+# can validate an export (allelio.schema.load_schema, allelio validate-evidence).
 [tool.setuptools.package-data]
-allelio = ["web/templates/*.html"]
+allelio = ["web/templates/*.html", "schemas/*.json"]

--- a/tests/fixtures/evidence_schema/invalid_candidate_support.json
+++ b/tests/fixtures/evidence_schema/invalid_candidate_support.json
@@ -1,0 +1,222 @@
+{
+  "schema_version": "1.0",
+  "software": {
+    "name": "Allelio",
+    "version": "0.3.0"
+  },
+  "generated_at": "2026-09-12T00:00:00+00:00",
+  "configuration": {
+    "include_benign": false,
+    "detailed_trace": false
+  },
+  "provenance": {
+    "clinvar": {
+      "label": "ClinVar",
+      "release": null,
+      "release_source": null,
+      "url": null,
+      "sha256": null
+    }
+  },
+  "inputs": [
+    {
+      "input_id": "input-1",
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "vcf_evidence": null,
+      "source_line": 2
+    }
+  ],
+  "findings": [
+    {
+      "finding_id": "finding-1",
+      "input_ids": [
+        "input-1"
+      ],
+      "candidate_ids": [
+        "candidate-2"
+      ],
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "category": "Health Conditions",
+      "significance_rank": 0.6,
+      "zygosity": "heterozygous",
+      "alt_copies": 1,
+      "matched_allele": "G",
+      "strand_flipped": false,
+      "zygosity_note": null,
+      "allele_role": "alternate",
+      "clinvar_entries": [
+        {
+          "rsid": "rs1",
+          "gene": "GENE",
+          "clinical_significance": "Pathogenic",
+          "classification_type": "germline",
+          "conditions": "Cond",
+          "condition_ids": "MONDO:MONDO:0000001",
+          "review_status": "practice guideline",
+          "review_stars": 4,
+          "ref_allele": "A",
+          "alt_allele": "G",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "allele_id": "1",
+          "variation_id": "2",
+          "hgnc_id": "HGNC:1",
+          "allele_match": "carried",
+          "allele_match_note": "1 copy of G",
+          "display_rank": 0.6,
+          "inheritance": null
+        }
+      ],
+      "gwas_entries": [],
+      "gnomad_entry": null,
+      "gnomad_entries": [],
+      "clingen_entries": [],
+      "inheritance": "not curated",
+      "inheritance_note": null,
+      "inheritance_resolution": null,
+      "pgx_entries": []
+    }
+  ],
+  "gene_groups": [
+    {
+      "key": "HGNC:1",
+      "hgnc_id": "HGNC:1",
+      "gene": "GENE",
+      "symbols": [
+        "GENE"
+      ],
+      "indices": [
+        0
+      ],
+      "count": 1,
+      "function": "A sourced function summary is not available in this release.",
+      "function_source": null,
+      "function_version": null,
+      "note": "",
+      "finding_ids": [
+        "finding-1"
+      ]
+    }
+  ],
+  "analysis_stats": {
+    "annotated_sites": 1,
+    "reference_genotype_sites": 0,
+    "zygosity_unknown_sites": 0,
+    "benign_sites": 0,
+    "vcf_filter_failed_sites": 0,
+    "dispositions": {
+      "rs1": "reported"
+    },
+    "duplicate_rows": 0,
+    "conflicting_input_sites": 0
+  },
+  "coverage": {
+    "scope": "parsed_inputs_only",
+    "total_rows": 1,
+    "accounted_rows": 1,
+    "counts": {
+      "reported": 1
+    },
+    "rows": [
+      {
+        "line": 2,
+        "input_id": "input-1",
+        "rsid": "rs1",
+        "status": "reported"
+      }
+    ],
+    "returned_findings": 1,
+    "complete": true,
+    "limitations": "Rows absent from the input cannot be counted."
+  },
+  "limitations": [
+    "Research and education only; not a clinical interpretation."
+  ],
+  "matching": {
+    "schema": "candidate-trace/1",
+    "candidate_count": 2,
+    "counts": {
+      "rejected": 1,
+      "retained": 1
+    },
+    "by_source": {
+      "clinvar": {
+        "retained": 1
+      },
+      "gnomad": {
+        "rejected": 1
+      }
+    },
+    "sites_with_candidates": 1,
+    "listed_candidate_count": 2,
+    "detailed": false,
+    "paths": {
+      "clinvar": "traced"
+    },
+    "sites": [
+      {
+        "rsid": "rs1",
+        "input_ids": [
+          "input-1"
+        ],
+        "finding_id": "finding-1",
+        "disposition": "reported",
+        "candidate_count": 2,
+        "counts": {
+          "rejected": 1,
+          "retained": 1
+        },
+        "candidate_ids": [
+          "candidate-1",
+          "candidate-2"
+        ],
+        "candidates_listed": true
+      }
+    ],
+    "candidates": [
+      {
+        "candidate_id": "candidate-1",
+        "rsid": "rs1",
+        "source": "clinvar",
+        "identity": {
+          "allele_id": "1",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "retained",
+        "stage": "allele",
+        "reason": "allele_carried",
+        "note": "1 copy of G",
+        "finding_id": "finding-1"
+      },
+      {
+        "candidate_id": "candidate-2",
+        "rsid": "rs1",
+        "source": "gnomad",
+        "identity": {
+          "assembly": "GRCh37",
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "rejected",
+        "stage": "frequency",
+        "reason": "frequency_build_mismatch",
+        "note": "GRCh37 record",
+        "finding_id": null
+      }
+    ],
+    "limitations": [
+      "Candidate counts are over reference records considered."
+    ]
+  }
+}

--- a/tests/fixtures/evidence_schema/invalid_coverage_counts.json
+++ b/tests/fixtures/evidence_schema/invalid_coverage_counts.json
@@ -1,0 +1,222 @@
+{
+  "schema_version": "1.0",
+  "software": {
+    "name": "Allelio",
+    "version": "0.3.0"
+  },
+  "generated_at": "2026-09-12T00:00:00+00:00",
+  "configuration": {
+    "include_benign": false,
+    "detailed_trace": false
+  },
+  "provenance": {
+    "clinvar": {
+      "label": "ClinVar",
+      "release": null,
+      "release_source": null,
+      "url": null,
+      "sha256": null
+    }
+  },
+  "inputs": [
+    {
+      "input_id": "input-1",
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "vcf_evidence": null,
+      "source_line": 2
+    }
+  ],
+  "findings": [
+    {
+      "finding_id": "finding-1",
+      "input_ids": [
+        "input-1"
+      ],
+      "candidate_ids": [
+        "candidate-1"
+      ],
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "category": "Health Conditions",
+      "significance_rank": 0.6,
+      "zygosity": "heterozygous",
+      "alt_copies": 1,
+      "matched_allele": "G",
+      "strand_flipped": false,
+      "zygosity_note": null,
+      "allele_role": "alternate",
+      "clinvar_entries": [
+        {
+          "rsid": "rs1",
+          "gene": "GENE",
+          "clinical_significance": "Pathogenic",
+          "classification_type": "germline",
+          "conditions": "Cond",
+          "condition_ids": "MONDO:MONDO:0000001",
+          "review_status": "practice guideline",
+          "review_stars": 4,
+          "ref_allele": "A",
+          "alt_allele": "G",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "allele_id": "1",
+          "variation_id": "2",
+          "hgnc_id": "HGNC:1",
+          "allele_match": "carried",
+          "allele_match_note": "1 copy of G",
+          "display_rank": 0.6,
+          "inheritance": null
+        }
+      ],
+      "gwas_entries": [],
+      "gnomad_entry": null,
+      "gnomad_entries": [],
+      "clingen_entries": [],
+      "inheritance": "not curated",
+      "inheritance_note": null,
+      "inheritance_resolution": null,
+      "pgx_entries": []
+    }
+  ],
+  "gene_groups": [
+    {
+      "key": "HGNC:1",
+      "hgnc_id": "HGNC:1",
+      "gene": "GENE",
+      "symbols": [
+        "GENE"
+      ],
+      "indices": [
+        0
+      ],
+      "count": 1,
+      "function": "A sourced function summary is not available in this release.",
+      "function_source": null,
+      "function_version": null,
+      "note": "",
+      "finding_ids": [
+        "finding-1"
+      ]
+    }
+  ],
+  "analysis_stats": {
+    "annotated_sites": 1,
+    "reference_genotype_sites": 0,
+    "zygosity_unknown_sites": 0,
+    "benign_sites": 0,
+    "vcf_filter_failed_sites": 0,
+    "dispositions": {
+      "rs1": "reported"
+    },
+    "duplicate_rows": 0,
+    "conflicting_input_sites": 0
+  },
+  "coverage": {
+    "scope": "parsed_inputs_only",
+    "total_rows": 1,
+    "accounted_rows": 1,
+    "counts": {
+      "reported": 2
+    },
+    "rows": [
+      {
+        "line": 2,
+        "input_id": "input-1",
+        "rsid": "rs1",
+        "status": "reported"
+      }
+    ],
+    "returned_findings": 1,
+    "complete": true,
+    "limitations": "Rows absent from the input cannot be counted."
+  },
+  "limitations": [
+    "Research and education only; not a clinical interpretation."
+  ],
+  "matching": {
+    "schema": "candidate-trace/1",
+    "candidate_count": 2,
+    "counts": {
+      "rejected": 1,
+      "retained": 1
+    },
+    "by_source": {
+      "clinvar": {
+        "retained": 1
+      },
+      "gnomad": {
+        "rejected": 1
+      }
+    },
+    "sites_with_candidates": 1,
+    "listed_candidate_count": 2,
+    "detailed": false,
+    "paths": {
+      "clinvar": "traced"
+    },
+    "sites": [
+      {
+        "rsid": "rs1",
+        "input_ids": [
+          "input-1"
+        ],
+        "finding_id": "finding-1",
+        "disposition": "reported",
+        "candidate_count": 2,
+        "counts": {
+          "rejected": 1,
+          "retained": 1
+        },
+        "candidate_ids": [
+          "candidate-1",
+          "candidate-2"
+        ],
+        "candidates_listed": true
+      }
+    ],
+    "candidates": [
+      {
+        "candidate_id": "candidate-1",
+        "rsid": "rs1",
+        "source": "clinvar",
+        "identity": {
+          "allele_id": "1",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "retained",
+        "stage": "allele",
+        "reason": "allele_carried",
+        "note": "1 copy of G",
+        "finding_id": "finding-1"
+      },
+      {
+        "candidate_id": "candidate-2",
+        "rsid": "rs1",
+        "source": "gnomad",
+        "identity": {
+          "assembly": "GRCh37",
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "rejected",
+        "stage": "frequency",
+        "reason": "frequency_build_mismatch",
+        "note": "GRCh37 record",
+        "finding_id": null
+      }
+    ],
+    "limitations": [
+      "Candidate counts are over reference records considered."
+    ]
+  }
+}

--- a/tests/fixtures/evidence_schema/invalid_dangling_reference.json
+++ b/tests/fixtures/evidence_schema/invalid_dangling_reference.json
@@ -1,0 +1,222 @@
+{
+  "schema_version": "1.0",
+  "software": {
+    "name": "Allelio",
+    "version": "0.3.0"
+  },
+  "generated_at": "2026-09-12T00:00:00+00:00",
+  "configuration": {
+    "include_benign": false,
+    "detailed_trace": false
+  },
+  "provenance": {
+    "clinvar": {
+      "label": "ClinVar",
+      "release": null,
+      "release_source": null,
+      "url": null,
+      "sha256": null
+    }
+  },
+  "inputs": [
+    {
+      "input_id": "input-1",
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "vcf_evidence": null,
+      "source_line": 2
+    }
+  ],
+  "findings": [
+    {
+      "finding_id": "finding-1",
+      "input_ids": [
+        "input-9"
+      ],
+      "candidate_ids": [
+        "candidate-1"
+      ],
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "category": "Health Conditions",
+      "significance_rank": 0.6,
+      "zygosity": "heterozygous",
+      "alt_copies": 1,
+      "matched_allele": "G",
+      "strand_flipped": false,
+      "zygosity_note": null,
+      "allele_role": "alternate",
+      "clinvar_entries": [
+        {
+          "rsid": "rs1",
+          "gene": "GENE",
+          "clinical_significance": "Pathogenic",
+          "classification_type": "germline",
+          "conditions": "Cond",
+          "condition_ids": "MONDO:MONDO:0000001",
+          "review_status": "practice guideline",
+          "review_stars": 4,
+          "ref_allele": "A",
+          "alt_allele": "G",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "allele_id": "1",
+          "variation_id": "2",
+          "hgnc_id": "HGNC:1",
+          "allele_match": "carried",
+          "allele_match_note": "1 copy of G",
+          "display_rank": 0.6,
+          "inheritance": null
+        }
+      ],
+      "gwas_entries": [],
+      "gnomad_entry": null,
+      "gnomad_entries": [],
+      "clingen_entries": [],
+      "inheritance": "not curated",
+      "inheritance_note": null,
+      "inheritance_resolution": null,
+      "pgx_entries": []
+    }
+  ],
+  "gene_groups": [
+    {
+      "key": "HGNC:1",
+      "hgnc_id": "HGNC:1",
+      "gene": "GENE",
+      "symbols": [
+        "GENE"
+      ],
+      "indices": [
+        0
+      ],
+      "count": 1,
+      "function": "A sourced function summary is not available in this release.",
+      "function_source": null,
+      "function_version": null,
+      "note": "",
+      "finding_ids": [
+        "finding-1"
+      ]
+    }
+  ],
+  "analysis_stats": {
+    "annotated_sites": 1,
+    "reference_genotype_sites": 0,
+    "zygosity_unknown_sites": 0,
+    "benign_sites": 0,
+    "vcf_filter_failed_sites": 0,
+    "dispositions": {
+      "rs1": "reported"
+    },
+    "duplicate_rows": 0,
+    "conflicting_input_sites": 0
+  },
+  "coverage": {
+    "scope": "parsed_inputs_only",
+    "total_rows": 1,
+    "accounted_rows": 1,
+    "counts": {
+      "reported": 1
+    },
+    "rows": [
+      {
+        "line": 2,
+        "input_id": "input-1",
+        "rsid": "rs1",
+        "status": "reported"
+      }
+    ],
+    "returned_findings": 1,
+    "complete": true,
+    "limitations": "Rows absent from the input cannot be counted."
+  },
+  "limitations": [
+    "Research and education only; not a clinical interpretation."
+  ],
+  "matching": {
+    "schema": "candidate-trace/1",
+    "candidate_count": 2,
+    "counts": {
+      "rejected": 1,
+      "retained": 1
+    },
+    "by_source": {
+      "clinvar": {
+        "retained": 1
+      },
+      "gnomad": {
+        "rejected": 1
+      }
+    },
+    "sites_with_candidates": 1,
+    "listed_candidate_count": 2,
+    "detailed": false,
+    "paths": {
+      "clinvar": "traced"
+    },
+    "sites": [
+      {
+        "rsid": "rs1",
+        "input_ids": [
+          "input-1"
+        ],
+        "finding_id": "finding-1",
+        "disposition": "reported",
+        "candidate_count": 2,
+        "counts": {
+          "rejected": 1,
+          "retained": 1
+        },
+        "candidate_ids": [
+          "candidate-1",
+          "candidate-2"
+        ],
+        "candidates_listed": true
+      }
+    ],
+    "candidates": [
+      {
+        "candidate_id": "candidate-1",
+        "rsid": "rs1",
+        "source": "clinvar",
+        "identity": {
+          "allele_id": "1",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "retained",
+        "stage": "allele",
+        "reason": "allele_carried",
+        "note": "1 copy of G",
+        "finding_id": "finding-1"
+      },
+      {
+        "candidate_id": "candidate-2",
+        "rsid": "rs1",
+        "source": "gnomad",
+        "identity": {
+          "assembly": "GRCh37",
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "rejected",
+        "stage": "frequency",
+        "reason": "frequency_build_mismatch",
+        "note": "GRCh37 record",
+        "finding_id": null
+      }
+    ],
+    "limitations": [
+      "Candidate counts are over reference records considered."
+    ]
+  }
+}

--- a/tests/fixtures/evidence_schema/invalid_major_version.json
+++ b/tests/fixtures/evidence_schema/invalid_major_version.json
@@ -1,0 +1,222 @@
+{
+  "schema_version": "2.0",
+  "software": {
+    "name": "Allelio",
+    "version": "0.3.0"
+  },
+  "generated_at": "2026-09-12T00:00:00+00:00",
+  "configuration": {
+    "include_benign": false,
+    "detailed_trace": false
+  },
+  "provenance": {
+    "clinvar": {
+      "label": "ClinVar",
+      "release": null,
+      "release_source": null,
+      "url": null,
+      "sha256": null
+    }
+  },
+  "inputs": [
+    {
+      "input_id": "input-1",
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "vcf_evidence": null,
+      "source_line": 2
+    }
+  ],
+  "findings": [
+    {
+      "finding_id": "finding-1",
+      "input_ids": [
+        "input-1"
+      ],
+      "candidate_ids": [
+        "candidate-1"
+      ],
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "category": "Health Conditions",
+      "significance_rank": 0.6,
+      "zygosity": "heterozygous",
+      "alt_copies": 1,
+      "matched_allele": "G",
+      "strand_flipped": false,
+      "zygosity_note": null,
+      "allele_role": "alternate",
+      "clinvar_entries": [
+        {
+          "rsid": "rs1",
+          "gene": "GENE",
+          "clinical_significance": "Pathogenic",
+          "classification_type": "germline",
+          "conditions": "Cond",
+          "condition_ids": "MONDO:MONDO:0000001",
+          "review_status": "practice guideline",
+          "review_stars": 4,
+          "ref_allele": "A",
+          "alt_allele": "G",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "allele_id": "1",
+          "variation_id": "2",
+          "hgnc_id": "HGNC:1",
+          "allele_match": "carried",
+          "allele_match_note": "1 copy of G",
+          "display_rank": 0.6,
+          "inheritance": null
+        }
+      ],
+      "gwas_entries": [],
+      "gnomad_entry": null,
+      "gnomad_entries": [],
+      "clingen_entries": [],
+      "inheritance": "not curated",
+      "inheritance_note": null,
+      "inheritance_resolution": null,
+      "pgx_entries": []
+    }
+  ],
+  "gene_groups": [
+    {
+      "key": "HGNC:1",
+      "hgnc_id": "HGNC:1",
+      "gene": "GENE",
+      "symbols": [
+        "GENE"
+      ],
+      "indices": [
+        0
+      ],
+      "count": 1,
+      "function": "A sourced function summary is not available in this release.",
+      "function_source": null,
+      "function_version": null,
+      "note": "",
+      "finding_ids": [
+        "finding-1"
+      ]
+    }
+  ],
+  "analysis_stats": {
+    "annotated_sites": 1,
+    "reference_genotype_sites": 0,
+    "zygosity_unknown_sites": 0,
+    "benign_sites": 0,
+    "vcf_filter_failed_sites": 0,
+    "dispositions": {
+      "rs1": "reported"
+    },
+    "duplicate_rows": 0,
+    "conflicting_input_sites": 0
+  },
+  "coverage": {
+    "scope": "parsed_inputs_only",
+    "total_rows": 1,
+    "accounted_rows": 1,
+    "counts": {
+      "reported": 1
+    },
+    "rows": [
+      {
+        "line": 2,
+        "input_id": "input-1",
+        "rsid": "rs1",
+        "status": "reported"
+      }
+    ],
+    "returned_findings": 1,
+    "complete": true,
+    "limitations": "Rows absent from the input cannot be counted."
+  },
+  "limitations": [
+    "Research and education only; not a clinical interpretation."
+  ],
+  "matching": {
+    "schema": "candidate-trace/1",
+    "candidate_count": 2,
+    "counts": {
+      "rejected": 1,
+      "retained": 1
+    },
+    "by_source": {
+      "clinvar": {
+        "retained": 1
+      },
+      "gnomad": {
+        "rejected": 1
+      }
+    },
+    "sites_with_candidates": 1,
+    "listed_candidate_count": 2,
+    "detailed": false,
+    "paths": {
+      "clinvar": "traced"
+    },
+    "sites": [
+      {
+        "rsid": "rs1",
+        "input_ids": [
+          "input-1"
+        ],
+        "finding_id": "finding-1",
+        "disposition": "reported",
+        "candidate_count": 2,
+        "counts": {
+          "rejected": 1,
+          "retained": 1
+        },
+        "candidate_ids": [
+          "candidate-1",
+          "candidate-2"
+        ],
+        "candidates_listed": true
+      }
+    ],
+    "candidates": [
+      {
+        "candidate_id": "candidate-1",
+        "rsid": "rs1",
+        "source": "clinvar",
+        "identity": {
+          "allele_id": "1",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "retained",
+        "stage": "allele",
+        "reason": "allele_carried",
+        "note": "1 copy of G",
+        "finding_id": "finding-1"
+      },
+      {
+        "candidate_id": "candidate-2",
+        "rsid": "rs1",
+        "source": "gnomad",
+        "identity": {
+          "assembly": "GRCh37",
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "rejected",
+        "stage": "frequency",
+        "reason": "frequency_build_mismatch",
+        "note": "GRCh37 record",
+        "finding_id": null
+      }
+    ],
+    "limitations": [
+      "Candidate counts are over reference records considered."
+    ]
+  }
+}

--- a/tests/fixtures/evidence_schema/invalid_missing_required.json
+++ b/tests/fixtures/evidence_schema/invalid_missing_required.json
@@ -1,0 +1,203 @@
+{
+  "schema_version": "1.0",
+  "software": {
+    "name": "Allelio",
+    "version": "0.3.0"
+  },
+  "generated_at": "2026-09-12T00:00:00+00:00",
+  "configuration": {
+    "include_benign": false,
+    "detailed_trace": false
+  },
+  "provenance": {
+    "clinvar": {
+      "label": "ClinVar",
+      "release": null,
+      "release_source": null,
+      "url": null,
+      "sha256": null
+    }
+  },
+  "inputs": [
+    {
+      "input_id": "input-1",
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "vcf_evidence": null,
+      "source_line": 2
+    }
+  ],
+  "findings": [
+    {
+      "finding_id": "finding-1",
+      "input_ids": [
+        "input-1"
+      ],
+      "candidate_ids": [
+        "candidate-1"
+      ],
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "category": "Health Conditions",
+      "significance_rank": 0.6,
+      "zygosity": "heterozygous",
+      "alt_copies": 1,
+      "matched_allele": "G",
+      "strand_flipped": false,
+      "zygosity_note": null,
+      "allele_role": "alternate",
+      "clinvar_entries": [
+        {
+          "rsid": "rs1",
+          "gene": "GENE",
+          "clinical_significance": "Pathogenic",
+          "classification_type": "germline",
+          "conditions": "Cond",
+          "condition_ids": "MONDO:MONDO:0000001",
+          "review_status": "practice guideline",
+          "review_stars": 4,
+          "ref_allele": "A",
+          "alt_allele": "G",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "allele_id": "1",
+          "variation_id": "2",
+          "hgnc_id": "HGNC:1",
+          "allele_match": "carried",
+          "allele_match_note": "1 copy of G",
+          "display_rank": 0.6,
+          "inheritance": null
+        }
+      ],
+      "gwas_entries": [],
+      "gnomad_entry": null,
+      "gnomad_entries": [],
+      "clingen_entries": [],
+      "inheritance": "not curated",
+      "inheritance_note": null,
+      "inheritance_resolution": null,
+      "pgx_entries": []
+    }
+  ],
+  "gene_groups": [
+    {
+      "key": "HGNC:1",
+      "hgnc_id": "HGNC:1",
+      "gene": "GENE",
+      "symbols": [
+        "GENE"
+      ],
+      "indices": [
+        0
+      ],
+      "count": 1,
+      "function": "A sourced function summary is not available in this release.",
+      "function_source": null,
+      "function_version": null,
+      "note": "",
+      "finding_ids": [
+        "finding-1"
+      ]
+    }
+  ],
+  "analysis_stats": {
+    "annotated_sites": 1,
+    "reference_genotype_sites": 0,
+    "zygosity_unknown_sites": 0,
+    "benign_sites": 0,
+    "vcf_filter_failed_sites": 0,
+    "dispositions": {
+      "rs1": "reported"
+    },
+    "duplicate_rows": 0,
+    "conflicting_input_sites": 0
+  },
+  "limitations": [
+    "Research and education only; not a clinical interpretation."
+  ],
+  "matching": {
+    "schema": "candidate-trace/1",
+    "candidate_count": 2,
+    "counts": {
+      "rejected": 1,
+      "retained": 1
+    },
+    "by_source": {
+      "clinvar": {
+        "retained": 1
+      },
+      "gnomad": {
+        "rejected": 1
+      }
+    },
+    "sites_with_candidates": 1,
+    "listed_candidate_count": 2,
+    "detailed": false,
+    "paths": {
+      "clinvar": "traced"
+    },
+    "sites": [
+      {
+        "rsid": "rs1",
+        "input_ids": [
+          "input-1"
+        ],
+        "finding_id": "finding-1",
+        "disposition": "reported",
+        "candidate_count": 2,
+        "counts": {
+          "rejected": 1,
+          "retained": 1
+        },
+        "candidate_ids": [
+          "candidate-1",
+          "candidate-2"
+        ],
+        "candidates_listed": true
+      }
+    ],
+    "candidates": [
+      {
+        "candidate_id": "candidate-1",
+        "rsid": "rs1",
+        "source": "clinvar",
+        "identity": {
+          "allele_id": "1",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "retained",
+        "stage": "allele",
+        "reason": "allele_carried",
+        "note": "1 copy of G",
+        "finding_id": "finding-1"
+      },
+      {
+        "candidate_id": "candidate-2",
+        "rsid": "rs1",
+        "source": "gnomad",
+        "identity": {
+          "assembly": "GRCh37",
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "rejected",
+        "stage": "frequency",
+        "reason": "frequency_build_mismatch",
+        "note": "GRCh37 record",
+        "finding_id": null
+      }
+    ],
+    "limitations": [
+      "Candidate counts are over reference records considered."
+    ]
+  }
+}

--- a/tests/fixtures/evidence_schema/invalid_unknown_enum.json
+++ b/tests/fixtures/evidence_schema/invalid_unknown_enum.json
@@ -1,0 +1,222 @@
+{
+  "schema_version": "1.0",
+  "software": {
+    "name": "Allelio",
+    "version": "0.3.0"
+  },
+  "generated_at": "2026-09-12T00:00:00+00:00",
+  "configuration": {
+    "include_benign": false,
+    "detailed_trace": false
+  },
+  "provenance": {
+    "clinvar": {
+      "label": "ClinVar",
+      "release": null,
+      "release_source": null,
+      "url": null,
+      "sha256": null
+    }
+  },
+  "inputs": [
+    {
+      "input_id": "input-1",
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "vcf_evidence": null,
+      "source_line": 2
+    }
+  ],
+  "findings": [
+    {
+      "finding_id": "finding-1",
+      "input_ids": [
+        "input-1"
+      ],
+      "candidate_ids": [
+        "candidate-1"
+      ],
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "category": "Health Conditions",
+      "significance_rank": 0.6,
+      "zygosity": "heterozygous",
+      "alt_copies": 1,
+      "matched_allele": "G",
+      "strand_flipped": false,
+      "zygosity_note": null,
+      "allele_role": "alternate",
+      "clinvar_entries": [
+        {
+          "rsid": "rs1",
+          "gene": "GENE",
+          "clinical_significance": "Pathogenic",
+          "classification_type": "germline",
+          "conditions": "Cond",
+          "condition_ids": "MONDO:MONDO:0000001",
+          "review_status": "practice guideline",
+          "review_stars": 4,
+          "ref_allele": "A",
+          "alt_allele": "G",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "allele_id": "1",
+          "variation_id": "2",
+          "hgnc_id": "HGNC:1",
+          "allele_match": "maybe",
+          "allele_match_note": "1 copy of G",
+          "display_rank": 0.6,
+          "inheritance": null
+        }
+      ],
+      "gwas_entries": [],
+      "gnomad_entry": null,
+      "gnomad_entries": [],
+      "clingen_entries": [],
+      "inheritance": "not curated",
+      "inheritance_note": null,
+      "inheritance_resolution": null,
+      "pgx_entries": []
+    }
+  ],
+  "gene_groups": [
+    {
+      "key": "HGNC:1",
+      "hgnc_id": "HGNC:1",
+      "gene": "GENE",
+      "symbols": [
+        "GENE"
+      ],
+      "indices": [
+        0
+      ],
+      "count": 1,
+      "function": "A sourced function summary is not available in this release.",
+      "function_source": null,
+      "function_version": null,
+      "note": "",
+      "finding_ids": [
+        "finding-1"
+      ]
+    }
+  ],
+  "analysis_stats": {
+    "annotated_sites": 1,
+    "reference_genotype_sites": 0,
+    "zygosity_unknown_sites": 0,
+    "benign_sites": 0,
+    "vcf_filter_failed_sites": 0,
+    "dispositions": {
+      "rs1": "reported"
+    },
+    "duplicate_rows": 0,
+    "conflicting_input_sites": 0
+  },
+  "coverage": {
+    "scope": "parsed_inputs_only",
+    "total_rows": 1,
+    "accounted_rows": 1,
+    "counts": {
+      "reported": 1
+    },
+    "rows": [
+      {
+        "line": 2,
+        "input_id": "input-1",
+        "rsid": "rs1",
+        "status": "reported"
+      }
+    ],
+    "returned_findings": 1,
+    "complete": true,
+    "limitations": "Rows absent from the input cannot be counted."
+  },
+  "limitations": [
+    "Research and education only; not a clinical interpretation."
+  ],
+  "matching": {
+    "schema": "candidate-trace/1",
+    "candidate_count": 2,
+    "counts": {
+      "rejected": 1,
+      "retained": 1
+    },
+    "by_source": {
+      "clinvar": {
+        "retained": 1
+      },
+      "gnomad": {
+        "rejected": 1
+      }
+    },
+    "sites_with_candidates": 1,
+    "listed_candidate_count": 2,
+    "detailed": false,
+    "paths": {
+      "clinvar": "traced"
+    },
+    "sites": [
+      {
+        "rsid": "rs1",
+        "input_ids": [
+          "input-1"
+        ],
+        "finding_id": "finding-1",
+        "disposition": "reported",
+        "candidate_count": 2,
+        "counts": {
+          "rejected": 1,
+          "retained": 1
+        },
+        "candidate_ids": [
+          "candidate-1",
+          "candidate-2"
+        ],
+        "candidates_listed": true
+      }
+    ],
+    "candidates": [
+      {
+        "candidate_id": "candidate-1",
+        "rsid": "rs1",
+        "source": "clinvar",
+        "identity": {
+          "allele_id": "1",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "retained",
+        "stage": "allele",
+        "reason": "allele_carried",
+        "note": "1 copy of G",
+        "finding_id": "finding-1"
+      },
+      {
+        "candidate_id": "candidate-2",
+        "rsid": "rs1",
+        "source": "gnomad",
+        "identity": {
+          "assembly": "GRCh37",
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "rejected",
+        "stage": "frequency",
+        "reason": "frequency_build_mismatch",
+        "note": "GRCh37 record",
+        "finding_id": null
+      }
+    ],
+    "limitations": [
+      "Candidate counts are over reference records considered."
+    ]
+  }
+}

--- a/tests/fixtures/evidence_schema/invalid_wrong_type.json
+++ b/tests/fixtures/evidence_schema/invalid_wrong_type.json
@@ -1,0 +1,222 @@
+{
+  "schema_version": "1.0",
+  "software": {
+    "name": "Allelio",
+    "version": "0.3.0"
+  },
+  "generated_at": "2026-09-12T00:00:00+00:00",
+  "configuration": {
+    "include_benign": false,
+    "detailed_trace": false
+  },
+  "provenance": {
+    "clinvar": {
+      "label": "ClinVar",
+      "release": null,
+      "release_source": null,
+      "url": null,
+      "sha256": null
+    }
+  },
+  "inputs": [
+    {
+      "input_id": "input-1",
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "vcf_evidence": null,
+      "source_line": 2
+    }
+  ],
+  "findings": [
+    {
+      "finding_id": "finding-1",
+      "input_ids": [
+        "input-1"
+      ],
+      "candidate_ids": [
+        "candidate-1"
+      ],
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "category": "Health Conditions",
+      "significance_rank": "high",
+      "zygosity": "heterozygous",
+      "alt_copies": 1,
+      "matched_allele": "G",
+      "strand_flipped": false,
+      "zygosity_note": null,
+      "allele_role": "alternate",
+      "clinvar_entries": [
+        {
+          "rsid": "rs1",
+          "gene": "GENE",
+          "clinical_significance": "Pathogenic",
+          "classification_type": "germline",
+          "conditions": "Cond",
+          "condition_ids": "MONDO:MONDO:0000001",
+          "review_status": "practice guideline",
+          "review_stars": 4,
+          "ref_allele": "A",
+          "alt_allele": "G",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "allele_id": "1",
+          "variation_id": "2",
+          "hgnc_id": "HGNC:1",
+          "allele_match": "carried",
+          "allele_match_note": "1 copy of G",
+          "display_rank": 0.6,
+          "inheritance": null
+        }
+      ],
+      "gwas_entries": [],
+      "gnomad_entry": null,
+      "gnomad_entries": [],
+      "clingen_entries": [],
+      "inheritance": "not curated",
+      "inheritance_note": null,
+      "inheritance_resolution": null,
+      "pgx_entries": []
+    }
+  ],
+  "gene_groups": [
+    {
+      "key": "HGNC:1",
+      "hgnc_id": "HGNC:1",
+      "gene": "GENE",
+      "symbols": [
+        "GENE"
+      ],
+      "indices": [
+        0
+      ],
+      "count": 1,
+      "function": "A sourced function summary is not available in this release.",
+      "function_source": null,
+      "function_version": null,
+      "note": "",
+      "finding_ids": [
+        "finding-1"
+      ]
+    }
+  ],
+  "analysis_stats": {
+    "annotated_sites": 1,
+    "reference_genotype_sites": 0,
+    "zygosity_unknown_sites": 0,
+    "benign_sites": 0,
+    "vcf_filter_failed_sites": 0,
+    "dispositions": {
+      "rs1": "reported"
+    },
+    "duplicate_rows": 0,
+    "conflicting_input_sites": 0
+  },
+  "coverage": {
+    "scope": "parsed_inputs_only",
+    "total_rows": 1,
+    "accounted_rows": 1,
+    "counts": {
+      "reported": 1
+    },
+    "rows": [
+      {
+        "line": 2,
+        "input_id": "input-1",
+        "rsid": "rs1",
+        "status": "reported"
+      }
+    ],
+    "returned_findings": 1,
+    "complete": true,
+    "limitations": "Rows absent from the input cannot be counted."
+  },
+  "limitations": [
+    "Research and education only; not a clinical interpretation."
+  ],
+  "matching": {
+    "schema": "candidate-trace/1",
+    "candidate_count": 2,
+    "counts": {
+      "rejected": 1,
+      "retained": 1
+    },
+    "by_source": {
+      "clinvar": {
+        "retained": 1
+      },
+      "gnomad": {
+        "rejected": 1
+      }
+    },
+    "sites_with_candidates": 1,
+    "listed_candidate_count": 2,
+    "detailed": false,
+    "paths": {
+      "clinvar": "traced"
+    },
+    "sites": [
+      {
+        "rsid": "rs1",
+        "input_ids": [
+          "input-1"
+        ],
+        "finding_id": "finding-1",
+        "disposition": "reported",
+        "candidate_count": 2,
+        "counts": {
+          "rejected": 1,
+          "retained": 1
+        },
+        "candidate_ids": [
+          "candidate-1",
+          "candidate-2"
+        ],
+        "candidates_listed": true
+      }
+    ],
+    "candidates": [
+      {
+        "candidate_id": "candidate-1",
+        "rsid": "rs1",
+        "source": "clinvar",
+        "identity": {
+          "allele_id": "1",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "retained",
+        "stage": "allele",
+        "reason": "allele_carried",
+        "note": "1 copy of G",
+        "finding_id": "finding-1"
+      },
+      {
+        "candidate_id": "candidate-2",
+        "rsid": "rs1",
+        "source": "gnomad",
+        "identity": {
+          "assembly": "GRCh37",
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "rejected",
+        "stage": "frequency",
+        "reason": "frequency_build_mismatch",
+        "note": "GRCh37 record",
+        "finding_id": null
+      }
+    ],
+    "limitations": [
+      "Candidate counts are over reference records considered."
+    ]
+  }
+}

--- a/tests/fixtures/evidence_schema/valid_minimal.json
+++ b/tests/fixtures/evidence_schema/valid_minimal.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "software": {
+    "name": "Allelio",
+    "version": "0.3.0"
+  },
+  "generated_at": "2026-09-12T00:00:00+00:00",
+  "configuration": {},
+  "provenance": {
+    "clinvar": {
+      "label": "ClinVar",
+      "release": null,
+      "release_source": null,
+      "url": null,
+      "sha256": null
+    }
+  },
+  "inputs": [],
+  "findings": [],
+  "gene_groups": [],
+  "analysis_stats": null,
+  "coverage": {
+    "scope": "parsed_inputs_only",
+    "total_rows": 0,
+    "accounted_rows": 0,
+    "counts": {},
+    "rows": [],
+    "returned_findings": 0,
+    "complete": true,
+    "limitations": "Rows absent from the input cannot be counted."
+  },
+  "limitations": [
+    "Research and education only; not a clinical interpretation."
+  ]
+}

--- a/tests/fixtures/evidence_schema/valid_small.json
+++ b/tests/fixtures/evidence_schema/valid_small.json
@@ -1,0 +1,222 @@
+{
+  "schema_version": "1.0",
+  "software": {
+    "name": "Allelio",
+    "version": "0.3.0"
+  },
+  "generated_at": "2026-09-12T00:00:00+00:00",
+  "configuration": {
+    "include_benign": false,
+    "detailed_trace": false
+  },
+  "provenance": {
+    "clinvar": {
+      "label": "ClinVar",
+      "release": null,
+      "release_source": null,
+      "url": null,
+      "sha256": null
+    }
+  },
+  "inputs": [
+    {
+      "input_id": "input-1",
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "vcf_evidence": null,
+      "source_line": 2
+    }
+  ],
+  "findings": [
+    {
+      "finding_id": "finding-1",
+      "input_ids": [
+        "input-1"
+      ],
+      "candidate_ids": [
+        "candidate-1"
+      ],
+      "rsid": "rs1",
+      "chromosome": "1",
+      "position": 100,
+      "genotype": "AG",
+      "category": "Health Conditions",
+      "significance_rank": 0.6,
+      "zygosity": "heterozygous",
+      "alt_copies": 1,
+      "matched_allele": "G",
+      "strand_flipped": false,
+      "zygosity_note": null,
+      "allele_role": "alternate",
+      "clinvar_entries": [
+        {
+          "rsid": "rs1",
+          "gene": "GENE",
+          "clinical_significance": "Pathogenic",
+          "classification_type": "germline",
+          "conditions": "Cond",
+          "condition_ids": "MONDO:MONDO:0000001",
+          "review_status": "practice guideline",
+          "review_stars": 4,
+          "ref_allele": "A",
+          "alt_allele": "G",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "allele_id": "1",
+          "variation_id": "2",
+          "hgnc_id": "HGNC:1",
+          "allele_match": "carried",
+          "allele_match_note": "1 copy of G",
+          "display_rank": 0.6,
+          "inheritance": null
+        }
+      ],
+      "gwas_entries": [],
+      "gnomad_entry": null,
+      "gnomad_entries": [],
+      "clingen_entries": [],
+      "inheritance": "not curated",
+      "inheritance_note": null,
+      "inheritance_resolution": null,
+      "pgx_entries": []
+    }
+  ],
+  "gene_groups": [
+    {
+      "key": "HGNC:1",
+      "hgnc_id": "HGNC:1",
+      "gene": "GENE",
+      "symbols": [
+        "GENE"
+      ],
+      "indices": [
+        0
+      ],
+      "count": 1,
+      "function": "A sourced function summary is not available in this release.",
+      "function_source": null,
+      "function_version": null,
+      "note": "",
+      "finding_ids": [
+        "finding-1"
+      ]
+    }
+  ],
+  "analysis_stats": {
+    "annotated_sites": 1,
+    "reference_genotype_sites": 0,
+    "zygosity_unknown_sites": 0,
+    "benign_sites": 0,
+    "vcf_filter_failed_sites": 0,
+    "dispositions": {
+      "rs1": "reported"
+    },
+    "duplicate_rows": 0,
+    "conflicting_input_sites": 0
+  },
+  "coverage": {
+    "scope": "parsed_inputs_only",
+    "total_rows": 1,
+    "accounted_rows": 1,
+    "counts": {
+      "reported": 1
+    },
+    "rows": [
+      {
+        "line": 2,
+        "input_id": "input-1",
+        "rsid": "rs1",
+        "status": "reported"
+      }
+    ],
+    "returned_findings": 1,
+    "complete": true,
+    "limitations": "Rows absent from the input cannot be counted."
+  },
+  "limitations": [
+    "Research and education only; not a clinical interpretation."
+  ],
+  "matching": {
+    "schema": "candidate-trace/1",
+    "candidate_count": 2,
+    "counts": {
+      "rejected": 1,
+      "retained": 1
+    },
+    "by_source": {
+      "clinvar": {
+        "retained": 1
+      },
+      "gnomad": {
+        "rejected": 1
+      }
+    },
+    "sites_with_candidates": 1,
+    "listed_candidate_count": 2,
+    "detailed": false,
+    "paths": {
+      "clinvar": "traced"
+    },
+    "sites": [
+      {
+        "rsid": "rs1",
+        "input_ids": [
+          "input-1"
+        ],
+        "finding_id": "finding-1",
+        "disposition": "reported",
+        "candidate_count": 2,
+        "counts": {
+          "rejected": 1,
+          "retained": 1
+        },
+        "candidate_ids": [
+          "candidate-1",
+          "candidate-2"
+        ],
+        "candidates_listed": true
+      }
+    ],
+    "candidates": [
+      {
+        "candidate_id": "candidate-1",
+        "rsid": "rs1",
+        "source": "clinvar",
+        "identity": {
+          "allele_id": "1",
+          "assembly": "GRCh38",
+          "chromosome": "1",
+          "position_vcf": 100,
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "retained",
+        "stage": "allele",
+        "reason": "allele_carried",
+        "note": "1 copy of G",
+        "finding_id": "finding-1"
+      },
+      {
+        "candidate_id": "candidate-2",
+        "rsid": "rs1",
+        "source": "gnomad",
+        "identity": {
+          "assembly": "GRCh37",
+          "ref_allele": "A",
+          "alt_allele": "G"
+        },
+        "decision": "rejected",
+        "stage": "frequency",
+        "reason": "frequency_build_mismatch",
+        "note": "GRCh37 record",
+        "finding_id": null
+      }
+    ],
+    "limitations": [
+      "Candidate counts are over reference records considered."
+    ]
+  }
+}

--- a/tests/test_evidence_schema.py
+++ b/tests/test_evidence_schema.py
@@ -203,17 +203,21 @@ class TestCommandLine:
         path.write_text(json.dumps(_load("invalid_dangling_reference")))
         result = CliRunner().invoke(cli.validate_evidence_command, [str(path)])
         assert result.exit_code == 1
-        assert "1 problem(s)" in result.output and "input-9" in result.output
+        output = " ".join(result.output.split())  # the console wraps at 80 columns when not a TTY
+        assert "1 problem(s)" in output and "input-9" in output
 
 
 class TestInstalledWheel:
     @pytest.fixture(scope="class")
     def wheel(self, tmp_path_factory):
         out = tmp_path_factory.mktemp("wheel")
-        build = subprocess.run(
-            [sys.executable, "-m", "pip", "wheel", str(ROOT), "--no-deps", "--no-build-isolation", "-w", str(out), "-q"],
-            capture_output=True, text=True,
-        )
+        command = [sys.executable, "-m", "pip", "wheel", str(ROOT), "--no-deps", "-w", str(out), "-q"]
+        # Without isolation when the environment has the build backend (a
+        # development checkout, no network needed); a Python without
+        # setuptools installed (3.12 on CI) falls back to pip's isolated build.
+        build = subprocess.run(command + ["--no-build-isolation"], capture_output=True, text=True)
+        if build.returncode != 0 and "BackendUnavailable" in build.stderr:
+            build = subprocess.run(command, capture_output=True, text=True)
         assert build.returncode == 0, build.stderr
         [path] = out.glob("allelio-*.whl")
         return path

--- a/tests/test_evidence_schema.py
+++ b/tests/test_evidence_schema.py
@@ -1,0 +1,235 @@
+"""The evidence JSON has a shipped, checkable contract.
+
+Structural validation is JSON Schema 2020-12 (allelio/schemas); reference and
+count conservation checks live in allelio.schema. Fixtures under
+tests/fixtures/evidence_schema/ are small synthetic documents.
+"""
+
+import json
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from allelio import evidence, schema
+from allelio.analysis.example_check import EXAMPLE_FILE, build_fixture_db, run_example
+from allelio.database import provenance_of
+from allelio.evidence import build_evidence_export
+from allelio.schema import load_schema, semantic_errors, validate_evidence, validate_evidence_file
+
+FIXTURES = Path(__file__).parent / "fixtures" / "evidence_schema"
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name):
+    return json.loads((FIXTURES / f"{name}.json").read_text())
+
+
+def _roundtrip(document):
+    return json.loads(json.dumps(document, allow_nan=False))
+
+
+@pytest.fixture(scope="module")
+def example_db(tmp_path_factory):
+    return build_fixture_db(str(tmp_path_factory.mktemp("schema") / "example.db"))
+
+
+class TestSchemaDocument:
+    def test_ships_the_pinned_dialect_and_version(self):
+        doc = load_schema()
+        assert doc["$schema"] == schema.SCHEMA_DIALECT
+        assert doc["$id"].endswith(f"evidence-{schema.DEFAULT_SCHEMA_VERSION}.json")
+        assert schema.DEFAULT_SCHEMA_VERSION == evidence.SCHEMA_VERSION
+        assert "not VRS IDs" in doc["description"] and "additional" in doc["description"]
+        jsonschema = pytest.importorskip("jsonschema")
+        jsonschema.Draft202012Validator.check_schema(doc)
+
+    def test_describes_every_section(self):
+        doc = load_schema()
+        assert set(doc["required"]) == {"schema_version", "software", "generated_at", "configuration", "provenance",
+                                        "inputs", "findings", "gene_groups", "coverage", "limitations"}
+        assert set(doc["$defs"]) >= {"input", "finding", "clinvar_entry", "gwas_entry", "gnomad_entry", "clingen_entry",
+                                     "pgx_entry", "inheritance_resolution", "gene_group", "coverage", "matching"}
+        finding = doc["$defs"]["finding"]["properties"]
+        assert finding["gnomad_entry"]["oneOf"][1] == {"type": "null"}  # null semantics are explicit
+        assert doc["$defs"]["clinvar_entry"]["properties"]["condition_ids"]["type"] == ["string", "null"]
+
+
+class TestRepresentativeExports:
+    def test_cli_export_validates(self, example_db, tmp_path, monkeypatch):
+        from click.testing import CliRunner
+        from allelio import cli
+        monkeypatch.setattr(cli, "AllelioDB", lambda: example_db)
+        sidecar = tmp_path / "evidence.json"
+        result = CliRunner().invoke(cli.analyze, [str(EXAMPLE_FILE), "--no-ai", "-o", str(tmp_path / "r.html"),
+                                                  "--json-output", str(sidecar), "--detailed-trace"])
+        assert result.exit_code == 0, result.output
+        assert validate_evidence_file(str(sidecar)) == []
+        check = CliRunner().invoke(cli.validate_evidence_command, [str(sidecar)])
+        assert check.exit_code == 0 and "valid evidence JSON" in check.output
+
+    def test_web_export_validates(self, example_db, monkeypatch):
+        from fastapi.testclient import TestClient
+        from allelio.web.app import app
+        from allelio.web import routes
+
+        class WebDB:
+            def __new__(cls, *args, **kwargs):
+                return example_db
+
+        class Engine:
+            status = "unavailable"
+            model = "none"
+
+            async def check_connection(self):
+                return False
+
+            def will_explain(self):
+                return False
+
+            async def explain_variants_batch(self, variants, progress_callback=None):
+                return {}
+
+            async def generate_summary(self, variants):
+                raise RuntimeError("no model server answering")
+
+        monkeypatch.setattr(routes, "AllelioDB", WebDB)
+        monkeypatch.setattr(routes, "AIEngine", Engine)
+        monkeypatch.setattr(example_db, "close", lambda: None)
+        response = TestClient(app, base_url="http://127.0.0.1").post(
+            "/api/analyze", files={"file": ("example.txt", EXAMPLE_FILE.read_bytes(), "text/plain")}
+        )
+        assert response.status_code == 200, response.text
+        document = response.json()["evidence_export"]
+        assert validate_evidence(document) == []
+        assert document["matching"]["detailed"] is False
+
+    def test_empty_results_validate(self, example_db):
+        from allelio.analysis.lookup import analyze_variants
+        from allelio.parsers.base import Variant
+        variants = [Variant("rs1", "1", 100, "--"), Variant("rs99999901", "1", 1, "AA")]
+        results = analyze_variants(variants, example_db)
+        document = _roundtrip(build_evidence_export(results, variants, provenance_of(example_db), {}, results.stats))
+        assert document["findings"] == [] and validate_evidence(document) == []
+        assert validate_evidence(_roundtrip(build_evidence_export([], [], {}, None, None))) == []
+
+    def test_legacy_or_missing_source_metadata_validates(self, example_db):
+        results, stats, _, variants = run_example(example_db)
+        no_provenance = _roundtrip(build_evidence_export(results, variants, {}, {}, stats))
+        assert validate_evidence(no_provenance) == []
+        legacy = provenance_of(example_db)
+        assert all(v["release"] is None for v in legacy.values())  # fixture database records no releases
+        document = _roundtrip(build_evidence_export(results, variants, legacy, {}, stats))
+        assert validate_evidence(document) == []
+        stripped = _roundtrip(build_evidence_export(results, variants, legacy, {}, stats))
+        for entry in stripped["findings"][0]["clinvar_entries"]:
+            entry["assembly"] = entry["allele_id"] = None
+            entry["classification_type"] = "unknown"
+        assert validate_evidence(stripped) == []
+
+
+class TestFixtures:
+    def test_valid_fixtures(self):
+        assert validate_evidence(_load("valid_minimal")) == []
+        assert validate_evidence(_load("valid_small")) == []
+
+    @pytest.mark.parametrize("name, expected", [
+        ("invalid_missing_required", "'coverage' is a required property"),
+        ("invalid_wrong_type", "findings/0/significance_rank: 'high' is not of type 'number'"),
+        ("invalid_unknown_enum", "allele_match: 'maybe' is not one of"),
+        ("invalid_dangling_reference", "findings/0/input_ids: input_id 'input-9' does not exist in this document"),
+        ("invalid_coverage_counts", "coverage/counts: {'reported': 2} does not match the listed rows {'reported': 1}"),
+        ("invalid_candidate_support", "findings/0/candidate_ids: candidate-2 is 'rejected', only retained candidates support a finding"),
+        ("invalid_major_version", "schema_version: '2.0' is not a 1.x document"),
+    ])
+    def test_invalid_fixtures_give_actionable_errors(self, name, expected):
+        errors = validate_evidence(_load(name))
+        assert errors and any(expected in line for line in errors), errors
+
+
+class TestSemanticChecks:
+    def test_conserved_counts(self):
+        doc = _load("valid_small")
+        doc["coverage"]["returned_findings"] = 3
+        doc["matching"]["candidate_count"] = 5
+        doc["matching"]["sites"][0]["candidate_count"] = 1
+        errors = semantic_errors(doc)
+        assert "coverage/returned_findings: 3 but 1 findings" in errors
+        assert "matching/counts: sum 2 but candidate_count 5" in errors
+        assert "matching/sites/0/candidate_count: 1 but 2 candidate_ids" in errors
+
+    def test_unlisted_site_must_not_enumerate_and_ids_stay_ordered(self):
+        doc = _load("valid_small")
+        doc["matching"]["sites"][0]["candidates_listed"] = False
+        errors = semantic_errors(doc)
+        assert any("must be null when candidates are not listed" in e for e in errors)
+        doc = _load("valid_small")
+        doc["matching"]["candidates"].reverse()
+        errors = semantic_errors(doc)
+        assert any("out of order" in e for e in errors)
+        doc = _load("valid_small")
+        doc["findings"][0]["finding_id"] = "finding-2"
+        errors = semantic_errors(doc)
+        assert any("expected finding-1 (sequential)" in e for e in errors)
+
+    def test_finding_inputs_must_share_the_rsid(self):
+        doc = _load("valid_small")
+        doc["inputs"][0]["rsid"] = "rs2"
+        assert any("referenced inputs carry rsIDs ['rs2']" in e for e in semantic_errors(doc))
+
+    def test_gene_group_references(self):
+        doc = _load("valid_small")
+        doc["gene_groups"][0]["finding_ids"] = ["finding-7"]
+        doc["gene_groups"][0]["indices"] = [4]
+        errors = semantic_errors(doc)
+        assert any("gene_groups/0/finding_ids: finding_id 'finding-7'" in e for e in errors)
+        assert "gene_groups/0/indices: index outside findings" in errors
+
+    def test_non_object_and_unreadable_file(self, tmp_path):
+        assert validate_evidence([1, 2]) == ["(document): expected a JSON object"]
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json")
+        [error] = validate_evidence_file(str(bad))
+        assert error.startswith(str(bad)) and "not readable as JSON" in error
+
+
+class TestCommandLine:
+    def test_validate_evidence_command_reports_each_problem(self, tmp_path):
+        from click.testing import CliRunner
+        from allelio import cli
+        path = tmp_path / "e.json"
+        path.write_text(json.dumps(_load("invalid_dangling_reference")))
+        result = CliRunner().invoke(cli.validate_evidence_command, [str(path)])
+        assert result.exit_code == 1
+        assert "1 problem(s)" in result.output and "input-9" in result.output
+
+
+class TestInstalledWheel:
+    @pytest.fixture(scope="class")
+    def wheel(self, tmp_path_factory):
+        out = tmp_path_factory.mktemp("wheel")
+        build = subprocess.run(
+            [sys.executable, "-m", "pip", "wheel", str(ROOT), "--no-deps", "--no-build-isolation", "-w", str(out), "-q"],
+            capture_output=True, text=True,
+        )
+        assert build.returncode == 0, build.stderr
+        [path] = out.glob("allelio-*.whl")
+        return path
+
+    def test_schema_ships_in_the_wheel_and_loads_from_it(self, wheel, tmp_path):
+        with zipfile.ZipFile(wheel) as archive:
+            names = archive.namelist()
+            assert f"allelio/schemas/evidence-{schema.DEFAULT_SCHEMA_VERSION}.json" in names
+            archive.extractall(tmp_path / "site")
+        script = (
+            "import json, sys; from allelio.schema import load_schema, validate_evidence, schema_path; "
+            "doc = load_schema(); assert 'allelio/schemas' in str(schema_path()).replace('\\\\', '/'); "
+            f"assert validate_evidence(json.load(open({str(FIXTURES / 'valid_small.json')!r}))) == []; "
+            "print(doc['$id'])"
+        )
+        run = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True,
+                             cwd=str(tmp_path), env={"PYTHONPATH": str(tmp_path / "site"), "PATH": ""})
+        assert run.returncode == 0, run.stderr
+        assert run.stdout.strip().endswith(f"evidence-{schema.DEFAULT_SCHEMA_VERSION}.json")


### PR DESCRIPTION
Stacked on #35 (base: `candidate-trace`), the last of the chain #32 → #33 → #34 → #35.

The evidence JSON now has a checked-in contract: `allelio/schemas/evidence-1.0.json`, JSON Schema 2020-12, one file per `schema_version` minor, shipped as package data so `allelio.schema.load_schema()` works from an installed wheel. It describes `inputs` (with VCF evidence), `findings` and every source record type (ClinVar with its context fields, GWAS, gnomAD with the identity verdict, ClinGen, ClinPGx, the inheritance resolution), `gene_groups`, `provenance`, `configuration`, `analysis_stats`, `coverage`, and `matching`, stating required and optional fields and null semantics per object with descriptions. The compatibility policy is in the schema's description and in `docs/evidence-schema.md`: within a major version fields are only added, objects allow additional properties, unknown enum values read as unknown, and a missing or null value means unavailable.

`allelio.schema.validate_evidence` (and the new `allelio validate-evidence FILE` command, exit 1 with one line per problem) adds the checks a schema cannot express: every `input_ids`, `finding_ids`, `finding_id`, and `candidate_ids` reference resolves in the document; ids are well formed, unique, and ordered (`input-N`/`finding-N` contiguous, `candidate-N` ascending because candidates at unlisted sites keep their number); a finding's inputs share its rsID; only retained candidates support a finding; gene group indices and counts agree; coverage rows, counts, `returned_findings`, and `complete` are conserved; matching `counts`, `by_source`, site counts, and `listed_candidate_count` are conserved and listed sites enumerate exactly their candidates. Errors are actionable, for example `findings/0/input_ids: input_id 'input-9' does not exist in this document`.

Document-local ids are documented, in the schema and the docs, as indices rather than normalized genomic identifiers, and the schema claims no conformance to VRS or any other standard. `jsonschema>=4.17` is added as a runtime dependency.

Validation: full suite (785 passed); new `tests/test_evidence_schema.py` validates a real CLI export (with `--detailed-trace`) and a real web export, empty results, a database without recorded releases and entries with stripped legacy metadata, the synthetic valid and invalid fixtures in `tests/fixtures/evidence_schema/` (missing section, wrong type, unknown enum, dangling reference, unconserved coverage, rejected candidate supporting a finding, wrong major version), each semantic check, the CLI command, and a wheel built with `pip wheel` from which the schema loads and validates.

Closes #26.